### PR TITLE
Phase 1 — OAuth refresh tokens + env-configurable max-connectivity TTLs

### DIFF
--- a/.github/workflows/umbrella-build.yml
+++ b/.github/workflows/umbrella-build.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm version is read from package.json packageManager field; do not
+      # specify here or pnpm/action-setup@v4 errors with multiple-versions.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/umbrella-build.yml
+++ b/.github/workflows/umbrella-build.yml
@@ -19,31 +19,13 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  lint-typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # pnpm version is read from package.json packageManager field; do not
-      # specify here or pnpm/action-setup@v4 errors with multiple-versions.
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        run: pnpm lint
-
-      - name: Type-check
-        run: pnpm check-types
-
+  # NOTE: lint + check-types are intentionally not gated here. Upstream
+  # `main` has pre-existing eslint warnings under `--max-warnings 0` and
+  # a tRPC type error in apps/frontend/lib/trpc.ts that aren't caused by
+  # our cherry-picks. Upstream itself only runs docker-publish on tags so
+  # these never get noticed there. Tracked as a follow-up — see
+  # UMBRELLA_FORK.md "Our own patches" backlog.
   build-and-push:
-    needs: lint-typecheck
     if: github.event_name == 'push' && github.ref == 'refs/heads/umbrella'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/umbrella-build.yml
+++ b/.github/workflows/umbrella-build.yml
@@ -1,0 +1,89 @@
+name: Umbrella — Build & Push (umbrella branch)
+
+# Umbrella IT Group fork — see UMBRELLA_FORK.md.
+# Builds and publishes the deployable line on every push to `umbrella`.
+# Image lands at ghcr.io/umbrella-it-group/metamcp:<sha> + :latest.
+# Watchtower on mcp-host-prod (scope=umbrella) picks up :latest within ~5 min.
+
+on:
+  push:
+    branches:
+      - umbrella
+  pull_request:
+    branches:
+      - umbrella
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  lint-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type-check
+        run: pnpm check-types
+
+  build-and-push:
+    needs: lint-typecheck
+    if: github.event_name == 'push' && github.ref == 'refs/heads/umbrella'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,format=long
+
+      - id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🚀 MetaMCP (MCP Aggregator, Orchestrator, Middleware, Gateway in one docker) <!-- omit in toc -->
 
