### PR TITLE
feat(fork): default new namespaces/endpoints/servers to public + endpoints OAuth-on

### DIFF
--- a/apps/backend/src/trpc/endpoints.impl.ts
+++ b/apps/backend/src/trpc/endpoints.impl.ts
@@ -38,7 +38,7 @@ export const endpointsImplementations = {
 
       // Determine user ownership based on input.user_id or default to current user
       const effectiveUserId =
-        input.user_id !== undefined ? input.user_id : userId;
+        input.user_id !== undefined ? input.user_id : null;
       const isPublicEndpoint = effectiveUserId === null;
 
       // Validate namespace accessibility and relationship rules
@@ -83,7 +83,7 @@ export const endpointsImplementations = {
         client_max_rate_seconds: input.clientMaxRateSeconds,
         client_max_rate_strategy: input.clientMaxRateStrategy,
         client_max_rate_strategy_key: input.clientMaxRateStrategyKey,
-        enable_oauth: input.enableOauth ?? false,
+        enable_oauth: input.enableOauth ?? true,
         use_query_param_auth: input.useQueryParamAuth ?? false,
         user_id: effectiveUserId,
       });

--- a/apps/backend/src/trpc/mcp-servers.impl.ts
+++ b/apps/backend/src/trpc/mcp-servers.impl.ts
@@ -33,7 +33,7 @@ export const mcpServersImplementations = {
     try {
       // Determine user ownership based on input.user_id or default to current user
       const effectiveUserId =
-        input.user_id !== undefined ? input.user_id : userId;
+        input.user_id !== undefined ? input.user_id : null;
 
       const createdServer = await mcpServersRepository.create({
         ...input,

--- a/apps/backend/src/trpc/namespaces.impl.ts
+++ b/apps/backend/src/trpc/namespaces.impl.ts
@@ -42,7 +42,7 @@ export const namespacesImplementations = {
     try {
       // Determine user ownership based on input.user_id or default to current user
       const effectiveUserId =
-        input.user_id !== undefined ? input.user_id : userId;
+        input.user_id !== undefined ? input.user_id : null;
       const isPublicNamespace = effectiveUserId === null;
 
       // Validate server accessibility and relationship rules

--- a/apps/frontend/app/[locale]/(sidebar)/endpoints/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/endpoints/page.tsx
@@ -79,10 +79,10 @@ export default function EndpointsPage() {
           clientMaxRateSeconds: undefined,
           clientMaxRateStrategy: "ip",
           clientMaxRateStrategyKey: "",
-          enableOauth: false,
+          enableOauth: true,
           useQueryParamAuth: false,
           createMcpServer: true,
-          user_id: undefined, // Default to "For myself" (Private)
+          user_id: null, // Default to public (Everyone)
         });
         setSelectedNamespaceUuid("");
         setSelectedNamespaceName("");
@@ -124,10 +124,10 @@ export default function EndpointsPage() {
       clientMaxRateStrategy: "ip",
       clientMaxRateStrategyKey: "",
       enableApiKeyAuth: true,
-      enableOauth: false,
+      enableOauth: true,
       useQueryParamAuth: false,
       createMcpServer: true,
-      user_id: undefined, // Default to "For myself" (Private)
+      user_id: null, // Default to public (Everyone)
     },
   });
 
@@ -193,10 +193,10 @@ export default function EndpointsPage() {
       clientMaxRateSeconds: undefined,
       clientMaxRateStrategy: "ip",
       clientMaxRateStrategyKey: "",
-      enableOauth: false,
+      enableOauth: true,
       useQueryParamAuth: false,
       createMcpServer: true,
-      user_id: undefined, // Default to "For myself" (Private)
+      user_id: null, // Default to public (Everyone)
     });
     setSelectedNamespaceUuid("");
     setSelectedNamespaceName("");

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/page.tsx
@@ -59,7 +59,7 @@ export default function McpServersPage() {
       url: "",
       bearerToken: "",
       headers: "",
-      user_id: undefined, // Default to private (current user)
+      user_id: null, // Default to public
     },
   });
 

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/page.tsx
@@ -74,7 +74,7 @@ export default function NamespacesPage() {
         form.reset({
           name: "",
           description: "",
-          user_id: undefined, // Default to "For myself" (Private)
+          user_id: null, // Default to public (Everyone)
         });
         setSelectedServerUuids([]);
         setServerSearchQuery("");
@@ -102,7 +102,7 @@ export default function NamespacesPage() {
       name: "",
       description: "",
       mcpServerUuids: [],
-      user_id: undefined, // Default to "For myself" (Private)
+      user_id: null, // Default to public (Everyone)
     },
   });
 
