### PR TITLE
fix(session): clean 404 response on stale sessionId — drop info leak + reinit-hint header

### DIFF
--- a/apps/backend/src/routers/public-metamcp/streamable-http.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.ts
@@ -343,7 +343,6 @@ streamableHttpRouter.get(
 
     try {
       logger.info(`Looking up existing session: ${sessionId}`);
-      logger.info(`Available sessions:`, sessionManager.getSessionIds());
 
       const authReq = req as ApiKeyAuthenticatedRequest;
       let transport = sessionManager.getSession(sessionId);
@@ -358,7 +357,19 @@ streamableHttpRouter.get(
           res.status(401).end("Unauthorized");
           return;
         } else {
-          res.status(404).end("Session not found");
+          // Stale or expired sessionId. Per MCP Streamable HTTP spec the
+          // client MUST start a new session in response to HTTP 404 on a
+          // sessioned request. Surface a header-flag for clients that
+          // honor the contract, and keep the response body minimal
+          // (the previous body dumped the full active-session list into
+          // logs/clients — info leak + not actionable).
+          res
+            .status(404)
+            .setHeader("Mcp-Session-Reinitialize-Required", "true")
+            .end(
+              "Session expired or unknown. Initialize a new MCP session " +
+                "(send `initialize` without an `Mcp-Session-Id` header).",
+            );
           return;
         }
       }
@@ -527,12 +538,37 @@ streamableHttpRouter.post(
             logger.error(
               `Transport not found for sessionId ${sessionId} and no recoverable persisted row.`,
             );
-            res.status(404).json({
-              error: "Session not found",
-              message: `Transport not found for sessionId ${sessionId}`,
-              available_sessions: sessionManager.getSessionIds(),
-              timestamp: new Date().toISOString(),
-            });
+            // Stale or expired sessionId. The prior response embedded
+            // `available_sessions: sessionManager.getSessionIds()` —
+            // a mild info leak of every live session UUID into client
+            // logs + zero diagnostic value to the caller (the caller
+            // just learns their own ID isn't in the list, which the
+            // 404 already conveyed).
+            //
+            // Per MCP Streamable HTTP spec the client MUST start a new
+            // session in response to HTTP 404 on a sessioned request.
+            // The `Mcp-Session-Reinitialize-Required` header signals
+            // that explicitly for spec-conformant clients; the body
+            // message guides anyone reading it manually.
+            //
+            // Background: 2026-05-15 sub-agent validation run on the
+            // CIPP MCP namespace hit this path 100% — Claude Code's
+            // MCP connector held a sessionId rotated out by the server,
+            // and the harness didn't auto-reinitialize on 404. Until
+            // the client side honors reinit, this is the cleanest
+            // server-side signal we can hand it. Task #29 has the
+            // full background.
+            res
+              .status(404)
+              .setHeader("Mcp-Session-Reinitialize-Required", "true")
+              .json({
+                error: "Session not found",
+                message:
+                  "Session expired or unknown. Initialize a new MCP " +
+                  "session (send `initialize` without an " +
+                  "`Mcp-Session-Id` header).",
+                timestamp: new Date().toISOString(),
+              });
             return;
           }
         }


### PR DESCRIPTION
## Summary

Task #29 — server-side fix for stale-session 404 response on public Streamable HTTP endpoints.

Surfaced by Captain's CIPP MCP validation agent run (2026-05-15): every sub-agent tool call hit the 404 "Session not found / Transport not found for sessionId X" path. Two server-side problems with the prior response:

1. **Info leak** — \`available_sessions: sessionManager.getSessionIds()\` returned every live session UUID to the caller. Mild leak into client logs + zero diagnostic value.
2. **No reinit signal** — per MCP Streamable HTTP spec the client MUST start a new session in response to HTTP 404 on a sessioned request. Spec-conformant signal absent.

## Changes

Both GET and POST handlers on \`/:endpoint_name/mcp\` updated. Lazy-recovery path (\`recoverPersistedSession\`) preserved.

**Before** (POST body, abbreviated):
\`\`\`json
{
  "error": "Session not found",
  "message": "Transport not found for sessionId X",
  "available_sessions": ["uuid-1", "...", "uuid-67"],
  "timestamp": "..."
}
\`\`\`

**After**:
- HTTP header \`Mcp-Session-Reinitialize-Required: true\`
- Body:
\`\`\`json
{
  "error": "Session not found",
  "message": "Session expired or unknown. Initialize a new MCP session (send \`initialize\` without an \`Mcp-Session-Id\` header).",
  "timestamp": "..."
}
\`\`\`

GET handler analogously updated.

## Scope

- **Client-side reinit out of scope** — task #29 spec described \`(a) harness re-init OR (b) server reinit-hint + client cooperation\`. (a) is Anthropic-side (closed-source). This PR ships the server side of (b). Clients that honor the header/body get the actionable signal; clients that don't are blocked on Anthropic-side work — Operator can escalate separately.
- **Admin-side 404 paths** (\`mcp-proxy/metamcp.ts\`, \`mcp-proxy/server.ts\`) intentionally NOT touched. Different consumers; same pattern can apply as follow-up.

## Test plan

- [x] \`pnpm check-types\` clean.
- [x] \`npx eslint src/routers/public-metamcp/streamable-http.ts --max-warnings 0\` clean.
- [ ] Captain reviews + merges.
- [ ] Post-merge: re-fire validation agent against CIPP MCP. Sub-agent will still see 404 (Anthropic-side reinit not fixed), but response is now clean — no UUID list leak, header flag present.

## Tests deliberately not added

Handlers depend on auth middleware, \`sessionManager\`, \`metaMcpServerPool\`, \`recoverPersistedSession\`. Mocking all of them for one behavioral change (drop field + add header) costs more than the change is worth. If Captain wants tests, can add as follow-up with a proper handler-test harness.

## Related

- Task #29 spec: \`FLEETPROJECTS/autotask-mcp/runtime/tasks/2026-05-15__29-mcp-subagent-session-stickiness.md\`
- Prior session work: PRs #12 (session-lost detector), #13 (transport-lost detector), #15 (lazy session recovery), #16 (pool invalidation cascade), #17 (OpenAPI bridge mirror).