### PR TITLE
fix(drizzle): idempotent 0014_oauth_refresh_token migration

### DIFF
--- a/apps/backend/drizzle/0014_oauth_refresh_token.sql
+++ b/apps/backend/drizzle/0014_oauth_refresh_token.sql
@@ -1,3 +1,3 @@
-ALTER TABLE "oauth_access_tokens" ADD COLUMN "refresh_token" text;--> statement-breakpoint
-ALTER TABLE "oauth_access_tokens" ADD COLUMN "refresh_token_expires_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "oauth_access_tokens" ADD COLUMN IF NOT EXISTS "refresh_token" text;--> statement-breakpoint
+ALTER TABLE "oauth_access_tokens" ADD COLUMN IF NOT EXISTS "refresh_token_expires_at" timestamp with time zone;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "oauth_access_tokens_refresh_token_idx" ON "oauth_access_tokens" USING btree ("refresh_token");


### PR DESCRIPTION
ADD COLUMN IF NOT EXISTS so the migration is safe to re-run. Defends against the next deploy crash-loop if hash math drifts after the manual hot-fix we did during initial deploy. No behavior change for clean installs.