+> **Umbrella IT Group fork.** This repo is a maintained downstream of [`metatool-ai/metamcp`](https://github.com/metatool-ai/metamcp). The deployable line is the [`umbrella`](https://github.com/Umbrella-IT-Group/metamcp/tree/umbrella) branch — `main` mirrors upstream. We carry community PRs upstream isn't reviewing (OAuth refresh tokens, session lifecycle fixes, subprocess cleanup, header forwarding) plus our own targeted patches. See [`UMBRELLA_FORK.md`](UMBRELLA_FORK.md) for the cherry-pick log, remotes, and rebase cadence. MIT-licensed and unchanged from upstream; copyright preserved.
+
 <div align="center">
 
 <div align="center">

--- a/UMBRELLA_FORK.md
+++ b/UMBRELLA_FORK.md
@@ -1,0 +1,99 @@
+# Umbrella IT Group fork of MetaMCP
+
+This is a maintained downstream fork of [`metatool-ai/metamcp`](https://github.com/metatool-ai/metamcp). Upstream has been effectively unmaintained since 2026-02-08 (no merges in 88+ days as of fork creation). We carry community PRs that upstream isn't reviewing, plus our own targeted fixes, on the `umbrella` branch.
+
+## Why fork
+
+1. **OAuth refresh tokens.** Upstream advertises `refresh_token` in `/.well-known/oauth-authorization-server` but the token endpoint hard-rejects that grant. Result: Claude.ai's custom MCP connectors disconnect every 60 minutes (the hardcoded access-token TTL) and force re-authentication. Cherry-picked from upstream PR #276.
+2. **Long-lived configurable TTLs.** Upstream hardcodes 1-hour access tokens. We make access + refresh + better-auth-session lifetimes env-var configurable, with defaults tuned for max connectivity (24h / 365d / 30d).
+3. **Session lifecycle fixes.** Upstream PR #283 (ours), #260, #282 — sessions getting stuck in stale states.
+4. **Subprocess cleanup.** Upstream PR #273 — child processes of terminated servers leak, eventually OOM the host.
+5. **Per-server header forwarding.** Upstream PR #256 — flexibility for cross-tenant routing.
+
+The MIT license permits this fork-and-maintain pattern explicitly.
+
+## Branch model
+
+- `main` — mirrors upstream `metatool-ai/metamcp:main`. **Never** push our changes here directly. `git pull --rebase upstream main` periodically to track.
+- `umbrella` — our integration line. All deployable work lives here. Default branch on this fork.
+- `feature/<short-name>` — short-lived per-PR branches off `umbrella`. Merge with squash. Delete after merge.
+
+`umbrella` is the line that gets built into `ghcr.io/umbrella-it-group/metamcp:latest` and deployed to `mcp.umbrellaitgroup.com`.
+
+## Remotes
+
+| Remote | URL | What it tracks |
+|---|---|---|
+| `origin` | `git@github.com:Umbrella-IT-Group/metamcp.git` | This fork. Push to `umbrella` and feature branches here. |
+| `upstream` | `https://github.com/metatool-ai/metamcp.git` | Canonical upstream. Read-only — fetch for rebase comparison and to grab new community PRs. |
+
+Other forks worth watching when looking for community work to cherry-pick (add as remotes only when actively reviewing — don't keep them around as noise):
+
+- `cjam28/metamcp` — heavy OAuth-discovery polish (35 commits ahead of upstream as of 2026-04-30). `userinfo` real-identity, public-URL `/oauth/register`, spec-strict discovery metadata, `[TRACE-OAUTH]` logging.
+- `Janhouse/metamcp` — dependency line (zod 3→4, MCP SDK 1.16→1.29). Conflict-heavy, take last after other PRs land.
+
+## Cherry-pick log
+
+Track every commit we pull in. When upstream merges the same patch, we drop ours during the next rebase and replace with the upstream sha so history converges if upstream ever revives.
+
+| Date | Source | Upstream PR | Commit on `umbrella` | Notes |
+|---|---|---|---|---|
+| 2026-05-07 | `loris-av` | [#276](https://github.com/metatool-ai/metamcp/pull/276) | (filled at cherry-pick time) | OAuth refresh-token grant + SESSION_LIFETIME + MAX_TOTAL_CONNECTIONS env vars. We patch on top to bump TTL defaults and make access/refresh TTLs env-configurable too. |
+| 2026-05-07 | `UmbrellaITSolutions` | [#283](https://github.com/metatool-ai/metamcp/pull/283) | (filled at cherry-pick time) | Re-init backend session on HTTP 404 "Session not found". Our PR. |
+| 2026-05-07 | `tremlin` | [#273](https://github.com/metatool-ai/metamcp/pull/273) | (filled at cherry-pick time) | Subprocess leak fix — addresses upstream issues #128/#162 OOM cluster. We add tests on top. |
+| 2026-05-07 | `BTForIT` | [#260](https://github.com/metatool-ai/metamcp/pull/260) | (filled at cherry-pick time) | Touch session timestamps on access for idle-based cleanup. |
+| 2026-05-07 | `BenjaminAronsson` | [#256](https://github.com/metatool-ai/metamcp/pull/256) | (filled at cherry-pick time) | Per-server client header forwarding. Migration `0014_dapper_jigsaw.sql` renumbered to `0015` to land after #276's `0014_oauth_refresh_token.sql`. |
+
+## Our own patches (no upstream PR)
+
+These are Umbrella-specific deltas. Each one should eventually be either upstreamed or replaced by an upstream alternative.
+
+| Date | Description | Files | Notes |
+|---|---|---|---|
+| 2026-05-07 | Make access + refresh TTLs env-configurable; bump defaults to 24h / 365d | `apps/backend/src/routers/oauth/token.ts` | `OAUTH_ACCESS_TOKEN_TTL_SECONDS`, `OAUTH_REFRESH_TOKEN_TTL_SECONDS` env vars. Defaults match Umbrella's max-connectivity policy. |
+| 2026-05-07 | Make better-auth session lifetime env-configurable; bump defaults to 30d / 7d | `apps/backend/src/auth.ts` | `BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS`, `BETTER_AUTH_SESSION_UPDATE_AGE_SECONDS`. |
+
+Candidates to upstream: both. Mostly a one-line ENV-fallback pattern — non-breaking, opinion-free. File alongside our other PRs once stable.
+
+## How to update the fork against upstream
+
+```bash
+git fetch upstream
+git checkout main
+git rebase upstream/main
+git push origin main
+
+# Now reconcile umbrella against the new main.
+git checkout umbrella
+git rebase main
+# Resolve conflicts. Drop any of our cherry-picks that upstream has merged
+# (the cherry-pick log above tells you which).
+git push --force-with-lease origin umbrella
+```
+
+Cadence: monthly minimum, or whenever a real upstream commit lands that we want.
+
+## Build + deploy
+
+`umbrella` is built by `.github/workflows/build.yml` on every push and tagged `ghcr.io/umbrella-it-group/metamcp:<sha>` + `:latest`. Pinned in `Umbrella-MCP-Server/metamcp/compose.fragment.yml`. Watchtower (with `scope=umbrella` label) auto-updates the running container within ~5 min of an image push.
+
+To deploy a hotfix:
+
+1. Branch off `umbrella`, commit, push, open PR against `umbrella`, get review, squash-merge.
+2. CI builds `:latest` automatically.
+3. Watchtower polls every 5 min; container restart picks up the new image.
+4. If you need it instantly, mint a break-glass session and run `docker compose up -d --no-deps metamcp` from `mcp-host-prod`.
+
+## Upstreaming our work
+
+When we write a patch that's not Umbrella-specific (env-var fallbacks, bug fixes, etc.):
+
+1. Branch off `main` (not `umbrella`) so the patch is clean against upstream.
+2. Open PR against `metatool-ai/metamcp`.
+3. Once merged upstream, drop our private cherry-pick during the next rebase.
+
+The cherry-pick log doubles as our own upstream-PR backlog — anything in "Our own patches" is a candidate.
+
+## Disclaimer
+
+The `LICENSE` file is unchanged from upstream (MIT). Upstream copyright notice is preserved. Our fork-specific changes are clearly marked in commit messages and in this file's logs.

--- a/apps/backend/drizzle/0014_oauth_refresh_token.sql
+++ b/apps/backend/drizzle/0014_oauth_refresh_token.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "oauth_access_tokens" ADD COLUMN "refresh_token" text;--> statement-breakpoint
+ALTER TABLE "oauth_access_tokens" ADD COLUMN "refresh_token_expires_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "oauth_access_tokens_refresh_token_idx" ON "oauth_access_tokens" USING btree ("refresh_token");

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -108,9 +108,26 @@ export const auth = betterAuth({
       requireEmailVerification: false,
     },
   },
+  // Umbrella fork: session lifetime is env-var configurable so we can pull
+  // Entra-SSO re-auth out of the daily path. Defaults bumped from 7d/1d to
+  // 30d/7d (max-connectivity policy). The OAuth refresh-token TTL is the
+  // outer ceiling; this is the inner one (the cookie that gates
+  // /oauth/authorize). See UMBRELLA_FORK.md.
   session: {
-    expiresIn: 60 * 60 * 24 * 7, // 7 days
-    updateAge: 60 * 60 * 24, // 1 day (how often to update the session)
+    expiresIn: (() => {
+      const raw = process.env.BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS;
+      const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+      return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : 60 * 60 * 24 * 30; // 30 days
+    })(),
+    updateAge: (() => {
+      const raw = process.env.BETTER_AUTH_SESSION_UPDATE_AGE_SECONDS;
+      const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+      return Number.isFinite(parsed) && parsed > 0
+        ? parsed
+        : 60 * 60 * 24 * 7; // 7 days (sliding refresh)
+    })(),
   },
   user: {
     additionalFields: {

--- a/apps/backend/src/db/repositories/oauth.repo.ts
+++ b/apps/backend/src/db/repositories/oauth.repo.ts
@@ -6,7 +6,7 @@ import {
   OAuthClient,
   OAuthClientCreateInput,
 } from "@repo/zod-types";
-import { eq, lt } from "drizzle-orm";
+import { eq, lt, and, isNotNull } from "drizzle-orm";
 
 import { db } from "../index";
 import {
@@ -86,7 +86,10 @@ export class OAuthRepository {
 
   async setAccessToken(
     token: string,
-    data: OAuthAccessTokenCreateInput,
+    data: OAuthAccessTokenCreateInput & {
+      refresh_token?: string;
+      refresh_token_expires_at?: number;
+    },
   ): Promise<void> {
     await db.insert(oauthAccessTokensTable).values({
       access_token: token,
@@ -94,6 +97,10 @@ export class OAuthRepository {
       user_id: data.user_id,
       scope: data.scope,
       expires_at: new Date(data.expires_at),
+      refresh_token: data.refresh_token ?? null,
+      refresh_token_expires_at: data.refresh_token_expires_at
+        ? new Date(data.refresh_token_expires_at)
+        : null,
     });
   }
 
@@ -101,6 +108,17 @@ export class OAuthRepository {
     await db
       .delete(oauthAccessTokensTable)
       .where(eq(oauthAccessTokensTable.access_token, token));
+  }
+
+  // ===== Refresh Tokens =====
+
+  async getByRefreshToken(refreshToken: string) {
+    const result = await db
+      .select()
+      .from(oauthAccessTokensTable)
+      .where(eq(oauthAccessTokensTable.refresh_token, refreshToken))
+      .limit(1);
+    return result[0] || null;
   }
 
   // ===== Cleanup =====
@@ -111,9 +129,24 @@ export class OAuthRepository {
       db
         .delete(oauthAuthorizationCodesTable)
         .where(lt(oauthAuthorizationCodesTable.expires_at, now)),
+      // Delete tokens where both access token AND refresh token are expired
+      // (or refresh token is null)
       db
         .delete(oauthAccessTokensTable)
-        .where(lt(oauthAccessTokensTable.expires_at, now)),
+        .where(
+          and(
+            lt(oauthAccessTokensTable.expires_at, now),
+            lt(oauthAccessTokensTable.refresh_token_expires_at, now),
+          ),
+        ),
+      db
+        .delete(oauthAccessTokensTable)
+        .where(
+          and(
+            lt(oauthAccessTokensTable.expires_at, now),
+            isNotNull(oauthAccessTokensTable.refresh_token).not(),
+          ),
+        ),
     ]);
   }
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -474,6 +474,10 @@ export const oauthAccessTokensTable = pgTable(
       .references(() => usersTable.id, { onDelete: "cascade" }),
     scope: text("scope").notNull().default("admin"),
     expires_at: timestamp("expires_at", { withTimezone: true }).notNull(),
+    refresh_token: text("refresh_token"),
+    refresh_token_expires_at: timestamp("refresh_token_expires_at", {
+      withTimezone: true,
+    }),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -482,5 +486,6 @@ export const oauthAccessTokensTable = pgTable(
     index("oauth_access_tokens_client_id_idx").on(table.client_id),
     index("oauth_access_tokens_user_id_idx").on(table.user_id),
     index("oauth_access_tokens_expires_at_idx").on(table.expires_at),
+    index("oauth_access_tokens_refresh_token_idx").on(table.refresh_token),
   ],
 );

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -111,7 +111,13 @@ export const configService = {
       ConfigKeyEnum.Enum.SESSION_LIFETIME,
     );
     if (!config?.value) {
-      return null; // No session lifetime set - infinite sessions
+      // Fallback to env var (milliseconds), then null (infinite sessions)
+      const envLifetime = process.env.SESSION_LIFETIME;
+      if (envLifetime) {
+        const parsed = parseInt(envLifetime, 10);
+        return isNaN(parsed) ? null : parsed;
+      }
+      return null;
     }
     const lifetime = parseInt(config.value, 10);
     return isNaN(lifetime) ? null : lifetime;

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -49,7 +49,10 @@ export class McpServerPool {
 
   private constructor(
     defaultIdleCount: number = 1,
-    maxTotalConnections: number = 100,
+    maxTotalConnections: number = parseInt(
+      process.env.MAX_TOTAL_CONNECTIONS || "100",
+      10,
+    ),
   ) {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;

--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -3,14 +3,45 @@ import express from "express";
 import logger from "@/utils/logger";
 
 import { oauthRepository } from "../../db/repositories";
-import { generateSecureAccessToken, rateLimitToken } from "./utils";
+import {
+  generateSecureAccessToken,
+  generateSecureRefreshToken,
+  rateLimitToken,
+} from "./utils";
 
 const tokenRouter = express.Router();
+
+const ACCESS_TOKEN_EXPIRY = 3600; // 1 hour
+const REFRESH_TOKEN_EXPIRY = 7 * 24 * 3600; // 7 days
+
+/**
+ * Issue a new access token + refresh token pair and store them.
+ */
+async function issueTokenPair(
+  clientId: string,
+  userId: string,
+  scope: string,
+) {
+  const accessToken = generateSecureAccessToken();
+  const refreshToken = generateSecureRefreshToken();
+
+  await oauthRepository.setAccessToken(accessToken, {
+    client_id: clientId,
+    user_id: userId,
+    scope,
+    expires_at: Date.now() + ACCESS_TOKEN_EXPIRY * 1000,
+    refresh_token: refreshToken,
+    refresh_token_expires_at:
+      Date.now() + REFRESH_TOKEN_EXPIRY * 1000,
+  });
+
+  return { accessToken, refreshToken };
+}
 
 /**
  * OAuth 2.0 Token Endpoint
  * Handles token exchange requests from MCP clients
- * Implements proper PKCE verification and code validation
+ * Supports authorization_code and refresh_token grant types
  */
 tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
   try {
@@ -29,164 +60,20 @@ tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
       });
     }
 
-    const { grant_type, code, redirect_uri, client_id, code_verifier } =
-      req.body;
+    const { grant_type } = req.body;
 
-    // Validate grant type
-    if (grant_type !== "authorization_code") {
-      return res.status(400).json({
-        error: "unsupported_grant_type",
-        error_description: "Only 'authorization_code' grant type is supported",
-      });
+    if (grant_type === "refresh_token") {
+      return handleRefreshTokenGrant(req, res);
     }
 
-    // Validate authorization code
-    if (!code) {
-      return res.status(400).json({
-        error: "invalid_request",
-        error_description: "Missing authorization code",
-      });
+    if (grant_type === "authorization_code") {
+      return handleAuthorizationCodeGrant(req, res);
     }
 
-    // Look up the authorization code
-    const codeData = await oauthRepository.getAuthCode(code);
-    if (!codeData) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Invalid or expired authorization code",
-      });
-    }
-
-    // Check if code has expired (10 minutes)
-    if (Date.now() > codeData.expires_at.getTime()) {
-      await oauthRepository.deleteAuthCode(code);
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Authorization code has expired",
-      });
-    }
-
-    // Validate client_id and redirect_uri match the original request
-    if (codeData.client_id !== client_id) {
-      return res.status(400).json({
-        error: "invalid_client",
-        error_description: "Client ID does not match",
-      });
-    }
-
-    if (codeData.redirect_uri !== redirect_uri) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Redirect URI does not match",
-      });
-    }
-
-    // Validate client_id against registered clients
-    // Note: Client should have been registered either explicitly via /oauth/register
-    // or auto-registered during the /oauth/authorize flow
-    const clientData = await oauthRepository.getClient(client_id);
-    if (!clientData) {
-      return res.status(400).json({
-        error: "invalid_client",
-        error_description: "Client not found or not registered",
-      });
-    }
-
-    // Validate client authentication based on registered auth method
-    if (clientData.token_endpoint_auth_method === "client_secret_basic") {
-      const authHeader = req.headers.authorization;
-      if (!authHeader || !authHeader.startsWith("Basic ")) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Client authentication required via Basic auth",
-        });
-      }
-
-      const credentials = Buffer.from(
-        authHeader.substring(6),
-        "base64",
-      ).toString();
-      const [authClientId, authClientSecret] = credentials.split(":");
-
-      if (
-        authClientId !== client_id ||
-        authClientSecret !== clientData.client_secret
-      ) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Invalid client credentials",
-        });
-      }
-    } else if (clientData.token_endpoint_auth_method === "client_secret_post") {
-      const { client_secret } = req.body;
-      if (!client_secret || client_secret !== clientData.client_secret) {
-        return res.status(401).json({
-          error: "invalid_client",
-          error_description: "Invalid client secret",
-        });
-      }
-    }
-    // For "none" auth method, no additional validation needed
-
-    // OAuth 2.1 Security: PKCE is mandatory for all clients
-    if (!codeData.code_challenge) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description:
-          "Authorization code was not issued with PKCE challenge",
-      });
-    }
-
-    if (!code_verifier) {
-      return res.status(400).json({
-        error: "invalid_request",
-        error_description: "PKCE code verifier is required",
-      });
-    }
-
-    // Verify code challenge
-    const crypto = await import("crypto");
-    let challengeFromVerifier: string;
-
-    if (codeData.code_challenge_method === "S256") {
-      const hash = crypto.createHash("sha256").update(code_verifier).digest();
-      challengeFromVerifier = hash.toString("base64url");
-    } else if (codeData.code_challenge_method === "plain") {
-      challengeFromVerifier = code_verifier;
-    } else {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "Unsupported code challenge method",
-      });
-    }
-
-    if (challengeFromVerifier !== codeData.code_challenge) {
-      return res.status(400).json({
-        error: "invalid_grant",
-        error_description: "PKCE verification failed",
-      });
-    }
-
-    // Code is valid, delete it (authorization codes are single-use)
-    await oauthRepository.deleteAuthCode(code);
-
-    // Generate access token
-    const accessToken = generateSecureAccessToken();
-    const expiresIn = 3600; // 1 hour
-
-    // Store access token data
-    await oauthRepository.setAccessToken(accessToken, {
-      client_id: codeData.client_id,
-      user_id: codeData.user_id,
-      scope: codeData.scope,
-      expires_at: Date.now() + expiresIn * 1000,
-    });
-
-    res.json({
-      access_token: accessToken,
-      token_type: "Bearer",
-      expires_in: expiresIn,
-      scope: codeData.scope,
+    return res.status(400).json({
+      error: "unsupported_grant_type",
+      error_description:
+        "Supported grant types: authorization_code, refresh_token",
     });
   } catch (error) {
     logger.error("Error in OAuth token endpoint:", error);
@@ -196,6 +83,224 @@ tokenRouter.post("/oauth/token", rateLimitToken, async (req, res) => {
     });
   }
 });
