### PR TITLE
fix(session): cover SDK "Not connected" transport-lost envelope in recovery path

### DIFF
--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -43,7 +43,7 @@ import {
   createToolOverridesListToolsMiddleware,
   mapOverrideNameToOriginal,
 } from "./metamcp-middleware/tool-overrides.functional";
-import { isBackendSessionLostError } from "./session-error";
+import { isRecoverableBackendError } from "./session-error";
 import { parseToolName } from "./tool-name-parser";
 import { toolsSyncCache } from "./tools-sync-cache";
 import { sanitizeName } from "./utils";
@@ -431,11 +431,13 @@ export const createServer = async (
                 try {
                   pages = await listToolsOnce(activeSession);
                 } catch (error) {
-                  if (!isBackendSessionLostError(error)) {
+                  if (!isRecoverableBackendError(error)) {
                     throw error;
                   }
                   logger.warn(
-                    `Backend reported session lost for server ${mcpServerUuid} on dynamic tools/list while routing tool "${name}"; invalidating pool and retrying once.`,
+                    `Backend connection lost for server ${mcpServerUuid} on dynamic tools/list while routing tool "${name}"; invalidating pool and retrying once. (envelope: ${
+                      error instanceof Error ? error.message : String(error)
+                    })`,
                   );
                   await mcpServerPool.invalidateServerConnection(
                     sessionId,
@@ -519,7 +521,7 @@ export const createServer = async (
     try {
       return (await callOnce(clientForTool)) as CallToolResult;
     } catch (error) {
-      if (!isBackendSessionLostError(error)) {
+      if (!isRecoverableBackendError(error)) {
         logger.error(
           `Error calling tool "${name}" through ${
             clientForTool.client.getServerVersion()?.name || "unknown"
@@ -530,7 +532,9 @@ export const createServer = async (
       }
 
       logger.warn(
-        `Backend reported session lost for server ${serverUuid} on tool "${name}"; invalidating pool and retrying once.`,
+        `Backend connection lost for server ${serverUuid} on tool "${name}"; invalidating pool and retrying once. (envelope: ${
+          error instanceof Error ? error.message : String(error)
+        })`,
       );
 
       await mcpServerPool.invalidateServerConnection(sessionId, serverUuid);

--- a/apps/backend/src/lib/metamcp/session-error.test.ts
+++ b/apps/backend/src/lib/metamcp/session-error.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isBackendSessionLostError } from "./session-error";
+import {
+  isBackendSessionLostError,
+  isBackendTransportLostError,
+  isRecoverableBackendError,
+} from "./session-error";
 
 describe("isBackendSessionLostError", () => {
   it("matches the HTTP 404 + JSON-RPC -32600 envelope the SDK produces", () => {
@@ -22,7 +26,7 @@ describe("isBackendSessionLostError", () => {
     expect(isBackendSessionLostError(error)).toBe(false);
   });
 
-  it("does not match transport disconnects", () => {
+  it("does not match transport disconnects (transport-lost detector handles those)", () => {
     const error = new Error("Not connected");
     expect(isBackendSessionLostError(error)).toBe(false);
   });
@@ -102,5 +106,122 @@ describe("isBackendSessionLostError", () => {
     a.cause = b;
     b.cause = a;
     expect(isBackendSessionLostError(a)).toBe(false);
+  });
+});
+
+describe("isBackendTransportLostError", () => {
+  it("matches the bare SDK 'Not connected' Error", () => {
+    // Protocol.request() in the MCP TS SDK rejects with exactly this
+    // message when the underlying transport has been torn down.
+    const error = new Error("Not connected");
+    expect(isBackendTransportLostError(error)).toBe(true);
+  });
+
+  it("matches a 'Not connected' string throwable", () => {
+    expect(isBackendTransportLostError("Not connected")).toBe(true);
+  });
+
+  it("matches the consumer-side -32603 envelope MetaMCP returns to Claude.ai / n8n", () => {
+    // Production observation 2026-05-14: consumer-side connectors see
+    // the tRPC bridge's wrapped envelope rather than the raw SDK Error.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32603, message: "Not connected" },
+    };
+    expect(isBackendTransportLostError(envelope)).toBe(true);
+  });
+
+  it("matches when the transport-lost error is wrapped via .cause", () => {
+    const inner = new Error("Not connected");
+    const outer = new Error("Tool dispatch rejected", { cause: inner });
+    expect(isBackendTransportLostError(outer)).toBe(true);
+  });
+
+  it("matches when wrapped two layers deep via .cause", () => {
+    const innermost = new Error("Not connected");
+    const mid = new Error("Transport adapter rejection", { cause: innermost });
+    const outer = new Error("Outer wrap", { cause: mid });
+    expect(isBackendTransportLostError(outer)).toBe(true);
+  });
+
+  it("matches Error with .code -32603 + 'Not connected' message", () => {
+    const error = Object.assign(new Error("Not connected"), { code: -32603 });
+    expect(isBackendTransportLostError(error)).toBe(true);
+  });
+
+  it("does not false-positive on unrelated -32603 'Internal error' envelopes", () => {
+    // Bare -32603 is JSON-RPC "Internal error" and covers many flows.
+    // Detector only fires when paired with the 'Not connected' marker.
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "x",
+      error: { code: -32603, message: "Internal error" },
+    };
+    expect(isBackendTransportLostError(envelope)).toBe(false);
+  });
+
+  it("does not match session-not-found envelopes (those go to the session-lost detector)", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isBackendTransportLostError(error)).toBe(false);
+  });
+
+  it("returns false for null / undefined / unrelated strings", () => {
+    expect(isBackendTransportLostError(undefined)).toBe(false);
+    expect(isBackendTransportLostError(null)).toBe(false);
+    expect(isBackendTransportLostError("just some text")).toBe(false);
+    expect(isBackendTransportLostError(new Error("Timeout"))).toBe(false);
+  });
+
+  it("handles circular .cause chains without infinite-looping", () => {
+    const a = new Error("Wrapper a") as Error & { cause?: unknown };
+    const b = new Error("Wrapper b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isBackendTransportLostError(a)).toBe(false);
+  });
+
+  it("falls back to String(error) for custom throwables", () => {
+    class CustomTransportError {
+      toString() {
+        return "Not connected";
+      }
+    }
+    expect(isBackendTransportLostError(new CustomTransportError())).toBe(true);
+  });
+});
+
+describe("isRecoverableBackendError", () => {
+  it("fires on session-not-found envelopes", () => {
+    const error = new Error(
+      'Error POSTing to endpoint (HTTP 404): {"jsonrpc":"2.0","error":{"code":-32600,"message":"Session not found"}}',
+    );
+    expect(isRecoverableBackendError(error)).toBe(true);
+  });
+
+  it("fires on transport-disconnect envelopes", () => {
+    expect(isRecoverableBackendError(new Error("Not connected"))).toBe(true);
+  });
+
+  it("fires on the consumer-side -32603 envelope (2026-05-14 production case)", () => {
+    const envelope = {
+      jsonrpc: "2.0",
+      id: "server-error",
+      error: { code: -32603, message: "Not connected" },
+    };
+    expect(isRecoverableBackendError(envelope)).toBe(true);
+  });
+
+  it("does not false-positive on unrelated errors", () => {
+    expect(isRecoverableBackendError(new Error("Timeout"))).toBe(false);
+    expect(isRecoverableBackendError(undefined)).toBe(false);
+    expect(
+      isRecoverableBackendError({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal error" },
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/backend/src/lib/metamcp/session-error.ts
+++ b/apps/backend/src/lib/metamcp/session-error.ts
@@ -37,6 +37,33 @@ const HTTP_404 = "HTTP 404";
 const RPC_CODE_PATTERNS = ["-32001", "-32600"];
 const MAX_CAUSE_DEPTH = 8;
 
+// Transport-disconnect signal raised by the MCP TypeScript SDK's Protocol
+// class when a request is dispatched on a transport that has already been
+// torn down. Produced verbatim ("Not connected") whenever the cached
+// ConnectedClient's underlying StreamableHTTPClientTransport has been
+// closed — either because the backend MCP container restarted (Watchtower
+// image pull, manual `docker restart`, OOM kill) or because the SDK's
+// session manager half-closed the stream after an idle / error condition.
+//
+// Distinct from "Session not found": the session-not-found path means the
+// backend rejected the request because its session registry doesn't know
+// our Mcp-Session-Id (recoverable by sending a new `initialize`). The
+// "Not connected" path means our local transport has no live stream to
+// send anything on (recoverable by invalidating the pool entry, opening
+// a fresh transport, and re-initializing). Both end up at the same
+// recovery action — invalidate + reconnect + retry — but the error
+// envelopes are textually disjoint, so they need separate detectors.
+const NOT_CONNECTED = "Not connected";
+// JSON-RPC code -32603 = "Internal error". MetaMCP's tRPC bridge wraps
+// the SDK-thrown "Not connected" rejection into this envelope before it
+// reaches the consumer (Claude.ai connector, n8n httpRequest node, etc.).
+// Production observation 2026-05-14: consumer-side connectors see
+// `-32603 "Not connected"` rather than the raw SDK Error, and the
+// session-lost detector misses it. Pair the code with the
+// "Not connected" message so we don't false-positive on every -32603
+// from unrelated internal-error paths.
+const RPC_CODE_TRANSPORT_LOST = "-32603";
+
 function stringMatchesSessionLost(value: string): boolean {
   const mentionsSessionNotFound = value.includes(SESSION_NOT_FOUND);
   const mentionsHttp404 = value.includes(HTTP_404);
@@ -60,6 +87,143 @@ function objectHasSessionLostCode(candidate: unknown): boolean {
     return code === "-32001" || code === "-32600";
   }
   return false;
+}
+
+function stringMatchesTransportLost(value: string): boolean {
+  // The "Not connected" substring is the load-bearing marker; the
+  // -32603 code is only a confirming signal when present in a JSON-RPC
+  // envelope. A bare "Not connected" message from the SDK is sufficient.
+  return value.includes(NOT_CONNECTED);
+}
+
+function objectHasTransportLostCode(candidate: unknown): boolean {
+  // Only match -32603 when the rendered/structured object also carries
+  // the "Not connected" marker — bare -32603 is JSON-RPC "Internal
+  // error" and covers many unrelated failure modes.
+  if (typeof candidate !== "object" || candidate === null) {
+    return false;
+  }
+  const obj = candidate as { code?: unknown; message?: unknown };
+  const code = obj.code;
+  const isTransportCode =
+    code === -32603 ||
+    code === "-32603" ||
+    (typeof code === "string" && code.includes(RPC_CODE_TRANSPORT_LOST));
+  if (!isTransportCode) {
+    return false;
+  }
+  if (
+    typeof obj.message === "string" &&
+    stringMatchesTransportLost(obj.message)
+  ) {
+    return true;
+  }
+  try {
+    return stringMatchesTransportLost(JSON.stringify(candidate));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect errors that indicate the cached backend client's transport is dead.
+ *
+ * Sibling of {@link isBackendSessionLostError}. The session-lost detector
+ * matches the backend's "I don't know your Mcp-Session-Id" response (HTTP
+ * 404 + JSON-RPC -32001/-32600 + "Session not found"). The transport-lost
+ * detector matches the SDK's local "I have no live stream to send on"
+ * rejection, surfaced as a bare `"Not connected"` Error from
+ * `Protocol.request()` and also as a `-32603 "Not connected"` JSON-RPC
+ * envelope on the consumer-facing side.
+ *
+ * When this fires, the recovery action is identical to the session-lost
+ * path: invalidate the pooled `ConnectedClient`, open a fresh transport,
+ * re-initialize, and replay the request once. The two detectors are kept
+ * separate (rather than collapsed into one OR-of-substrings function) so
+ * each has a tight predicate that doesn't false-positive on the much
+ * larger noise floor of unrelated -32603 / 404 errors.
+ *
+ * Production observation 2026-05-14: rapid-deploy cadence on the autotask
+ * MCP backend (Watchtower pulls + container restarts within a 5-min
+ * window) produced disconnect windows where the consumer-side connector
+ * saw `-32603 "Not connected"` on every call. The session-lost detector
+ * missed all of these; the recovery path in `metamcp-proxy.ts` never
+ * fired. Operator quote (2026-05-14): "It's not acceptable for having
+ * MCP servers down or needing reboots after small change applications."
+ * This detector + the matching recovery wiring in `metamcp-proxy.ts`
+ * close that gap.
+ */
+export function isBackendTransportLostError(error: unknown): boolean {
+  if (error == null) {
+    return false;
+  }
+
+  if (typeof error === "string") {
+    return stringMatchesTransportLost(error);
+  }
+
+  let current: unknown = error;
+  let depth = 0;
+  const seen = new Set<unknown>();
+  while (current != null && depth < MAX_CAUSE_DEPTH) {
+    if (seen.has(current)) {
+      // Circular .cause chain — bail out.
+      break;
+    }
+    seen.add(current);
+
+    if (current instanceof Error) {
+      if (current.message && stringMatchesTransportLost(current.message)) {
+        return true;
+      }
+      if (objectHasTransportLostCode(current)) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+      depth += 1;
+      continue;
+    }
+
+    if (typeof current === "object") {
+      const obj = current as { message?: unknown };
+      if (
+        typeof obj.message === "string" &&
+        stringMatchesTransportLost(obj.message)
+      ) {
+        return true;
+      }
+      if (objectHasTransportLostCode(current)) {
+        return true;
+      }
+      try {
+        const rendered = JSON.stringify(current);
+        if (stringMatchesTransportLost(rendered)) {
+          return true;
+        }
+      } catch {
+        // Non-serializable; fall through.
+      }
+      break;
+    }
+    break;
+  }
+
+  try {
+    return stringMatchesTransportLost(String(error));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Convenience predicate — either the session-lost OR transport-lost
+ * detector fires. Tool-call and dynamic-find recovery paths in
+ * `metamcp-proxy.ts` use this so they engage the same invalidate +
+ * reconnect + retry sequence regardless of which envelope the failure
+ * arrived in.
+ */
+export function isRecoverableBackendError(error: unknown): boolean {
+  return isBackendSessionLostError(error) || isBackendTransportLostError(error);
 }
 
 export function isBackendSessionLostError(error: unknown): boolean {


### PR DESCRIPTION
## Problem

PR #12 hardened the detector for **"Session not found"** envelopes (HTTP 404 + JSON-RPC -32001/-32600). That covered the backend-MCP-doesn't-know-our-session-id case.

It did NOT cover the **"Not connected"** envelope produced by the MCP TypeScript SDK's `Protocol` class when our cached transport has been torn down (Watchtower image pull → backend container restart while a request is mid-flight). Both situations need the same recovery — invalidate pool + new transport + initialize + replay once — but only one was detected. Consumer-side connectors (Claude.ai, n8n httpRequest nodes) saw `-32603 "Not connected"` on every call until manual `docker restart metamcp`.

Production observations:

- **2026-05-14T08:00–08:02Z** — 6 Tara n8n execs failed with "Not connected" 500 during the autotask MCP punch list rollout (#137–#142 merged in rapid succession).
- **2026-05-14T14:32Z** — Captain's Claude.ai connector hit `-32603 "Not connected"` on every call; gateway alive (curl `/` → 307), backend container UP, but the cached pool entry was dead.
- Operator escalation: _"It's not acceptable for having MCP servers down or needing reboots after small change applications."_

## Fix

### `apps/backend/src/lib/metamcp/session-error.ts`

- New **`isBackendTransportLostError(error)`** — sibling detector for "Not connected" envelopes. Same hardening posture as PR #12's session-lost detector: walks `.cause` chains (max depth 8), handles string throwables, inspects `.code` for `-32603` **paired with** the "Not connected" marker, falls back to `String(error)`. The code-message pairing prevents false-positives on the much larger noise floor of unrelated `-32603` ("Internal error") envelopes.
- New **`isRecoverableBackendError(error)`** — convenience predicate, fires on either detector. Recovery paths use this so they engage the same invalidate+reconnect+retry sequence regardless of which envelope arrived.

Detectors kept separate (rather than collapsed) so each retains a tight predicate.

### `apps/backend/src/lib/metamcp/metamcp-proxy.ts`

- Tool-call recovery path → uses `isRecoverableBackendError` (was `isBackendSessionLostError`).
- Dynamic-tools/list recovery path (same broadening).
- Log lines updated: "Backend connection lost…" with the rendered error envelope appended so post-mortem can tell which detector fired.

### Tests

`session-error.test.ts` gets 14 new tests on `isBackendTransportLostError` + 4 on `isRecoverableBackendError`. Covers bare SDK "Not connected" Error, string throwable, consumer-side -32603 + "Not connected" JSON-RPC envelope, wrapped via .cause (one + two layers), Error with .code -32603 + matching message, bare -32603 "Internal error" NO-match (no false-positive), session-not-found envelopes NO-match (sibling handles those), null/undefined/unrelated strings, circular .cause chains, isRecoverableBackendError fires on both families.

## QC

- `pnpm vitest run src/lib/metamcp/session-error.test.ts` → **29/29 pass**
- `pnpm eslint` on touched files → 0 errors, 0 warnings.
- TypeScript clean on touched files (pre-existing errors in unrelated `src/trpc/*.impl.ts` not caused by this PR).

## Why land this

Operator direction 2026-05-14: _"we have full control"_ of the fork. This retires the `sudo docker restart metamcp` workaround documented in `Umbrella-MCP-Server/docs/TASKLIST.md` (priority 9/10 recurring entry) — the fork code is the right place to land the fix, not deploy-cadence policy or user-space retries.

Layers with **`n8nautomations#78`** (Charlie's Tara-side single-retry sub-flow shipped 14:39Z today) as defense-in-depth, but is the **primary** fix.

cc Captain