### PR TITLE
ci: drop nonexistent package from GHCR cleanup

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:
           owner: Umbrella-IT-Group
-          packages: metamcp,metamcp-docker-per-mcp
+          packages: metamcp
           delete-untagged: true
           keep-n-tagged: 20
           exclude-tags: latest


### PR DESCRIPTION
Follow-up to #41. The cleanup listed `metamcp-docker-per-mcp`, which was never published to GHCR — the job 404'd and failed *after* correctly pruning the real `metamcp` package (90 old versions). Restricting to `metamcp` keeps the job green.

https://claude.ai/code/session_01PHs12fajWK64nVLK6oZ2PQ