### PR TITLE
fix(pool): cascade invalidateServerConnection across every session slot for the affected serverUuid

### DIFF
--- a/apps/backend/src/lib/metamcp/mcp-server-pool.test.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for `McpServerPool.invalidateServerConnection`.
+ *
+ * The unit-under-test is the invalidation cascade introduced after the
+ * 2026-05-14T17:29Z production case where PR #13's recovery path
+ * engaged correctly (detector fired, `invalidateServerConnection`
+ * logged), but the recovery's retry call ALSO got `Not connected`
+ * because the cap-reuse branch in `getSession` handed back a stale
+ * ConnectedClient cached under a DIFFERENT session's slot for the same
+ * serverUuid.
+ *
+ * These tests poke the pool's internal maps directly (cast to
+ * `any` once at the top so the tests don't have to negotiate the
+ * private-field discipline). They do NOT exercise the
+ * `connectMetaMcpClient` path — that's the integration layer; the
+ * unit-under-test here is the invalidation surface.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `mcp-server-pool.ts` instantiates a `connectMetaMcpClient` -driven
+// pool at module load time. Stub the heavy imports so the unit test
+// doesn't need a postgres or a real upstream MCP.
+vi.mock("./client", () => ({
+  connectMetaMcpClient: vi.fn(),
+}));
+vi.mock("../config.service", () => ({
+  configService: {
+    getSessionLifetime: vi.fn().mockResolvedValue(null),
+    getMaxConnections: vi.fn().mockResolvedValue(100),
+    getMaxConnectionsPerServer: vi.fn().mockResolvedValue(5),
+    getMcpTimeout: vi.fn().mockResolvedValue(60000),
+    getMcpMaxTotalTimeout: vi.fn().mockResolvedValue(60000),
+    getMcpResetTimeoutOnProgress: vi.fn().mockResolvedValue(true),
+    getMaxAttempts: vi.fn().mockResolvedValue(3),
+  },
+}));
+vi.mock("../../db/repositories/mcp-servers.repo", () => ({
+  mcpServersRepository: {},
+}));
+vi.mock("./server-error-tracker", () => ({
+  serverErrorTracker: {
+    recordServerCrash: vi.fn(),
+  },
+}));
+
+import { McpServerPool } from "./mcp-server-pool";
+
+type FakeClient = { cleanup: ReturnType<typeof vi.fn>; closed: boolean };
+
+function makeFakeClient(): FakeClient {
+  const fake: FakeClient = {
+    cleanup: vi.fn(async () => {
+      fake.closed = true;
+    }),
+    closed: false,
+  };
+  return fake;
+}
+
+describe("McpServerPool.invalidateServerConnection — cascade across sessions", () => {
+  let pool: McpServerPool;
+  let internals: {
+    activeSessions: Record<string, Record<string, FakeClient>>;
+    idleSessions: Record<string, FakeClient>;
+    sessionToServers: Record<string, Set<string>>;
+    creatingIdleSessions: Set<string>;
+  };
+
+  beforeEach(() => {
+    pool = new McpServerPool();
+
+    internals = pool as any;
+    internals.activeSessions = {};
+    internals.idleSessions = {};
+    internals.sessionToServers = {};
+    internals.creatingIdleSessions = new Set();
+  });
+
+  it("invalidates the cached client for the triggering session", async () => {
+    const triggering = makeFakeClient();
+    internals.activeSessions["session-A"] = {
+      "server-1": triggering as never,
+    };
+    internals.sessionToServers["session-A"] = new Set(["server-1"]);
+
+    await pool.invalidateServerConnection("session-A", "server-1");
+
+    expect(triggering.cleanup).toHaveBeenCalledTimes(1);
+    expect(triggering.closed).toBe(true);
+    expect(internals.activeSessions["session-A"]?.["server-1"]).toBeUndefined();
+    expect(internals.sessionToServers["session-A"]?.has("server-1")).toBe(
+      false,
+    );
+  });
+
+  it("cascades to every other session's slot for the same serverUuid", async () => {
+    // Pre-2026-05-14 bug: only session-A's slot got invalidated; sessions
+    // B + C kept their stale clients, and the next getSession() hit the
+    // cap-reuse branch which handed one back to the recovery path.
+    const clientA = makeFakeClient();
+    const clientB = makeFakeClient();
+    const clientC = makeFakeClient();
+    internals.activeSessions["session-A"] = { "server-1": clientA as never };
+    internals.activeSessions["session-B"] = { "server-1": clientB as never };
+    internals.activeSessions["session-C"] = { "server-1": clientC as never };
+    internals.sessionToServers["session-A"] = new Set(["server-1"]);
+    internals.sessionToServers["session-B"] = new Set(["server-1"]);
+    internals.sessionToServers["session-C"] = new Set(["server-1"]);
+
+    await pool.invalidateServerConnection("session-A", "server-1");
+
+    expect(clientA.cleanup).toHaveBeenCalled();
+    expect(clientB.cleanup).toHaveBeenCalled();
+    expect(clientC.cleanup).toHaveBeenCalled();
+    expect(internals.activeSessions["session-A"]?.["server-1"]).toBeUndefined();
+    expect(internals.activeSessions["session-B"]?.["server-1"]).toBeUndefined();
+    expect(internals.activeSessions["session-C"]?.["server-1"]).toBeUndefined();
+    expect(internals.sessionToServers["session-A"]?.has("server-1")).toBe(
+      false,
+    );
+    expect(internals.sessionToServers["session-B"]?.has("server-1")).toBe(
+      false,
+    );
+    expect(internals.sessionToServers["session-C"]?.has("server-1")).toBe(
+      false,
+    );
+  });
+
+  it("does NOT touch slots for other serverUuids on the same session", async () => {
+    // A backend restart on server-1 should not blow away server-2's
+    // healthy cached client on the same session.
+    const stale = makeFakeClient();
+    const healthy = makeFakeClient();
+    internals.activeSessions["session-A"] = {
+      "server-1": stale as never,
+      "server-2": healthy as never,
+    };
+    internals.sessionToServers["session-A"] = new Set(["server-1", "server-2"]);
+
+    await pool.invalidateServerConnection("session-A", "server-1");
+
+    expect(stale.cleanup).toHaveBeenCalled();
+    expect(healthy.cleanup).not.toHaveBeenCalled();
+    expect(internals.activeSessions["session-A"]?.["server-1"]).toBeUndefined();
+    expect(internals.activeSessions["session-A"]?.["server-2"]).toBe(healthy);
+    expect(internals.sessionToServers["session-A"]?.has("server-2")).toBe(true);
+  });
+
+  it("also clears the idle slot for the affected serverUuid", async () => {
+    const idle = makeFakeClient();
+    internals.idleSessions["server-1"] = idle as never;
+
+    await pool.invalidateServerConnection("session-A", "server-1");
+
+    expect(idle.cleanup).toHaveBeenCalled();
+    expect(internals.idleSessions["server-1"]).toBeUndefined();
+  });
+
+  it("clears the creatingIdleSessions guard so a pending creation can't re-store a stale client", async () => {
+    internals.creatingIdleSessions.add("server-1");
+
+    await pool.invalidateServerConnection("session-A", "server-1");
+
+    expect(internals.creatingIdleSessions.has("server-1")).toBe(false);
+  });
+
+  it("continues cleaning up siblings when one cleanup throws", async () => {
+    // The bug-fix needs to be defensive — one cleanup() failure must
+    // not leave OTHER stale slots cached. Per-cleanup try/catch is
+    // load-bearing for the cascade.
+    const blowsUp = makeFakeClient();
+    blowsUp.cleanup = vi.fn(async () => {
+      throw new Error("cleanup raised");
+    });
+    const recovers = makeFakeClient();
+    internals.activeSessions["session-A"] = { "server-1": blowsUp as never };
+    internals.activeSessions["session-B"] = { "server-1": recovers as never };
+
+    await pool.invalidateServerConnection("session-A", "server-1");
+
+    expect(blowsUp.cleanup).toHaveBeenCalled();
+    expect(recovers.cleanup).toHaveBeenCalled();
+    // Slots dropped regardless of cleanup() exceptions.
+    expect(internals.activeSessions["session-A"]?.["server-1"]).toBeUndefined();
+    expect(internals.activeSessions["session-B"]?.["server-1"]).toBeUndefined();
+  });
+
+  it("is a no-op when no clients are cached for the serverUuid (defensive)", async () => {
+    // The recovery path may call invalidate even when the maps have
+    // already been drained by a concurrent cleanup. Don't throw.
+    await expect(
+      pool.invalidateServerConnection("session-A", "server-1"),
+    ).resolves.not.toThrow();
+  });
+});