@@ -308,7 +308,7 @@ export default function NamespacesPage() {
                       form.reset({
                         name: "",
                         description: "",
-                        user_id: undefined, // Default to "For myself" (Private)
+                        user_id: null, // Default to public (Everyone)
                       });
                       setSelectedServerUuids([]);
                       setServerSearchQuery("");

--- a/apps/frontend/components/edit-endpoint.tsx
+++ b/apps/frontend/components/edit-endpoint.tsx
@@ -123,7 +123,7 @@ export function EditEndpoint({
       clientMaxRateSeconds: undefined,
       clientMaxRateStrategy: "ip",
       clientMaxRateStrategyKey: "",
-      enableOauth: false,
+      enableOauth: true,
       useQueryParamAuth: false,
     },
   });
@@ -206,7 +206,7 @@ export function EditEndpoint({
       description: "",
       namespaceUuid: "",
       enableApiKeyAuth: true,
-      enableOauth: false,
+      enableOauth: true,
       useQueryParamAuth: false,
     });
     setSelectedNamespaceUuid("");

--- a/packages/zod-types/src/endpoints.zod.ts
+++ b/packages/zod-types/src/endpoints.zod.ts
@@ -71,7 +71,7 @@ export const CreateEndpointRequestSchema = z.object({
     .optional(),
   clientMaxRateStrategy: z.string().optional(),
   clientMaxRateStrategyKey: z.string().optional(),
-  enableOauth: z.boolean().default(false),
+  enableOauth: z.boolean().default(true),
   useQueryParamAuth: z.boolean().default(false),
   createMcpServer: z.boolean().default(true),
   user_id: z.string().nullable().optional(),
@@ -198,7 +198,7 @@ export const EndpointCreateInputSchema = z.object({
   client_max_rate_seconds: z.number().nullable().optional(),
   client_max_rate_strategy: z.string().nullable().optional(),
   client_max_rate_strategy_key: z.string().nullable().optional(),
-  enable_oauth: z.boolean().optional().default(false),
+  enable_oauth: z.boolean().optional().default(true),
   use_query_param_auth: z.boolean().optional().default(false),
   user_id: z.string().nullable().optional(),
 });


### PR DESCRIPTION
## Phase 1 of the MetaMCP naming + topology refactor

Plan of record: `Umbrella-MCP-Server/docs/refactor-naming-topology-plan.md` (D5). This is the standalone, low-risk, zero-consumer-blast-radius entry point — fork creation **defaults** only.

### What changes
**Ownership default → public** for new namespaces, endpoints, and MCP servers. When the owner is omitted, it now resolves to `null` (Everyone) instead of the creating user.
- Frontend `defaultValues` / `reset()` sites: `namespaces/page.tsx` (×3), `endpoints/page.tsx` (×3), `mcp-servers/page.tsx` (×1)
- Backend ownership fallback: `namespaces.impl.ts`, `endpoints.impl.ts`, `mcp-servers.impl.ts` (`?? userId` → `?? null`)
- **Private option kept** in the form selector; edit-of-existing-records unchanged.

**Endpoint OAuth default → on** for new endpoints (api-key auth still coexists).
- Create-form defaults/resets (`endpoints/page.tsx` ×3) + edit-form blank/close resets (`edit-endpoint.tsx` ×2)
- Backend fallback `enable_oauth: ?? true`; both Zod schemas `.default(true)`
- Edit form still reads the **stored** value (`endpoint.enable_oauth ?? false`) so existing endpoints render their real state.

### No DB migration
`user_id` is nullable with no DB default; `enable_oauth`'s DB default (`false`) is never exercised — the app always sends the value explicitly. Existing namespaces/endpoints/servers are untouched.

### Verification
- `pnpm check-types` clean (zod-types + frontend)
- `tsc --noEmit` clean in `apps/backend` (0 errors)

### Deploy note
Merge to `umbrella` → `umbrella-build.yml` builds + pushes `:latest` → Watchtower on mcp-host-prod (~5 min; manual `docker pull` + recreate if it lags). A `docker restart metamcp` after deploy also clears the schema cache for the pending Umbrella-MCP-Server PR #304 (is_billable) — folded in.

https://claude.ai/code/session_01SKmZX2bGiKRBNxxEQ5g9oB