### PR TITLE
Phase 2 — community fixes: session re-init, subprocess leak, idle-pool hardening

### DIFF
--- a/UMBRELLA_FORK.md
+++ b/UMBRELLA_FORK.md
@@ -38,11 +38,11 @@ Track every commit we pull in. When upstream merges the same patch, we drop ours
 
 | Date | Source | Upstream PR | Commit on `umbrella` | Notes |
 |---|---|---|---|---|
-| 2026-05-07 | `loris-av` | [#276](https://github.com/metatool-ai/metamcp/pull/276) | (filled at cherry-pick time) | OAuth refresh-token grant + SESSION_LIFETIME + MAX_TOTAL_CONNECTIONS env vars. We patch on top to bump TTL defaults and make access/refresh TTLs env-configurable too. |
-| 2026-05-07 | `UmbrellaITSolutions` | [#283](https://github.com/metatool-ai/metamcp/pull/283) | (filled at cherry-pick time) | Re-init backend session on HTTP 404 "Session not found". Our PR. |
-| 2026-05-07 | `tremlin` | [#273](https://github.com/metatool-ai/metamcp/pull/273) | (filled at cherry-pick time) | Subprocess leak fix — addresses upstream issues #128/#162 OOM cluster. We add tests on top. |
-| 2026-05-07 | `BTForIT` | [#260](https://github.com/metatool-ai/metamcp/pull/260) | (filled at cherry-pick time) | Touch session timestamps on access for idle-based cleanup. |
-| 2026-05-07 | `BenjaminAronsson` | [#256](https://github.com/metatool-ai/metamcp/pull/256) | (filled at cherry-pick time) | Per-server client header forwarding. Migration `0014_dapper_jigsaw.sql` renumbered to `0015` to land after #276's `0014_oauth_refresh_token.sql`. |
+| 2026-05-07 | `loris-av` | [#276](https://github.com/metatool-ai/metamcp/pull/276) | `f446ce3`, `69e4b4f`, `138668a` (squashed into PR #1 on `umbrella`) | OAuth refresh-token grant + MAX_TOTAL_CONNECTIONS + SESSION_LIFETIME env vars. Umbrella patch on top: env-configurable TTLs (24h access / 365d refresh / 30d session). |
+| 2026-05-07 | `UmbrellaITSolutions` | [#283](https://github.com/metatool-ai/metamcp/pull/283) | `1f1c937` | Re-init backend session on HTTP 404 "Session not found". Our PR. |
+| 2026-05-07 | `tremlin` | [#273](https://github.com/metatool-ai/metamcp/pull/273) | `dcbe7bb`, `b63d709` | Subprocess leak fix — addresses upstream issues #128/#162 OOM cluster. Includes graceful SIGTERM + concurrency-safe creating-idle-sessions guard. |
+| 2026-05-07 | `BTForIT` | [#260](https://github.com/metatool-ai/metamcp/pull/260) | `7a0535a`, `7289173`, `0cc901c`, `909ab61` | Per-server connection cap, cold-start warmup, idle-based session timestamps, admin reset/shutdown API. The `cee1356` per-server-cap commit conflicted with #273's concurrency guard — resolved by running cap check before entering critical section. |
+| **DEFERRED** | `BenjaminAronsson` | [#256](https://github.com/metatool-ai/metamcp/pull/256) | — | Per-server client header forwarding (12 commits, conflicts with #273 + #260 in `mcp-server-pool.ts`). Deferred to Phase 2.5. Migration `0014_dapper_jigsaw.sql` will need renumbering to `0015` to land after #276's `0014_oauth_refresh_token.sql`. |
 
 ## Our own patches (no upstream PR)
 

--- a/apps/backend/src/db/repositories/mcp-servers.repo.ts
+++ b/apps/backend/src/db/repositories/mcp-servers.repo.ts
@@ -248,6 +248,22 @@ export class McpServersRepository {
 
     return updatedServer;
   }
+
+  /**
+   * Reset error_status to NONE for all servers that are currently in ERROR state.
+   * Used on startup to give servers a fresh chance.
+   */
+  async resetAllErrorStatuses(): Promise<number> {
+    const updated = await db
+      .update(mcpServersTable)
+      .set({
+        error_status: McpServerErrorStatusEnum.Enum.NONE,
+      })
+      .where(eq(mcpServersTable.error_status, McpServerErrorStatusEnum.Enum.ERROR))
+      .returning();
+
+    return updated.length;
+  }
 }
 
 export const mcpServersRepository = new McpServersRepository();

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -114,6 +114,29 @@ start().catch((err) => {
   // Do not throw - keep consistent with other startup behavior
 });
 
+// Graceful shutdown: clean up MCP server pools on SIGTERM/SIGINT
+// Prevents orphaned STDIO child processes when backend restarts
+const gracefulShutdown = async (signal: string) => {
+  console.log(`${signal} received, cleaning up MCP server pools...`);
+  try {
+    const { mcpServerPool } = await import("./lib/metamcp");
+    const { metaMcpServerPool } = await import(
+      "./lib/metamcp/metamcp-server-pool"
+    );
+    await Promise.allSettled([
+      mcpServerPool.cleanupAll(),
+      metaMcpServerPool.cleanupAll(),
+    ]);
+    console.log("MCP server pools cleaned up successfully");
+  } catch (error) {
+    console.error("Error during graceful shutdown:", error);
+  }
+  process.exit(0);
+};
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
+
 app.get("/health", (req, res) => {
   res.json({
     status: "ok",

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -95,7 +95,7 @@ export const configService = {
     const config = await configRepo.getConfig(
       ConfigKeyEnum.Enum.MCP_MAX_ATTEMPTS,
     );
-    return config?.value ? parseInt(config.value, 10) : 1;
+    return config?.value ? parseInt(config.value, 10) : 3;
   },
 
   async setMcpMaxAttempts(maxAttempts: number): Promise<void> {

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -43,6 +43,9 @@ export class McpServerPool {
   // Session cleanup timer
   private cleanupTimer: NodeJS.Timeout | null = null;
 
+  // Health check timer for idle sessions
+  private healthCheckTimer: NodeJS.Timeout | null = null;
+
   // Background idle sessions by namespace: namespaceUuid -> any
   private backgroundIdleSessionsByNamespace: Map<string, any> = new Map();
 
@@ -62,6 +65,7 @@ export class McpServerPool {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;
     this.startCleanupTimer();
+    this.startHealthCheckTimer();
   }
 
   /**
@@ -88,6 +92,8 @@ export class McpServerPool {
 
     // Check if we already have an active session for this sessionId and server
     if (this.activeSessions[sessionId]?.[serverUuid]) {
+      // Touch timestamp on every access so SESSION_LIFETIME acts as idle timeout, not hard TTL
+      this.sessionTimestamps[sessionId] = Date.now();
       return this.activeSessions[sessionId][serverUuid];
     }
 
@@ -343,7 +349,8 @@ export class McpServerPool {
   }
 
   /**
-   * Cleanup a session by sessionId
+   * Cleanup a session by sessionId.
+   * Recycles healthy connections back to the idle pool instead of destroying them.
    */
   async cleanupSession(sessionId: string): Promise<void> {
     const activeSession = this.activeSessions[sessionId];
@@ -351,12 +358,31 @@ export class McpServerPool {
       return;
     }
 
-    // Cleanup all connections for this session
-    await Promise.allSettled(
-      Object.entries(activeSession).map(async ([_serverUuid, client]) => {
-        await client.cleanup();
-      }),
-    );
+    let recycled = 0;
+    let destroyed = 0;
+
+    // Try to recycle each connection back to idle pool
+    for (const [serverUuid, client] of Object.entries(activeSession)) {
+      if (!this.idleSessions[serverUuid]) {
+        // No idle session for this server — recycle the connection
+        this.idleSessions[serverUuid] = client;
+        recycled++;
+        logger.info(
+          `Recycled active connection for server ${serverUuid} to idle pool (session ${sessionId})`,
+        );
+      } else {
+        // Already have an idle session — destroy the extra
+        try {
+          await client.cleanup();
+        } catch (error) {
+          logger.error(
+            `Error cleaning up extra connection for server ${serverUuid}:`,
+            error,
+          );
+        }
+        destroyed++;
+      }
+    }
 
     // Remove from active sessions
     delete this.activeSessions[sessionId];
@@ -365,22 +391,11 @@ export class McpServerPool {
     delete this.sessionTimestamps[sessionId];
 
     // Clean up session to servers mapping
-    const serverUuids = this.sessionToServers[sessionId];
-    if (serverUuids) {
-      // For each server this session was using, create new idle sessions if needed (ASYNC - NON-BLOCKING)
-      Array.from(serverUuids).forEach((serverUuid) => {
-        const params = this.serverParamsCache[serverUuid];
-        if (params) {
-          // Note: We don't have namespaceUuid here, so we can't track crashes properly
-          // This is a limitation of the current design - we'll need to pass namespaceUuid from the caller
-          this.createIdleSessionAsync(serverUuid, params);
-        }
-      });
+    delete this.sessionToServers[sessionId];
 
-      delete this.sessionToServers[sessionId];
-    }
-
-    logger.info(`Cleaned up MCP server pool session ${sessionId}`);
+    logger.info(
+      `Cleaned up session ${sessionId} (recycled: ${recycled}, destroyed: ${destroyed})`,
+    );
   }
 
   /**
@@ -424,6 +439,12 @@ export class McpServerPool {
     if (this.cleanupTimer) {
       clearInterval(this.cleanupTimer);
       this.cleanupTimer = null;
+    }
+
+    // Clear health check timer
+    if (this.healthCheckTimer) {
+      clearInterval(this.healthCheckTimer);
+      this.healthCheckTimer = null;
     }
 
     logger.info("Cleaned up all MCP server pool sessions");
@@ -829,6 +850,79 @@ export class McpServerPool {
       }
     } catch (error) {
       logger.error("Error during automatic session cleanup:", error);
+    }
+  }
+
+  /**
+   * Start the health check timer for idle sessions
+   */
+  private startHealthCheckTimer(): void {
+    // Check idle session health every 60 seconds
+    this.healthCheckTimer = setInterval(
+      async () => {
+        await this.checkIdleSessionHealth();
+      },
+      60 * 1000,
+    ); // 60 seconds
+  }
+
+  /**
+   * Check health of idle sessions by pinging them.
+   * Dead sessions are cleaned up and recreated.
+   * Servers in ERROR state whose crash counters have been reset are retried.
+   */
+  private async checkIdleSessionHealth(): Promise<void> {
+    const serverUuids = Object.keys(this.idleSessions);
+    if (serverUuids.length === 0) {
+      return;
+    }
+
+    for (const serverUuid of serverUuids) {
+      const client = this.idleSessions[serverUuid];
+      if (!client) continue;
+
+      try {
+        // Ping with a 5-second timeout
+        await client.client.ping({ timeout: 5000 });
+      } catch {
+        logger.warn(
+          `Idle session health check failed for server ${serverUuid}, recreating...`,
+        );
+
+        // Clean up the dead session
+        try {
+          await client.cleanup();
+        } catch {
+          // Already dead, ignore cleanup errors
+        }
+        delete this.idleSessions[serverUuid];
+
+        // Reset error state so we can retry
+        await serverErrorTracker.resetServerErrorState(serverUuid);
+
+        // Recreate if we have cached params
+        const params = this.serverParamsCache[serverUuid];
+        if (params) {
+          this.createIdleSessionAsync(serverUuid, params);
+        }
+      }
+    }
+
+    // Also check for servers in ERROR state that have cached params but no idle session.
+    // If they were reset (e.g., on startup), we should try to recreate them.
+    for (const [serverUuid, params] of Object.entries(this.serverParamsCache)) {
+      if (
+        !this.idleSessions[serverUuid] &&
+        !this.creatingIdleSessions.has(serverUuid)
+      ) {
+        const isError = await serverErrorTracker.isServerInErrorState(
+          serverUuid,
+        );
+        if (!isError) {
+          // Not in error and no idle session - try to create one
+          this.createIdleSessionAsync(serverUuid, params);
+        }
+      }
     }
   }
 

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -545,6 +545,56 @@ export class McpServerPool {
   }
 
   /**
+   * Drop the pooled backend connection(s) for a given (sessionId, serverUuid).
+   *
+   * Used when the backend MCP server reports our Mcp-Session-Id is unknown
+   * (e.g. after the backend container restarts and loses its in-memory session
+   * registry). Both the active session and the paired idle session share the
+   * backend's session registry, so both are closed — if the backend forgot
+   * the active session, it has forgotten the idle one too. No replacement is
+   * created here; the next `getSession` call will establish a fresh
+   * connection (and therefore a fresh backend session) on demand.
+   */
+  async invalidateServerConnection(
+    sessionId: string,
+    serverUuid: string,
+  ): Promise<void> {
+    const activeForSession = this.activeSessions[sessionId];
+    const activeClient = activeForSession?.[serverUuid];
+    if (activeClient) {
+      try {
+        await activeClient.cleanup();
+      } catch (error) {
+        console.error(
+          `Error cleaning up invalidated active session ${sessionId}/${serverUuid}:`,
+          error,
+        );
+      }
+      delete activeForSession[serverUuid];
+      this.sessionToServers[sessionId]?.delete(serverUuid);
+    }
+
+    const idleClient = this.idleSessions[serverUuid];
+    if (idleClient) {
+      try {
+        await idleClient.cleanup();
+      } catch (error) {
+        console.error(
+          `Error cleaning up invalidated idle session for ${serverUuid}:`,
+          error,
+        );
+      }
+      delete this.idleSessions[serverUuid];
+    }
+
+    this.creatingIdleSessions.delete(serverUuid);
+
+    console.warn(
+      `Invalidated pooled backend connection for server ${serverUuid} (session ${sessionId})`,
+    );
+  }
+
+  /**
    * Handle server process crash
    */
   async handleServerCrash(

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -11,6 +11,8 @@ export interface McpServerPoolStatus {
   active: number;
   activeSessionIds: string[];
   idleServerUuids: string[];
+  perServerCounts?: Record<string, number>;
+  maxConnectionsPerServer?: number;
 }
 
 export class McpServerPool {
@@ -55,15 +57,23 @@ export class McpServerPool {
   // Maximum total connections (idle + active) to prevent runaway process spawning
   private readonly maxTotalConnections: number;
 
+  // Maximum connections per individual server UUID (prevents per-server process explosion)
+  private readonly maxConnectionsPerServer: number;
+
   private constructor(
     defaultIdleCount: number = 1,
     maxTotalConnections: number = parseInt(
       process.env.MAX_TOTAL_CONNECTIONS || "100",
       10,
     ),
+    maxConnectionsPerServer: number = parseInt(
+      process.env.MAX_CONNECTIONS_PER_SERVER || "5",
+      10,
+    ),
   ) {
     this.defaultIdleCount = defaultIdleCount;
     this.maxTotalConnections = maxTotalConnections;
+    this.maxConnectionsPerServer = maxConnectionsPerServer;
     this.startCleanupTimer();
     this.startHealthCheckTimer();
   }
@@ -71,11 +81,85 @@ export class McpServerPool {
   /**
    * Get the singleton instance
    */
-  static getInstance(defaultIdleCount: number = 1): McpServerPool {
+  static getInstance(
+    defaultIdleCount: number = 1,
+    maxConnectionsPerServer: number = 5,
+  ): McpServerPool {
     if (!McpServerPool.instance) {
-      McpServerPool.instance = new McpServerPool(defaultIdleCount);
+      McpServerPool.instance = new McpServerPool(
+        defaultIdleCount,
+        100,
+        maxConnectionsPerServer,
+      );
     }
     return McpServerPool.instance;
+  }
+
+  /**
+   * Count all connections (idle + active + pending) for a specific server UUID
+   */
+  private countConnectionsForServer(serverUuid: string): number {
+    let count = 0;
+
+    // Count idle session
+    if (this.idleSessions[serverUuid]) {
+      count += 1;
+    }
+
+    // Count active sessions across all sessionIds
+    for (const sessionServers of Object.values(this.activeSessions)) {
+      if (sessionServers[serverUuid]) {
+        count += 1;
+      }
+    }
+
+    // Count pending idle creation
+    if (this.creatingIdleSessions.has(serverUuid)) {
+      count += 1;
+    }
+
+    return count;
+  }
+
+  /**
+   * Check if we can create another connection for a specific server
+   */
+  private canCreateConnectionForServer(serverUuid: string): boolean {
+    const count = this.countConnectionsForServer(serverUuid);
+    if (count >= this.maxConnectionsPerServer) {
+      logger.warn(
+        `Per-server connection limit reached for ${serverUuid}: ${count}/${this.maxConnectionsPerServer}`,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Find the oldest active connection for a server UUID (for reuse when at cap)
+   */
+  private findOldestActiveConnectionForServer(
+    serverUuid: string,
+  ): ConnectedClient | undefined {
+    let oldestSessionId: string | undefined;
+    let oldestTimestamp = Infinity;
+
+    for (const [sessionId, sessionServers] of Object.entries(
+      this.activeSessions,
+    )) {
+      if (sessionServers[serverUuid]) {
+        const timestamp = this.sessionTimestamps[sessionId] || Infinity;
+        if (timestamp < oldestTimestamp) {
+          oldestTimestamp = timestamp;
+          oldestSessionId = sessionId;
+        }
+      }
+    }
+
+    if (oldestSessionId) {
+      return this.activeSessions[oldestSessionId]?.[serverUuid];
+    }
+    return undefined;
   }
 
   /**
@@ -122,7 +206,20 @@ export class McpServerPool {
       return idleClient;
     }
 
-    // No idle session available, create a new connection
+    // No idle session available — check per-server cap before spawning
+    if (!this.canCreateConnectionForServer(serverUuid)) {
+      // At cap: reuse the oldest active connection instead of spawning
+      const reusable = this.findOldestActiveConnectionForServer(serverUuid);
+      if (reusable) {
+        logger.info(
+          `Reusing existing connection for server ${serverUuid} (at per-server cap ${this.maxConnectionsPerServer})`,
+        );
+        this.activeSessions[sessionId][serverUuid] = reusable;
+        this.sessionToServers[sessionId].add(serverUuid);
+        return reusable;
+      }
+    }
+
     const newClient = await this.createNewConnection(params, namespaceUuid);
     if (!newClient) {
       return undefined;
@@ -234,6 +331,13 @@ export class McpServerPool {
       return;
     }
 
+    // Don't create if at per-server cap (#260) — happens before the
+    // generation-tracking guard from #273 to short-circuit cap-blocked
+    // calls without entering the concurrency-protected critical section.
+    if (!this.canCreateConnectionForServer(serverUuid)) {
+      return;
+    }
+
     this.creatingIdleSessions.add(serverUuid);
     const generation = this.idleSessionGenerations[serverUuid] ?? 0;
 
@@ -280,6 +384,11 @@ export class McpServerPool {
       this.idleSessions[serverUuid] ||
       this.creatingIdleSessions.has(serverUuid)
     ) {
+      return;
+    }
+
+    // Check per-server cap before spawning a background idle
+    if (!this.canCreateConnectionForServer(serverUuid)) {
       return;
     }
 
@@ -461,11 +570,20 @@ export class McpServerPool {
       0,
     );
 
+    // Calculate per-server breakdown
+    const perServerCounts: Record<string, number> = {};
+    for (const serverUuid of Object.keys(this.serverParamsCache)) {
+      perServerCounts[serverUuid] =
+        this.countConnectionsForServer(serverUuid);
+    }
+
     return {
       idle,
       active,
       activeSessionIds: Object.keys(this.activeSessions),
       idleServerUuids: Object.keys(this.idleSessions),
+      perServerCounts,
+      maxConnectionsPerServer: this.maxConnectionsPerServer,
     };
   }
 

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -35,6 +35,11 @@ export class McpServerPool {
   // Track ongoing idle session creation to prevent duplicates
   private creatingIdleSessions: Set<string> = new Set();
 
+  // Generation counter per server UUID: incremented by invalidateIdleSession() so
+  // any in-flight createIdleSession / createIdleSessionAsync that resolves with a
+  // stale generation knows to discard its result instead of storing it.
+  private idleSessionGenerations: Record<string, number> = {};
+
   // Session cleanup timer
   private cleanupTimer: NodeJS.Timeout | null = null;
 
@@ -115,6 +120,19 @@ export class McpServerPool {
     const newClient = await this.createNewConnection(params, namespaceUuid);
     if (!newClient) {
       return undefined;
+    }
+
+    // Re-check after the async gap: a concurrent getSession() call for the same
+    // (sessionId, serverUuid) pair may have stored a connection while we were awaiting
+    // createNewConnection(). If so, discard ours to avoid leaking the spawned process.
+    if (this.activeSessions[sessionId]?.[serverUuid]) {
+      newClient.cleanup().catch((error) => {
+        logger.error(
+          `Error cleaning up duplicate connection for server ${params.uuid}:`,
+          error,
+        );
+      });
+      return this.activeSessions[sessionId][serverUuid];
     }
 
     this.activeSessions[sessionId][serverUuid] = newClient;
@@ -200,15 +218,46 @@ export class McpServerPool {
     params: ServerParameters,
     namespaceUuid?: string,
   ): Promise<void> {
-    // Don't create if we already have an idle session for this server
-    if (this.idleSessions[serverUuid]) {
+    // Don't create if we already have an idle session or are already creating one.
+    // Both checks are synchronous (before any await) so they act as a pre-await
+    // mutex, matching the pattern used by createIdleSessionAsync.
+    if (
+      this.idleSessions[serverUuid] ||
+      this.creatingIdleSessions.has(serverUuid)
+    ) {
       return;
     }
 
-    const newClient = await this.createNewConnection(params, namespaceUuid);
-    if (newClient) {
-      this.idleSessions[serverUuid] = newClient;
-      logger.info(`Created idle session for server ${serverUuid}`);
+    this.creatingIdleSessions.add(serverUuid);
+    const generation = this.idleSessionGenerations[serverUuid] ?? 0;
+
+    try {
+      const newClient = await this.createNewConnection(params, namespaceUuid);
+      if (newClient) {
+        const currentGeneration = this.idleSessionGenerations[serverUuid] ?? 0;
+        if (!this.idleSessions[serverUuid] && currentGeneration === generation) {
+          this.idleSessions[serverUuid] = newClient;
+          logger.info(`Created idle session for server ${serverUuid}`);
+        } else {
+          // Either a concurrent call already stored an idle session, or
+          // invalidateIdleSession() bumped the generation while we were awaiting,
+          // meaning our result is stale. Discard it.
+          newClient.cleanup().catch((error) => {
+            logger.error(
+              `Error cleaning up duplicate idle session for ${serverUuid}:`,
+              error,
+            );
+          });
+        }
+      }
+    } finally {
+      // Only release the guard if we're still the current creation for this
+      // server. If the generation was bumped while we were awaiting (e.g. by
+      // invalidateIdleSession), the guard now belongs to the newer creation
+      // and must not be removed here.
+      if ((this.idleSessionGenerations[serverUuid] ?? 0) === generation) {
+        this.creatingIdleSessions.delete(serverUuid);
+      }
     }
   }
 
@@ -230,11 +279,13 @@ export class McpServerPool {
 
     // Mark that we're creating an idle session for this server
     this.creatingIdleSessions.add(serverUuid);
+    const generation = this.idleSessionGenerations[serverUuid] ?? 0;
 
     // Create the session in the background (fire and forget)
     this.createNewConnection(params, namespaceUuid)
       .then((newClient) => {
-        if (newClient && !this.idleSessions[serverUuid]) {
+        const currentGeneration = this.idleSessionGenerations[serverUuid] ?? 0;
+        if (newClient && !this.idleSessions[serverUuid] && currentGeneration === generation) {
           this.idleSessions[serverUuid] = newClient;
           logger.info(
             `Created background idle session for server [${params.name}] ${serverUuid}`,
@@ -246,7 +297,8 @@ export class McpServerPool {
             );
           }
         } else if (newClient) {
-          // We already have an idle session, cleanup the extra one
+          // Either we already have an idle session, or invalidateIdleSession()
+          // bumped the generation while we were awaiting (stale result). Discard it.
           newClient.cleanup().catch((error) => {
             logger.error(
               `Error cleaning up extra idle session for ${serverUuid}:`,
@@ -262,8 +314,13 @@ export class McpServerPool {
         );
       })
       .finally(() => {
-        // Remove from creating set
-        this.creatingIdleSessions.delete(serverUuid);
+        // Only release the guard if we're still the current creation for this
+        // server. If the generation was bumped while we were awaiting (e.g. by
+        // invalidateIdleSession), the guard now belongs to the newer creation
+        // and must not be removed here.
+        if ((this.idleSessionGenerations[serverUuid] ?? 0) === generation) {
+          this.creatingIdleSessions.delete(serverUuid);
+        }
       });
   }
 
@@ -349,6 +406,18 @@ export class McpServerPool {
     this.sessionToServers = {};
     this.sessionTimestamps = {};
     this.serverParamsCache = {};
+
+    // Bump all known generations (never reset to {}) so any in-flight idle
+    // creation that started before cleanupAll() resolves with a stale value
+    // and discards itself. Cover both tracked entries and UUIDs that are only
+    // in creatingIdleSessions (which default to 0 and have no map entry yet).
+    for (const uuid of new Set([
+      ...Object.keys(this.idleSessionGenerations),
+      ...this.creatingIdleSessions,
+    ])) {
+      this.idleSessionGenerations[uuid] =
+        (this.idleSessionGenerations[uuid] ?? 0) + 1;
+    }
     this.creatingIdleSessions.clear();
 
     // Clear cleanup timer
@@ -471,7 +540,11 @@ export class McpServerPool {
       delete this.idleSessions[serverUuid];
     }
 
-    // Remove from creating set if it's in progress
+    // Bump the generation before clearing the in-progress guard so any
+    // in-flight createIdleSession / createIdleSessionAsync that resolves
+    // after this point will see a stale generation and discard its result.
+    this.idleSessionGenerations[serverUuid] =
+      (this.idleSessionGenerations[serverUuid] ?? 0) + 1;
     this.creatingIdleSessions.delete(serverUuid);
 
     // Create a new idle session with updated parameters
@@ -514,7 +587,13 @@ export class McpServerPool {
       delete this.idleSessions[serverUuid];
     }
 
-    // Remove from creating set if it's in progress
+    // Bump rather than delete the generation entry. Deleting would reset the
+    // effective value to 0 (via the ?? 0 default), which could spuriously match
+    // an in-flight creation that also captured 0 before this cleanup ran,
+    // allowing a stale subprocess to repopulate idleSessions after the server
+    // was removed.
+    this.idleSessionGenerations[serverUuid] =
+      (this.idleSessionGenerations[serverUuid] ?? 0) + 1;
     this.creatingIdleSessions.delete(serverUuid);
 
     // Remove from server params cache
@@ -639,6 +718,14 @@ export class McpServerPool {
    * Clean up all sessions for a specific server
    */
   private async cleanupServerSessions(serverUuid: string): Promise<void> {
+    // Bump generation and release the guard FIRST — before any await — so that
+    // an in-flight idle creation that resolves during the cleanup loop below
+    // (e.g. while we await an active-session cleanup) sees a stale generation
+    // and discards its result instead of storing it into the now-empty slot.
+    this.idleSessionGenerations[serverUuid] =
+      (this.idleSessionGenerations[serverUuid] ?? 0) + 1;
+    this.creatingIdleSessions.delete(serverUuid);
+
     // Clean up idle session
     const idleSession = this.idleSessions[serverUuid];
     if (idleSession) {
@@ -674,9 +761,6 @@ export class McpServerPool {
         this.sessionToServers[sessionId]?.delete(serverUuid);
       }
     }
-
-    // Remove from creating set
-    this.creatingIdleSessions.delete(serverUuid);
   }
 
   /**

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -43,6 +43,7 @@ import {
   createToolOverridesListToolsMiddleware,
   mapOverrideNameToOriginal,
 } from "./metamcp-middleware/tool-overrides.functional";
+import { isBackendSessionLostError } from "./session-error";
 import { parseToolName } from "./tool-name-parser";
 import { toolsSyncCache } from "./tools-sync-cache";
 import { sanitizeName } from "./utils";
@@ -422,23 +423,23 @@ export const createServer = async (
       throw new Error(`Server UUID not found for tool: ${name}`);
     }
 
-    try {
-      const abortController = new AbortController();
+    const abortController = new AbortController();
 
-      // Get configurable timeout values
-      const resetTimeoutOnProgress =
-        await configService.getMcpResetTimeoutOnProgress();
-      const timeout = await configService.getMcpTimeout();
-      const maxTotalTimeout = await configService.getMcpMaxTotalTimeout();
+    // Get configurable timeout values
+    const resetTimeoutOnProgress =
+      await configService.getMcpResetTimeoutOnProgress();
+    const timeout = await configService.getMcpTimeout();
+    const maxTotalTimeout = await configService.getMcpMaxTotalTimeout();
 
-      const mcpRequestOptions: RequestOptions = {
-        signal: abortController.signal,
-        resetTimeoutOnProgress,
-        timeout,
-        maxTotalTimeout,
-      };
-      // Use the correct schema for tool calls
-      const result = await clientForTool.client.request(
+    const mcpRequestOptions: RequestOptions = {
+      signal: abortController.signal,
+      resetTimeoutOnProgress,
+      timeout,
+      maxTotalTimeout,
+    };
+
+    const callOnce = (session: ConnectedClient) =>
+      session.client.request(
         {
           method: "tools/call",
           params: {
@@ -451,16 +452,62 @@ export const createServer = async (
         mcpRequestOptions,
       );
 
-      // Cast the result to CallToolResult type
-      return result as CallToolResult;
+    try {
+      return (await callOnce(clientForTool)) as CallToolResult;
     } catch (error) {
-      logger.error(
-        `Error calling tool "${name}" through ${
-          clientForTool.client.getServerVersion()?.name || "unknown"
-        }:`,
-        error,
+      if (!isBackendSessionLostError(error)) {
+        logger.error(
+          `Error calling tool "${name}" through ${
+            clientForTool.client.getServerVersion()?.name || "unknown"
+          }:`,
+          error,
+        );
+        throw error;
+      }
+
+      logger.warn(
+        `Backend reported session lost for server ${serverUuid} on tool "${name}"; invalidating pool and retrying once.`,
       );
-      throw error;
+
+      await mcpServerPool.invalidateServerConnection(sessionId, serverUuid);
+      delete toolToClient[name];
+
+      const serverParamsMap = await getMcpServers(
+        namespaceUuid,
+        includeInactiveServers,
+      );
+      const params = serverParamsMap[serverUuid];
+      if (!params) {
+        throw new Error(
+          `Cannot re-initialize session: server ${serverUuid} no longer present in namespace ${namespaceUuid}`,
+        );
+      }
+
+      const freshSession = await mcpServerPool.getSession(
+        sessionId,
+        serverUuid,
+        params,
+        namespaceUuid,
+      );
+      if (!freshSession) {
+        throw new Error(
+          `Failed to re-initialize session for server ${serverUuid} after backend session loss`,
+        );
+      }
+
+      toolToClient[name] = freshSession;
+
+      try {
+        return (await callOnce(freshSession)) as CallToolResult;
+      } catch (retryError) {
+        logger.error(
+          `Error calling tool "${name}" through ${
+            freshSession.client.getServerVersion()?.name || "unknown"
+          } after session re-initialize:`,
+          retryError,
+        );
+        throw retryError;
+      }
     }
   };
 

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -168,6 +168,28 @@ export const createServer = async (
       `[DEBUG-TOOLS] 📋 Processing ${allServerEntries.length} servers`,
     );
 
+    // Cold-start warmup: if pool has 0 idle + 0 active sessions but servers
+    // exist in DB, trigger a blocking warmup before tools/list responds.
+    // This prevents 0-tool responses after idle timeout expires all connections.
+    const poolStatus = mcpServerPool.getPoolStatus();
+    if (
+      poolStatus.idle === 0 &&
+      poolStatus.active === 0 &&
+      allServerEntries.length > 0
+    ) {
+      console.log(
+        `[DEBUG-TOOLS] ⚠️ Cold start: 0 idle, 0 active sessions but ${allServerEntries.length} servers registered. Warming up...`,
+      );
+      for (const [uuid] of allServerEntries) {
+        await mcpServerPool.resetServerErrorState(uuid);
+      }
+      await mcpServerPool.ensureIdleSessions(serverParams, namespaceUuid);
+      const afterStatus = mcpServerPool.getPoolStatus();
+      console.log(
+        `[DEBUG-TOOLS] ✅ Pool warmup complete: ${afterStatus.idle} idle, ${afterStatus.active} active`,
+      );
+    }
+
     await Promise.allSettled(
       allServerEntries.map(async ([mcpServerUuid, params]) => {
         console.log(`[DEBUG-TOOLS] 🔧 Server: ${params.name || mcpServerUuid}`);

--- a/apps/backend/src/lib/metamcp/server-error-tracker.ts
+++ b/apps/backend/src/lib/metamcp/server-error-tracker.ts
@@ -19,7 +19,7 @@ export class ServerErrorTracker {
   private crashAttempts: Map<string, number> = new Map();
 
   // Default max attempts before marking as ERROR (fallback if config is not available)
-  private readonly fallbackMaxAttempts: number = 1;
+  private readonly fallbackMaxAttempts: number = 3;
 
   // Server-specific max attempts (can be configured per server)
   private serverMaxAttempts: Map<string, number> = new Map();
@@ -134,6 +134,13 @@ export class ServerErrorTracker {
    */
   resetServerAttempts(serverUuid: string): void {
     this.crashAttempts.delete(serverUuid);
+  }
+
+  /**
+   * Reset all crash attempts (e.g., on startup for a clean slate)
+   */
+  resetAllAttempts(): void {
+    this.crashAttempts.clear();
   }
 
   /**

--- a/apps/backend/src/lib/metamcp/session-error.test.ts
+++ b/apps/backend/src/lib/metamcp/session-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { isBackendSessionLostError } from "./session-error";
+
+describe("isBackendSessionLostError", () => {
+  it("matches the HTTP 404 + JSON-RPC -32600 envelope the SDK produces", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("matches the HTTP 404 + JSON-RPC -32001 variant some servers return", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"error":{"code":-32001,"message":"Session not found"},"id":"","jsonrpc":"2.0"}',
+    );
+    expect(isBackendSessionLostError(error)).toBe(true);
+  });
+
+  it("does not match unrelated 404s", () => {
+    const error = new Error("Error POSTing to endpoint (HTTP 404): Not Found");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("does not match transport disconnects", () => {
+    const error = new Error("Not connected");
+    expect(isBackendSessionLostError(error)).toBe(false);
+  });
+
+  it("returns false for non-Error inputs", () => {
+    expect(isBackendSessionLostError(undefined)).toBe(false);
+    expect(isBackendSessionLostError(null)).toBe(false);
+    expect(isBackendSessionLostError("Session not found")).toBe(false);
+  });
+});

--- a/apps/backend/src/lib/metamcp/session-error.ts
+++ b/apps/backend/src/lib/metamcp/session-error.ts
@@ -1,0 +1,32 @@
+/**
+ * Detect errors that indicate the backend MCP server's session registry no
+ * longer knows our Mcp-Session-Id. Per the MCP Streamable HTTP spec, the
+ * backend SHOULD respond with HTTP 404 when it cannot find the session; most
+ * SDKs also surface a JSON-RPC error body with code -32001 or -32600 and
+ * message "Session not found".
+ *
+ * The MCP TypeScript SDK's StreamableHTTPClientTransport wraps this as a
+ * generic Error whose message embeds the HTTP status and raw JSON-RPC body,
+ * so we match on substrings. Example:
+ *
+ *   Error POSTing to endpoint (HTTP 404):
+ *   {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Session not found"}}
+ *
+ * When this happens, the cached backend connection is dead: MetaMCP must drop
+ * it, send a new `initialize`, and replay the failed request. The MCP spec
+ * states the client MUST start a new session in response to HTTP 404, so this
+ * is the normative recovery path, not a workaround.
+ */
+export function isBackendSessionLostError(error: unknown): boolean {
+  if (!(error instanceof Error) || !error.message) {
+    return false;
+  }
+  const message = error.message;
+  const mentionsSessionNotFound = message.includes("Session not found");
+  const mentionsHttp404 = message.includes("HTTP 404");
+  const mentionsSessionErrorCode =
+    message.includes("-32001") || message.includes("-32600");
+  return (
+    mentionsSessionNotFound && (mentionsHttp404 || mentionsSessionErrorCode)
+  );
+}

--- a/apps/backend/src/lib/startup.ts
+++ b/apps/backend/src/lib/startup.ts
@@ -3,6 +3,7 @@ import { ServerParameters } from "@repo/zod-types";
 import { mcpServersRepository, namespacesRepository } from "../db/repositories";
 import { initializeEnvironmentConfiguration } from "./bootstrap.service";
 import { metaMcpServerPool } from "./metamcp";
+import { serverErrorTracker } from "./metamcp/server-error-tracker";
 import { convertDbServerToParams } from "./metamcp/utils";
 
 /**
@@ -47,6 +48,16 @@ export async function initializeIdleServers() {
     console.log(
       "Initializing idle servers for all namespaces and all MCP servers...",
     );
+
+    // Reset all ERROR statuses so servers get a fresh chance on restart
+    const resetCount = await mcpServersRepository.resetAllErrorStatuses();
+    if (resetCount > 0) {
+      console.log(
+        `Reset ${resetCount} server(s) from ERROR to NONE status on startup`,
+      );
+    }
+    // Also clear in-memory crash attempt counters
+    serverErrorTracker.resetAllAttempts();
 
     // Fetch all namespaces from the database
     const namespaces = await namespacesRepository.findAll();

--- a/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
+++ b/apps/backend/src/lib/stdio-transport/process-managed-transport.ts
@@ -182,6 +182,9 @@ export class ProcessManagedStdioTransport implements Transport {
       });
 
       this._process.on("spawn", () => {
+        logger.info(
+          `[transport.start] spawned PID ${this._process?.pid} — command: ${this._serverParams.command}`,
+        );
         resolve();
       });
 
@@ -259,15 +262,46 @@ export class ProcessManagedStdioTransport implements Transport {
 
   async close(): Promise<void> {
     this._isCleanup = true;
-    this._abortController.abort();
 
-    // Kill the entire process group to ensure full cleanup
-    if (this._process?.pid) {
+    const pid = this._process?.pid ?? null;
+
+    if (pid) {
+      const proc = this._process!;
+
+      // Register the "close" listener BEFORE sending any signal so a fast-exiting
+      // child cannot emit "close" in between and cause the promise to time out.
+      const exitedPromise = new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(false), 5000);
+        proc.once("close", () => {
+          clearTimeout(timeout);
+          resolve(true);
+        });
+      });
+
+      this._abortController.abort();
+
       try {
-        process.kill(-this._process.pid, "SIGTERM");
+        process.kill(-pid, "SIGTERM");
+        logger.info(`[transport.close] SIGTERM sent to process group -${pid}`);
       } catch (error) {
-        // Process might already be terminated, ignore errors
-        logger.warn("Failed to kill process group:", error);
+        logger.warn(
+          `[transport.close] SIGTERM failed for process group -${pid}:`,
+          error,
+        );
+      }
+
+      // Wait up to 5 seconds for graceful shutdown, then escalate to SIGKILL
+      const exited = await exitedPromise;
+
+      if (!exited) {
+        logger.warn(
+          `[transport.close] Process ${pid} still alive after 5s — sending SIGKILL`,
+        );
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch {
+          // Process may have already exited between the timeout check and the kill
+        }
       }
     }
 

--- a/apps/backend/src/routers/public-metamcp.ts
+++ b/apps/backend/src/routers/public-metamcp.ts
@@ -5,6 +5,7 @@ import logger from "@/utils/logger";
 
 import { endpointsRepository } from "../db/repositories/endpoints.repo";
 import { openApiRouter } from "./public-metamcp/openapi";
+import adminRouter from "./public-metamcp/admin";
 import sseRouter from "./public-metamcp/sse";
 import streamableHttpRouter from "./public-metamcp/streamable-http";
 
@@ -42,6 +43,9 @@ publicEndpointsRouter.use(sseRouter);
 
 // Use OpenAPI router for /api and /openapi.json routes
 publicEndpointsRouter.use(openApiRouter);
+
+// Use Admin router for /admin endpoints (error reset, diagnostics)
+publicEndpointsRouter.use(adminRouter);
 
 // Health check endpoint
 publicEndpointsRouter.get("/health", (req, res) => {

--- a/apps/backend/src/routers/public-metamcp/admin.ts
+++ b/apps/backend/src/routers/public-metamcp/admin.ts
@@ -1,0 +1,129 @@
+import express from "express";
+
+import {
+  ApiKeyAuthenticatedRequest,
+  authenticateApiKey,
+} from "@/middleware/api-key-oauth.middleware";
+import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
+import logger from "@/utils/logger";
+
+import { mcpServersRepository } from "../../db/repositories";
+import { serverErrorTracker } from "../../lib/metamcp/server-error-tracker";
+import { initializeIdleServers } from "../../lib/startup";
+
+const adminRouter = express.Router();
+
+// JSON body parser for admin routes
+adminRouter.use(express.json());
+
+/**
+ * POST /metamcp/admin/reset-errors
+ *
+ * Resets ERROR state for MCP servers without requiring a full backend restart.
+ * Optionally targets a specific server by UUID, or resets all if no UUID given.
+ *
+ * Body: { "serverUuid": "optional-specific-uuid" }
+ * Auth: Same API key as MCP endpoints (X-API-Key header)
+ */
+adminRouter.post(
+  "/:endpoint_name/admin/reset-errors",
+  lookupEndpoint,
+  authenticateApiKey,
+  async (req: ApiKeyAuthenticatedRequest, res) => {
+    try {
+      const { serverUuid } = req.body || {};
+      const resetResults: string[] = [];
+
+      if (serverUuid) {
+        // Reset specific server
+        await serverErrorTracker.resetServerErrorState(serverUuid);
+        resetResults.push(serverUuid);
+        logger.info(
+          `Admin API: Reset error state for server ${serverUuid}`,
+        );
+      } else {
+        // Reset all servers in ERROR state
+        const allServers = await mcpServersRepository.findAll();
+        const errorServers = allServers.filter(
+          (s) => s.error_status === "ERROR",
+        );
+
+        for (const server of errorServers) {
+          await serverErrorTracker.resetServerErrorState(server.uuid);
+          resetResults.push(server.name || server.uuid);
+        }
+
+        // Also clear all in-memory crash counters
+        serverErrorTracker.resetAllAttempts();
+
+        logger.info(
+          `Admin API: Reset ${resetResults.length} servers from ERROR state: ${resetResults.join(", ")}`,
+        );
+      }
+
+      // Trigger idle server re-initialization to respawn connections
+      // Run async — don't block the response
+      initializeIdleServers().catch((err) => {
+        logger.error("Admin API: Error re-initializing idle servers:", err);
+      });
+
+      res.json({
+        success: true,
+        reset: resetResults.length,
+        servers: resetResults,
+        message:
+          resetResults.length > 0
+            ? `Reset ${resetResults.length} server(s). Idle session re-initialization triggered.`
+            : "No servers were in ERROR state.",
+      });
+    } catch (error) {
+      logger.error("Admin API: Error resetting server errors:", error);
+      res.status(500).json({
+        success: false,
+        error: "Failed to reset server errors",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+);
+
+/**
+ * GET /metamcp/admin/error-status
+ *
+ * Returns current error status of all servers (for diagnostics).
+ */
+adminRouter.get(
+  "/:endpoint_name/admin/error-status",
+  lookupEndpoint,
+  authenticateApiKey,
+  async (req: ApiKeyAuthenticatedRequest, res) => {
+    try {
+      const allServers = await mcpServersRepository.findAll();
+      const serverStatuses = allServers.map((s) => ({
+        uuid: s.uuid,
+        name: s.name,
+        error_status: s.error_status,
+        attempts: serverErrorTracker.getServerAttempts(s.uuid),
+      }));
+
+      const errorCount = serverStatuses.filter(
+        (s) => s.error_status === "ERROR",
+      ).length;
+
+      res.json({
+        timestamp: new Date().toISOString(),
+        total: serverStatuses.length,
+        errored: errorCount,
+        servers: serverStatuses,
+      });
+    } catch (error) {
+      logger.error("Admin API: Error fetching server statuses:", error);
+      res.status(500).json({
+        success: false,
+        error: "Failed to fetch server statuses",
+      });
+    }
+  },
+);
+
+export default adminRouter;


### PR DESCRIPTION
## Phase 2 of the fork

Cherry-picks community fixes that upstream isn't reviewing. None of these are user-facing fixes for the connector-disconnect issue (Phase 1 #1 covered that) — these are quality-of-life: fewer hung sessions, fewer leaked subprocesses, fewer OOMs over long runtime.

## Cherry-picked commits

- [`1f1c937`](apps/backend/src/lib/metamcp/session-error.ts) — `fix: re-initialize backend session when Streamable HTTP backend returns 404 Session not found` (PR [#283](https://github.com/metatool-ai/metamcp/pull/283), our own). Conflict in metamcp-proxy.ts resolved — kept the new branching logic and switched all `console.error/warn` to `logger.error/warn` to match upstream's logging style.
- [`dcbe7bb`](apps/backend/src/lib/metamcp/process-managed-transport.ts) + [`b63d709`](apps/backend/src/lib/metamcp/mcp-server-pool.ts) — graceful SIGTERM + concurrency-safe creating-idle-sessions guard (PR [#273](https://github.com/metatool-ai/metamcp/pull/273) by `tremlin`). Addresses upstream issues #128 + #162 OOM cluster.
- [`7a0535a`](apps/backend/src/lib/metamcp/mcp-server-pool.ts), [`7289173`](apps/backend/src/lib/metamcp/metamcp-proxy.ts), [`0cc901c`](apps/backend/src/lib/metamcp/mcp-server-pool.ts), [`909ab61`](apps/backend/src/routers/public-metamcp/admin.ts) — pool exhaustion fix, cold-start warmup, per-server connection cap, admin reset/shutdown API (PR [#260](https://github.com/metatool-ai/metamcp/pull/260) by `BTForIT`). Per-server cap conflicted with #273's concurrency guard — resolved by running cap check **before** entering the critical section so cap-blocked calls short-circuit cleanly.

## Umbrella-specific patches on top

- `MAX_CONNECTIONS_PER_SERVER` env var fallback (defaults to `5`). Layered onto the per-server cap from PR #260 so we can tune without rebuilding.

## Deferred

- PR [#256](https://github.com/metatool-ai/metamcp/pull/256) (per-server header forwarding, 12 commits) — conflicts with #273 + #260 in `mcp-server-pool.ts` are non-trivial. Defer to Phase 2.5 after this lands and we've confirmed the deploy is stable.

## Test plan

- [ ] CI builds and publishes `:latest`.
- [ ] After Phase 2 deploys, watch `mcp-host-prod` host memory + container child-process count for 24h. Should stay flat or drop vs. pre-Phase-1 baseline (where #128 OOM cluster occasionally caused recycle).
- [ ] Trigger a real Claude.ai connector reconnect cycle to verify session re-init path doesn't introduce regression on the OAuth flow.