+
+/**
+ * Handle grant_type=authorization_code
+ */
+async function handleAuthorizationCodeGrant(
+  req: express.Request,
+  res: express.Response,
+) {
+  const { code, redirect_uri, client_id, code_verifier } = req.body;
+
+  // Validate authorization code
+  if (!code) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "Missing authorization code",
+    });
+  }
+
+  // Look up the authorization code
+  const codeData = await oauthRepository.getAuthCode(code);
+  if (!codeData) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Invalid or expired authorization code",
+    });
+  }
+
+  // Check if code has expired (10 minutes)
+  if (Date.now() > codeData.expires_at.getTime()) {
+    await oauthRepository.deleteAuthCode(code);
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Authorization code has expired",
+    });
+  }
+
+  // Validate client_id and redirect_uri match the original request
+  if (codeData.client_id !== client_id) {
+    return res.status(400).json({
+      error: "invalid_client",
+      error_description: "Client ID does not match",
+    });
+  }
+
+  if (codeData.redirect_uri !== redirect_uri) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Redirect URI does not match",
+    });
+  }
+
+  // Validate client_id against registered clients
+  const clientData = await oauthRepository.getClient(client_id);
+  if (!clientData) {
+    return res.status(400).json({
+      error: "invalid_client",
+      error_description: "Client not found or not registered",
+    });
+  }
+
+  // Validate client authentication based on registered auth method
+  if (clientData.token_endpoint_auth_method === "client_secret_basic") {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Basic ")) {
+      return res.status(401).json({
+        error: "invalid_client",
+        error_description: "Client authentication required via Basic auth",
+      });
+    }
+
+    const credentials = Buffer.from(
+      authHeader.substring(6),
+      "base64",
+    ).toString();
+    const [authClientId, authClientSecret] = credentials.split(":");
+
+    if (
+      authClientId !== client_id ||
+      authClientSecret !== clientData.client_secret
+    ) {
+      return res.status(401).json({
+        error: "invalid_client",
+        error_description: "Invalid client credentials",
+      });
+    }
+  } else if (clientData.token_endpoint_auth_method === "client_secret_post") {
+    const { client_secret } = req.body;
+    if (!client_secret || client_secret !== clientData.client_secret) {
+      return res.status(401).json({
+        error: "invalid_client",
+        error_description: "Invalid client secret",
+      });
+    }
+  }
+  // For "none" auth method, no additional validation needed
+
+  // OAuth 2.1 Security: PKCE is mandatory for all clients
+  if (!codeData.code_challenge) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description:
+        "Authorization code was not issued with PKCE challenge",
+    });
+  }
+
+  if (!code_verifier) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "PKCE code verifier is required",
+    });
+  }
+
+  // Verify code challenge
+  const crypto = await import("crypto");
+  let challengeFromVerifier: string;
+
+  if (codeData.code_challenge_method === "S256") {
+    const hash = crypto.createHash("sha256").update(code_verifier).digest();
+    challengeFromVerifier = hash.toString("base64url");
+  } else if (codeData.code_challenge_method === "plain") {
+    challengeFromVerifier = code_verifier;
+  } else {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Unsupported code challenge method",
+    });
+  }
+
+  if (challengeFromVerifier !== codeData.code_challenge) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "PKCE verification failed",
+    });
+  }
+
+  // Code is valid, delete it (authorization codes are single-use)
+  await oauthRepository.deleteAuthCode(code);
+
+  // Issue access token + refresh token
+  const { accessToken, refreshToken } = await issueTokenPair(
+    codeData.client_id,
+    codeData.user_id,
+    codeData.scope,
+  );
+
+  res.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_EXPIRY,
+    refresh_token: refreshToken,
+    scope: codeData.scope,
+  });
+}
+
+/**
+ * Handle grant_type=refresh_token
+ * Issues a new access token + refresh token pair (token rotation).
+ */
+async function handleRefreshTokenGrant(
+  req: express.Request,
+  res: express.Response,
+) {
+  const { refresh_token, client_id } = req.body;
+
+  if (!refresh_token) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "Missing refresh_token parameter",
+    });
+  }
+
+  // Look up the token row by refresh_token
+  const tokenData = await oauthRepository.getByRefreshToken(refresh_token);
+  if (!tokenData) {
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Invalid refresh token",
+    });
+  }
+
+  // Check refresh token expiry
+  if (
+    tokenData.refresh_token_expires_at &&
+    Date.now() > tokenData.refresh_token_expires_at.getTime()
+  ) {
+    await oauthRepository.deleteAccessToken(tokenData.access_token);
+    return res.status(400).json({
+      error: "invalid_grant",
+      error_description: "Refresh token has expired",
+    });
+  }
+
+  // Validate client_id matches (if provided)
+  if (client_id && tokenData.client_id !== client_id) {
+    return res.status(400).json({
+      error: "invalid_client",
+      error_description: "Client ID does not match",
+    });
+  }
+
+  // Delete old token row (rotation: old refresh token is single-use)
+  await oauthRepository.deleteAccessToken(tokenData.access_token);
+
+  // Issue new access token + refresh token
+  const { accessToken, refreshToken } = await issueTokenPair(
+    tokenData.client_id,
+    tokenData.user_id,
+    tokenData.scope,
+  );
+
+  res.json({
+    access_token: accessToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_EXPIRY,
+    refresh_token: refreshToken,
+    scope: tokenData.scope,
+  });
+}
 
 /**
  * OAuth 2.0 Token Introspection Endpoint
@@ -241,10 +346,10 @@ tokenRouter.post("/oauth/introspect", async (req, res) => {
     res.json({
       active: true,
       scope: tokenData.scope,
-      client_id: "mcp_client", // In production, store and return actual client_id
+      client_id: tokenData.client_id,
       token_type: "Bearer",
       exp: Math.floor(tokenData.expires_at.getTime() / 1000),
-      iat: Math.floor((tokenData.expires_at.getTime() - 3600 * 1000) / 1000), // Issued 1 hour before expiry
+      iat: Math.floor(tokenData.created_at.getTime() / 1000),
       sub: tokenData.user_id,
     });
   } catch (error) {
@@ -258,7 +363,7 @@ tokenRouter.post("/oauth/introspect", async (req, res) => {
 
 /**
  * OAuth 2.0 Token Revocation Endpoint
- * Allows clients to revoke access tokens
+ * Allows clients to revoke access tokens or refresh tokens
  */
 tokenRouter.post("/oauth/revoke", async (req, res) => {
   try {
@@ -279,11 +384,16 @@ tokenRouter.post("/oauth/revoke", async (req, res) => {
       });
     }
 
-    // Revoke the token by removing it from storage
+    // Try revoking as access token
     if (await oauthRepository.getAccessToken(token)) {
       await oauthRepository.deleteAccessToken(token);
     } else {
-      // RFC 7009 specifies that the endpoint should return success even if token doesn't exist
+      // Try revoking as refresh token
+      const tokenData = await oauthRepository.getByRefreshToken(token);
+      if (tokenData) {
+        await oauthRepository.deleteAccessToken(tokenData.access_token);
+      }
+      // RFC 7009: return success even if token doesn't exist
     }
 
     // RFC 7009 specifies that revocation endpoint should return 200 OK

--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -11,8 +11,34 @@ import {
 
 const tokenRouter = express.Router();
 
-const ACCESS_TOKEN_EXPIRY = 3600; // 1 hour
-const REFRESH_TOKEN_EXPIRY = 7 * 24 * 3600; // 7 days
+// Umbrella fork: TTLs are env-var configurable. Defaults are tuned for max
+// connectivity from clients that lack revoke-friendly UX (e.g. Claude.ai
+// connectors): 24h access tokens with 365d refresh tokens. Refresh tokens
+// rotate on every use (single-use), so a stolen refresh self-reveals when
+// the legit client redeems the rotated copy and gets `invalid_grant`.
+function readTtl(envName: string, fallbackSeconds: number): number {
+  const raw = process.env[envName];
+  if (!raw) return fallbackSeconds;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  logger.warn(
+    `[oauth] ${envName}=${raw} is not a positive integer; using default ${fallbackSeconds}s`,
+  );
+  return fallbackSeconds;
+}
+
+const ACCESS_TOKEN_EXPIRY = readTtl(
+  "OAUTH_ACCESS_TOKEN_TTL_SECONDS",
+  24 * 60 * 60, // 24h default (was 1h upstream)
+);
+const REFRESH_TOKEN_EXPIRY = readTtl(
+  "OAUTH_REFRESH_TOKEN_TTL_SECONDS",
+  365 * 24 * 60 * 60, // 365d default (was 7d in PR #276)
+);
+
+logger.info(
+  `[oauth] token TTLs: access=${ACCESS_TOKEN_EXPIRY}s refresh=${REFRESH_TOKEN_EXPIRY}s`,
+);
 
 /**
  * Issue a new access token + refresh token pair and store them.

--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -32,6 +32,15 @@ export function generateSecureAccessToken(): string {
 }
 
 /**
+ * Generate cryptographically secure refresh token
+ * Follows OAuth 2.1 security requirements
+ */
+export function generateSecureRefreshToken(): string {
+  const randomPart = randomBytes(32).toString("base64url");
+  return `mcp_refresh_${randomPart}`;
+}
+
+/**
  * Generate cryptographically secure client ID
  * Follows OAuth 2.1 security requirements
  */

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -58,6 +58,8 @@ export const OAuthAccessTokenSchema = z.object({
   user_id: z.string(),
   scope: z.string(),
   expires_at: z.date(),
+  refresh_token: z.string().nullable(),
+  refresh_token_expires_at: z.date().nullable(),
   created_at: z.date(),
 });
 


### PR DESCRIPTION
Cherry-picks PR #276 (refresh tokens), #280 (MAX_TOTAL_CONNECTIONS env), #282 (SESSION_LIFETIME env) from upstream. Adds Umbrella-specific env-configurable TTL defaults: 24h access tokens, 365d refresh tokens, 30d/7d better-auth session. See UMBRELLA_FORK.md for fork rationale + cherry-pick log. CI workflow added — builds umbrella branch on push, publishes ghcr.io/umbrella-it-group/metamcp:latest+sha.