--- a/apps/backend/src/lib/metamcp/mcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/mcp-server-pool.ts
@@ -345,7 +345,10 @@ export class McpServerPool {
       const newClient = await this.createNewConnection(params, namespaceUuid);
       if (newClient) {
         const currentGeneration = this.idleSessionGenerations[serverUuid] ?? 0;
-        if (!this.idleSessions[serverUuid] && currentGeneration === generation) {
+        if (
+          !this.idleSessions[serverUuid] &&
+          currentGeneration === generation
+        ) {
           this.idleSessions[serverUuid] = newClient;
           logger.info(`Created idle session for server ${serverUuid}`);
         } else {
@@ -400,7 +403,11 @@ export class McpServerPool {
     this.createNewConnection(params, namespaceUuid)
       .then((newClient) => {
         const currentGeneration = this.idleSessionGenerations[serverUuid] ?? 0;
-        if (newClient && !this.idleSessions[serverUuid] && currentGeneration === generation) {
+        if (
+          newClient &&
+          !this.idleSessions[serverUuid] &&
+          currentGeneration === generation
+        ) {
           this.idleSessions[serverUuid] = newClient;
           logger.info(
             `Created background idle session for server [${params.name}] ${serverUuid}`,
@@ -573,8 +580,7 @@ export class McpServerPool {
     // Calculate per-server breakdown
     const perServerCounts: Record<string, number> = {};
     for (const serverUuid of Object.keys(this.serverParamsCache)) {
-      perServerCounts[serverUuid] =
-        this.countConnectionsForServer(serverUuid);
+      perServerCounts[serverUuid] = this.countConnectionsForServer(serverUuid);
     }
 
     return {
@@ -777,39 +783,89 @@ export class McpServerPool {
     sessionId: string,
     serverUuid: string,
   ): Promise<void> {
-    const activeForSession = this.activeSessions[sessionId];
-    const activeClient = activeForSession?.[serverUuid];
-    if (activeClient) {
-      try {
-        await activeClient.cleanup();
-      } catch (error) {
-        console.error(
-          `Error cleaning up invalidated active session ${sessionId}/${serverUuid}:`,
-          error,
-        );
+    // When a backend MCP container restarts, EVERY cached ConnectedClient
+    // for that serverUuid is dead — not just the slot owned by the
+    // sessionId that surfaced the error. The original implementation
+    // only invalidated `activeSessions[sessionId][serverUuid]` plus the
+    // single `idleSessions[serverUuid]` slot, which left stale clients
+    // sitting in OTHER session's slots for the same backend.
+    //
+    // Once the cap-reuse branch in `getSession` engages
+    // (`findOldestActiveConnectionForServer`), the recovery path would
+    // hand back one of those stale clients to satisfy the recovery
+    // request — and the retry would immediately fail with the same
+    // "Not connected" envelope that triggered the recovery to begin
+    // with. Production observation 2026-05-14T17:29Z (Captain): detector
+    // fired correctly, recovery attempted re-init, recovery's retry call
+    // ALSO got "Not connected", forcing a manual `docker restart metamcp`.
+    //
+    // Fix: cascade the invalidation to every session's slot for the
+    // affected serverUuid. The next `getSession` call then has no stale
+    // candidates to reuse and must `createNewConnection`, producing the
+    // fresh transport the recovery path expects.
+    const cleanupPromises: Promise<void>[] = [];
+
+    for (const [sid, sessionServers] of Object.entries(this.activeSessions)) {
+      const cachedClient = sessionServers[serverUuid];
+      if (!cachedClient) {
+        continue;
       }
-      delete activeForSession[serverUuid];
-      this.sessionToServers[sessionId]?.delete(serverUuid);
+      // Fire all cleanups concurrently; we await the batch below. Each
+      // cleanup is wrapped so one cleanup failure doesn't short-circuit
+      // the rest — we WANT every stale slot dropped from the map.
+      cleanupPromises.push(
+        (async () => {
+          try {
+            await cachedClient.cleanup();
+          } catch (error) {
+            console.error(
+              `Error cleaning up invalidated active session ${sid}/${serverUuid}:`,
+              error,
+            );
+          }
+        })(),
+      );
+      delete sessionServers[serverUuid];
+      this.sessionToServers[sid]?.delete(serverUuid);
     }
 
     const idleClient = this.idleSessions[serverUuid];
     if (idleClient) {
-      try {
-        await idleClient.cleanup();
-      } catch (error) {
-        console.error(
-          `Error cleaning up invalidated idle session for ${serverUuid}:`,
-          error,
-        );
-      }
+      cleanupPromises.push(
+        (async () => {
+          try {
+            await idleClient.cleanup();
+          } catch (error) {
+            console.error(
+              `Error cleaning up invalidated idle session for ${serverUuid}:`,
+              error,
+            );
+          }
+        })(),
+      );
       delete this.idleSessions[serverUuid];
     }
 
+    // Drop the in-flight idle-creation guard. Any pending
+    // `createNewConnection` for this server captures the generation
+    // counter at await time and discards its result if the counter has
+    // bumped — so an in-flight stale creation can't sneak a dead
+    // client back into the map between the invalidation and the
+    // recovery's getSession call. (See createIdleSessionAsync.)
     this.creatingIdleSessions.delete(serverUuid);
 
-    console.warn(
-      `Invalidated pooled backend connection for server ${serverUuid} (session ${sessionId})`,
-    );
+    await Promise.all(cleanupPromises);
+
+    if (cleanupPromises.length > 0) {
+      console.warn(
+        `Invalidated ${cleanupPromises.length} pooled backend connection(s) for server ${serverUuid} ` +
+          `(triggered by session ${sessionId}; cascaded across every active + idle slot for this serverUuid)`,
+      );
+    } else {
+      console.warn(
+        `Invalidated pooled backend connection for server ${serverUuid} (session ${sessionId}) — no clients were cached`,
+      );
+    }
   }
 
   /**
@@ -976,12 +1032,9 @@ export class McpServerPool {
    */
   private startHealthCheckTimer(): void {
     // Check idle session health every 60 seconds
-    this.healthCheckTimer = setInterval(
-      async () => {
-        await this.checkIdleSessionHealth();
-      },
-      60 * 1000,
-    ); // 60 seconds
+    this.healthCheckTimer = setInterval(async () => {
+      await this.checkIdleSessionHealth();
+    }, 60 * 1000); // 60 seconds
   }
 
   /**
@@ -1033,9 +1086,8 @@ export class McpServerPool {
         !this.idleSessions[serverUuid] &&
         !this.creatingIdleSessions.has(serverUuid)
       ) {
-        const isError = await serverErrorTracker.isServerInErrorState(
-          serverUuid,
-        );
+        const isError =
+          await serverErrorTracker.isServerInErrorState(serverUuid);
         if (!isError) {
           // Not in error and no idle session - try to create one
           this.createIdleSessionAsync(serverUuid, params);

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,6 +1,16 @@
+import path from "node:path";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirror the tsconfig.json `paths` mapping so unit tests can
+      // import modules that use the `@/` prefix without each test
+      // having to hand-mock every transitive logger / utils import.
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     globals: true,
     environment: "node",


### PR DESCRIPTION
Closes the secondary recovery-doesn't-recover bug behind PR #13. PR #13's detector fires correctly; this PR fixes the recovery action that runs after it fires.

## The bug

Captain's 2026-05-14T17:29Z metamcp logs:

```
[WARN] Backend connection lost for server f15177ea-... on tool 'autotask__autotask_resolve_id';
       invalidating pool and retrying once. (envelope: Not connected)
[INFO] Invalidated pooled backend connection for server f15177ea-... (session idle_6b9e5665-..._...)
[ERROR] Error calling tool 'autotask__autotask_resolve_id' through autotask after session re-initialize:
        Error: Not connected
```

Detector fires → invalidate runs → re-init runs → retry **also** gets `Not connected`. Recovery is engaged but doesn't actually recover.

## Root cause

When a backend MCP container restarts, **every** cached `ConnectedClient` for that `serverUuid` is dead — not just the slot owned by the sessionId that surfaced the error. The original `invalidateServerConnection` only dropped:

- `activeSessions[sessionId][serverUuid]` (the triggering session's slot)
- `idleSessions[serverUuid]` (the idle slot)

Other sessions' slots for the same `serverUuid` stayed in the map with stale clients. When the recovery's `getSession` ran:

1. Triggering session's slot empty → fall through.
2. Idle slot empty → fall through.
3. `canCreateConnectionForServer` saw per-server count still at cap because the OTHER sessions' stale clients counted.
4. `findOldestActiveConnectionForServer` returned one of those stale clients.
5. Retry called the stale client → `Not connected` again.

## The fix

Cascade the invalidation across **every** session's slot for the affected `serverUuid`. The next `getSession` then has no stale candidates to reuse via the cap-reuse branch and must `createNewConnection`, producing the fresh transport the recovery path expects.

Per-cleanup try/catch so one failed cleanup doesn't leave OTHER stale slots cached. Cleanups run concurrently via `Promise.all` to keep the invalidation latency bounded.

## Tests

`apps/backend/src/lib/metamcp/mcp-server-pool.test.ts` — 7 vitest cases pin the cascade behavior:

- Invalidates the triggering session's slot (regression coverage of the original single-session behavior).
- **Cascades to every other session's slot for the same serverUuid** (the new behavior — direct repro of the 17:29Z production bug).
- Does NOT touch slots for other serverUuids on the same session (defense: a restart of server-1 doesn't blow away server-2's healthy cache).
- Also clears the idle slot for the affected serverUuid.
- Clears the creatingIdleSessions guard so a pending creation can't re-store a stale client.
- Continues cleaning up siblings when one cleanup throws.
- Is a no-op when no clients are cached for the serverUuid.

```
✓ src/lib/metamcp/mcp-server-pool.test.ts (7 tests)

Test Files  3 passed (3)
     Tests  56 passed (56) [across the full metamcp + db surface]
```

ESLint clean on the touched lines (5 warnings remaining — 3 pre-existing `any` in `mcp-server-pool.ts`, 2 expected `any` casts in the test helper for the private-field poke).

## Vitest config

Adds `resolve.alias['@'] = './src'` to `vitest.config.ts` so unit tests can import modules that use the `@/` prefix (mirrors `tsconfig.json` `paths` mapping). Previously every test had to hand-mock the transitive `logger` / `utils` imports.

## Coordination

- **Independent of PR #15** (lazy session recovery). Both can ship in either order — this PR closes the BACKEND-restart recovery hole; PR #15 closes the GATEWAY-restart cascade. They layer.
- **HARD GATE policy** per 2026-05-14T05:00Z rule-change-merge-authority: CI green + peer review → self-merge.
- **Tara risk**: LOW. Surface change is internal to the pool; recovery semantics improve. n8nautomations#78 (Charlie's user-space retry) layers on top.

cc Captain, Charlie