### PR TITLE
fix(drizzle): add 0014_oauth_refresh_token journal entry

### DIFF
--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1766064780578,
       "tag": "0013_late_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1778457600000,
+      "tag": "0014_oauth_refresh_token",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
PR #276 cherry-pick added 0014_oauth_refresh_token.sql but missed updating apps/backend/drizzle/meta/_journal.json. drizzle-kit migrate at runtime consults the journal to know which SQL files to apply — without the entry, it skips 0014. Result: refresh-token columns never get added to oauth_access_tokens, /oauth/token with grant_type=refresh_token returns 500 with a query-failed error. Caught during initial deploy of Phase 1.