### PR TITLE
fix(frontend): proxy /health/:path* to backend (was 404 on /health/upstream)

### DIFF
--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -13,6 +13,12 @@ const nextConfig = {
         source: "/health",
         destination: `${backendUrl}/health`,
       },
+      // Umbrella fork: /health/upstream rollup endpoint also lives on
+      // the backend; needs a rewrite or Next.js 404s on the path.
+      {
+        source: "/health/:path*",
+        destination: `${backendUrl}/health/:path*`,
+      },
       // OAuth endpoints - proxy all oauth paths
       {
         source: "/oauth/:path*",


### PR DESCRIPTION
PR #6 added /health/upstream on the backend but Next.js next.config.js only had a rewrite for the exact /health path. Result: external requests to /health/upstream returned a Next.js 404. Wildcard the rewrite so /health/upstream and any future /health/* paths route to backend.