### PR TITLE
fix(mcp-proxy): bounded warmup fallback for tools/call reconnect 404

### DIFF
--- a/apps/backend/src/db/repositories/namespaces.repo.ts
+++ b/apps/backend/src/db/repositories/namespaces.repo.ts
@@ -277,6 +277,46 @@ export class NamespacesRepository {
     return toolsData;
   }
 
+  /**
+   * Last-known-good routing for the tools/call reconnect-window fix
+   * (see metamcp-proxy.ts / openapi/handlers.ts originalCallToolHandler).
+   * Looks up which server(s) the DB currently associates a tool name
+   * with inside a namespace, using the rows written by the last
+   * successful tools/list sync — independent of whether a live pooled
+   * session exists right now. Returns every match rather than one row:
+   * the same original tool name can legitimately exist on more than one
+   * backend server in a namespace, disambiguated only by the
+   * server-name prefix on the call side, so callers must filter by
+   * `sanitizeName(serverName) === serverPrefix` themselves.
+   */
+  async findServersForNamespaceToolName(
+    namespaceUuid: string,
+    toolName: string,
+  ): Promise<Array<{ serverUuid: string; serverName: string | null }>> {
+    const rows = await db
+      .select({
+        serverUuid: toolsTable.mcp_server_uuid,
+        serverName: mcpServersTable.name,
+      })
+      .from(toolsTable)
+      .innerJoin(
+        namespaceToolMappingsTable,
+        eq(toolsTable.uuid, namespaceToolMappingsTable.tool_uuid),
+      )
+      .innerJoin(
+        mcpServersTable,
+        eq(toolsTable.mcp_server_uuid, mcpServersTable.uuid),
+      )
+      .where(
+        and(
+          eq(namespaceToolMappingsTable.namespace_uuid, namespaceUuid),
+          eq(toolsTable.name, toolName),
+        ),
+      );
+
+    return rows;
+  }
+
   async deleteByUuid(uuid: string): Promise<DatabaseNamespace | undefined> {
     const [deletedNamespace] = await db
       .delete(namespacesTable)

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -106,6 +106,29 @@ export const configService = {
     );
   },
 
+  /**
+   * Per-attempt hard cap (ms) for the bounded reconnect-window warmup
+   * on the tools/call path (metamcp-proxy.ts / openapi/handlers.ts).
+   * Default 5s: long enough to catch the common watchtower-bounce
+   * reconnect, short enough that a genuinely dead upstream still fails
+   * fast instead of hanging the caller on `client.ts`'s much longer
+   * (up to 30s+ per hop) internal reconnect backoff.
+   */
+  async getMcpToolCallReconnectWarmupTimeout(): Promise<number> {
+    const config = await configRepo.getConfig(
+      ConfigKeyEnum.Enum.MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT,
+    );
+    return config?.value ? parseInt(config.value, 10) : 5000;
+  },
+
+  async setMcpToolCallReconnectWarmupTimeout(timeout: number): Promise<void> {
+    await configRepo.setConfig(
+      ConfigKeyEnum.Enum.MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT,
+      timeout.toString(),
+      "Per-attempt hard cap (ms) for the tools/call reconnect-window warmup",
+    );
+  },
+
   async getSessionLifetime(): Promise<number | null> {
     const config = await configRepo.getConfig(
       ConfigKeyEnum.Enum.SESSION_LIFETIME,

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -116,14 +116,14 @@ export const configService = {
    */
   async getMcpToolCallReconnectWarmupTimeout(): Promise<number> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT,
+      ConfigKeyEnum.enum.MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT,
     );
     return config?.value ? parseInt(config.value, 10) : 5000;
   },
 
   async setMcpToolCallReconnectWarmupTimeout(timeout: number): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT,
+      ConfigKeyEnum.enum.MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT,
       timeout.toString(),
       "Per-attempt hard cap (ms) for the tools/call reconnect-window warmup",
     );

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -23,6 +23,7 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
+import { namespacesRepository } from "../../db/repositories/namespaces.repo";
 import { toolsImplementations } from "../../trpc/tools.impl";
 import { configService } from "../config.service";
 import { buildM365BrokerErrorResult } from "../m365/broker-error-result";
@@ -49,6 +50,7 @@ import {
   mapOverrideNameToOriginal,
 } from "./metamcp-middleware/tool-overrides.functional";
 import { isRecoverableBackendError } from "./session-error";
+import { acquireSessionWithBoundedWarmup } from "./tool-call-warmup";
 import { parseToolName } from "./tool-name-parser";
 import { toolsSyncCache } from "./tools-sync-cache";
 import { sanitizeName } from "./utils";
@@ -616,6 +618,69 @@ export const createServer = async (
                 );
                 continue;
               }
+            }
+          }
+        }
+
+        // Reconnect-window fallback: the loop above only reaches the
+        // name-prefix check when `mcpServerPool.getSession` already has
+        // (or can immediately mint) a live connection. During an
+        // upstream reconnect, `invalidateServerConnection` tears the
+        // pooled client down and fires `list_changed` BEFORE the
+        // replacement connection exists (mcp-server-pool.ts) — a call
+        // landing in that gap sees `getSession` return `undefined` for
+        // the owning server too, so the loop never even checks its name
+        // and this would otherwise fall straight to "Unknown tool"
+        // despite the tool being real (Umbrella-MCP-Server tools/call
+        // 404 during reconnect).
+        //
+        // Use the DB `toolsTable` (populated by the last successful
+        // tools/list sync) as last-known-good routing to find the
+        // owning server WITHOUT needing a live session, then give that
+        // one server a short, bounded chance to come back. Skip
+        // entirely — no wait — when the DB has no record of this tool:
+        // that's a genuinely unknown tool, not a reconnect race, and it
+        // must still 404 immediately.
+        if (!clientForTool) {
+          const candidates =
+            await namespacesRepository.findServersForNamespaceToolName(
+              namespaceUuid,
+              originalToolName,
+            );
+          const match = candidates.find(
+            (candidate) =>
+              sanitizeName(candidate.serverName || "") === serverPrefix,
+          );
+          const paramsForMatch = match
+            ? serverParams[match.serverUuid]
+            : undefined;
+
+          // No `paramsForMatch` means the server isn't in the
+          // active/non-error namespace set right now (getMcpServers
+          // already filtered it out above) — it was removed or
+          // disabled, not mid-reconnect. Don't wait for something that
+          // isn't coming back.
+          if (match && paramsForMatch) {
+            const warmupTimeoutMs =
+              await configService.getMcpToolCallReconnectWarmupTimeout();
+            const warmedSession = await acquireSessionWithBoundedWarmup({
+              pool: mcpServerPool,
+              sessionId,
+              serverUuid: match.serverUuid,
+              params: paramsForMatch,
+              namespaceUuid,
+              timeoutMs: warmupTimeoutMs,
+            });
+
+            if (
+              warmedSession &&
+              warmedSession.client.getServerCapabilities()?.tools
+            ) {
+              registerListChangedSubscriber(warmedSession, match.serverUuid);
+              clientForTool = warmedSession;
+              serverUuid = match.serverUuid;
+              toolToClient[name] = warmedSession;
+              toolToServerUuid[name] = match.serverUuid;
             }
           }
         }

--- a/apps/backend/src/lib/metamcp/tool-call-warmup.test.ts
+++ b/apps/backend/src/lib/metamcp/tool-call-warmup.test.ts
@@ -1,0 +1,102 @@
+import { ServerParameters } from "@repo/zod-types";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConnectedClient } from "./client";
+import {
+  acquireSessionWithBoundedWarmup,
+  ToolCallWarmupPool,
+} from "./tool-call-warmup";
+
+const makeSession = (label: string): ConnectedClient =>
+  ({ label }) as unknown as ConnectedClient;
+
+const params = { uuid: "server-1", name: "test-server" } as ServerParameters;
+
+// A getSession mock that never settles — models a connect attempt still
+// in flight or backing off when the caller's bounded wait expires.
+const pending = () => new Promise<ConnectedClient | undefined>(() => {});
+
+const baseOpts = (pool: ToolCallWarmupPool, timeoutMs: number) => ({
+  pool,
+  sessionId: "session-abc",
+  serverUuid: "server-1",
+  params,
+  namespaceUuid: "ns-1",
+  timeoutMs,
+});
+
+describe("acquireSessionWithBoundedWarmup", () => {
+  it("returns the session on the first attempt when getSession resolves before the cap", async () => {
+    const session = makeSession("fresh");
+    const pool: ToolCallWarmupPool = {
+      getSession: vi.fn().mockResolvedValue(session),
+    };
+
+    const result = await acquireSessionWithBoundedWarmup(baseOpts(pool, 1000));
+
+    expect(result).toBe(session);
+    expect(pool.getSession).toHaveBeenCalledTimes(1);
+    expect(pool.getSession).toHaveBeenCalledWith(
+      "session-abc",
+      "server-1",
+      params,
+      "ns-1",
+    );
+  });
+
+  it("retries once when the first attempt doesn't settle before the cap, and returns the retry's session", async () => {
+    const session = makeSession("reconnected");
+    const getSession = vi
+      .fn()
+      .mockImplementationOnce(pending)
+      .mockResolvedValueOnce(session);
+    const pool: ToolCallWarmupPool = { getSession };
+
+    const result = await acquireSessionWithBoundedWarmup(baseOpts(pool, 20));
+
+    expect(result).toBe(session);
+    expect(getSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("is bounded — returns undefined (never hangs) once every attempt is exhausted", async () => {
+    const getSession = vi.fn().mockImplementation(pending);
+    const pool: ToolCallWarmupPool = { getSession };
+
+    const start = Date.now();
+    const result = await acquireSessionWithBoundedWarmup(baseOpts(pool, 20));
+    const elapsedMs = Date.now() - start;
+
+    expect(result).toBeUndefined();
+    expect(getSession).toHaveBeenCalledTimes(2);
+    // Worst case is attempts * timeoutMs (2 * 20ms). Generous upper
+    // bound below just proves this isn't an unbounded hang, not a tight
+    // timing assertion.
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+
+  it("honors a custom attempts count instead of the default retry-once", async () => {
+    const getSession = vi.fn().mockImplementation(pending);
+    const pool: ToolCallWarmupPool = { getSession };
+
+    const result = await acquireSessionWithBoundedWarmup({
+      ...baseOpts(pool, 10),
+      attempts: 1,
+    });
+
+    expect(result).toBeUndefined();
+    expect(getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a rejected getSession call as undefined rather than throwing", async () => {
+    // Defensive branch: mcp-server-pool.ts's getSession never rejects
+    // today, but this guards against a future regression there turning
+    // into an unhandled rejection here.
+    const getSession = vi.fn().mockRejectedValue(new Error("boom"));
+    const pool: ToolCallWarmupPool = { getSession };
+
+    await expect(
+      acquireSessionWithBoundedWarmup(baseOpts(pool, 10)),
+    ).resolves.toBeUndefined();
+    expect(getSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/lib/metamcp/tool-call-warmup.ts
+++ b/apps/backend/src/lib/metamcp/tool-call-warmup.ts
@@ -1,0 +1,118 @@
+import { ServerParameters } from "@repo/zod-types";
+
+import { ConnectedClient } from "./client";
+
+/**
+ * Minimal slice of McpServerPool the warmup helper needs. Structural so
+ * tests can drive it with a fake pool (same pattern as
+ * list-handler-recovery.ts / mcp-server-pool.test.ts) instead of
+ * mocking the real singleton.
+ */
+export interface ToolCallWarmupPool {
+  getSession(
+    sessionId: string,
+    serverUuid: string,
+    params: ServerParameters,
+    namespaceUuid?: string,
+  ): Promise<ConnectedClient | undefined>;
+}
+
+export interface AcquireSessionWithBoundedWarmupOptions {
+  pool: ToolCallWarmupPool;
+  sessionId: string;
+  serverUuid: string;
+  params: ServerParameters;
+  namespaceUuid?: string;
+  /**
+   * Hard cap per attempt, ms. Callers source this from
+   * `configService.getMcpToolCallReconnectWarmupTimeout()` rather than
+   * hardcoding it here, so the primitive stays test-friendly (no
+   * config/DB dependency in this module).
+   */
+  timeoutMs: number;
+  /** Total attempts including the first. Default 2 — one shot + one retry. */
+  attempts?: number;
+}
+
+/**
+ * Give a server a short, BOUNDED chance to come back before the caller
+ * treats a tools/call routing lookup as unresolved.
+ *
+ * Exists for the reconnect-window 404: `McpServerPool.invalidateServer-
+ * Connection` tears a pooled client down and fires `list_changed`
+ * BEFORE the replacement connection exists (mcp-server-pool.ts). A
+ * `tools/call` landing in that gap sees `getSession` return `undefined`
+ * even though the owning server is real and just mid-reconnect
+ * (`createNewConnection` returns `undefined` on a failed/backing-off
+ * attempt) — without this helper, callers fall straight through to
+ * "Unknown tool", which the OpenAPI bridge maps to a literal HTTP 404.
+ *
+ * Each attempt races `pool.getSession` against `timeoutMs` rather than
+ * waiting out the full connect, which can itself take 30s+ per hop
+ * under `client.ts`'s exponential reconnect backoff schedule. If an
+ * attempt's promise hasn't settled by the deadline, this stops waiting
+ * on it — JS can't cancel it, so it keeps running in the background and,
+ * if it later succeeds, still lands in the pool for the NEXT caller —
+ * and, if attempts remain, immediately fires a fresh `getSession` call.
+ * Two overlapping `getSession` calls for the same (sessionId,
+ * serverUuid) are safe: `McpServerPool.getSession` already de-dupes
+ * post-await (whichever resolves second discards its own connection and
+ * reuses the first's), the same tolerance the pool already relies on
+ * for concurrent request races.
+ *
+ * Bounded on purpose: a genuinely-dead upstream must fail within
+ * `attempts * timeoutMs`, never hang. Callers are expected to fall
+ * through to their existing "Unknown tool" error when this resolves
+ * `undefined`, and to skip calling this entirely when they have no
+ * last-known-good server to warm up (a tool that truly doesn't exist
+ * anywhere must still 404 without paying this wait).
+ */
+export async function acquireSessionWithBoundedWarmup(
+  opts: AcquireSessionWithBoundedWarmupOptions,
+): Promise<ConnectedClient | undefined> {
+  const attempts = opts.attempts ?? 2;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const session = await raceWithTimeout(
+      opts.pool.getSession(
+        opts.sessionId,
+        opts.serverUuid,
+        opts.params,
+        opts.namespaceUuid,
+      ),
+      opts.timeoutMs,
+    );
+    if (session) {
+      return session;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve with `undefined` if `promise` hasn't settled within
+ * `timeoutMs`, otherwise resolve/reject with whatever `promise` did.
+ * `getSession` never rejects in practice (mcp-server-pool.ts resolves
+ * `undefined` on every failure path instead), but the reject branch is
+ * handled defensively so a future change there can't turn this into an
+ * unhandled rejection.
+ */
+function raceWithTimeout<T>(
+  promise: Promise<T | undefined>,
+  timeoutMs: number,
+): Promise<T | undefined> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(undefined), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        clearTimeout(timer);
+        resolve(undefined);
+      },
+    );
+  });
+}

--- a/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
+import { namespacesRepository } from "../../../db/repositories/namespaces.repo";
 import { configService } from "../../../lib/config.service";
 import { ConnectedClient } from "../../../lib/metamcp";
 import { getMcpServers } from "../../../lib/metamcp/fetch-metamcp";
@@ -28,6 +29,7 @@ import {
   createToolOverridesListToolsMiddleware,
 } from "../../../lib/metamcp/metamcp-middleware/tool-overrides.functional";
 import { isRecoverableBackendError } from "../../../lib/metamcp/session-error";
+import { acquireSessionWithBoundedWarmup } from "../../../lib/metamcp/tool-call-warmup";
 import { sanitizeName } from "../../../lib/metamcp/utils";
 
 // Original List Tools Handler (adapted from metamcp-proxy.ts)
@@ -206,6 +208,61 @@ export const createOriginalCallToolHandler = (): CallToolHandler => {
         toolToClient[name] = session;
         toolToServerUuid[name] = mcpServerUuid;
         break;
+      }
+    }
+
+    // Reconnect-window fallback (mirrors metamcp-proxy.ts's
+    // originalCallToolHandler). The loop above only reaches the
+    // name-prefix check when `getSession` already has a live
+    // connection — during an upstream reconnect,
+    // `invalidateServerConnection` tears the pooled client down and
+    // fires `list_changed` BEFORE the replacement exists
+    // (mcp-server-pool.ts), so a call landing in that gap sees
+    // `getSession` return `undefined` for the owning server too and
+    // falls straight to "Unknown tool" (tool-execution.ts maps that to
+    // a literal HTTP 404) despite the tool being real.
+    //
+    // Resolve the owning server from the DB `toolsTable` (last known
+    // good, from the last successful tools/list sync) without needing
+    // a live session, then give that one server a short, bounded
+    // chance to come back. Skip the wait entirely when the DB has no
+    // record of this tool — that's genuinely unknown, not a reconnect
+    // race, and must still 404 immediately.
+    if (!targetSession) {
+      const candidates =
+        await namespacesRepository.findServersForNamespaceToolName(
+          context.namespaceUuid,
+          originalToolName,
+        );
+      const match = candidates.find(
+        (candidate) =>
+          sanitizeName(candidate.serverName || "") === serverPrefix,
+      );
+      const paramsForMatch = match ? serverParams[match.serverUuid] : undefined;
+
+      // No `paramsForMatch` means the server isn't in the
+      // active/non-error namespace set right now (already filtered out
+      // of `serverParams` above) — removed/disabled, not mid-reconnect.
+      if (match && paramsForMatch) {
+        const warmupTimeoutMs =
+          await configService.getMcpToolCallReconnectWarmupTimeout();
+        const warmedSession = await acquireSessionWithBoundedWarmup({
+          pool: mcpServerPool,
+          sessionId: context.sessionId,
+          serverUuid: match.serverUuid,
+          params: paramsForMatch,
+          namespaceUuid: context.namespaceUuid,
+          timeoutMs: warmupTimeoutMs,
+        });
+
+        if (
+          warmedSession &&
+          warmedSession.client.getServerCapabilities()?.tools
+        ) {
+          targetSession = warmedSession;
+          toolToClient[name] = warmedSession;
+          toolToServerUuid[name] = match.serverUuid;
+        }
       }
     }
 

--- a/packages/zod-types/src/config.zod.ts
+++ b/packages/zod-types/src/config.zod.ts
@@ -10,6 +10,12 @@ export const ConfigKeyEnum = z.enum([
   "MCP_MAX_TOTAL_TIMEOUT",
   "MCP_MAX_ATTEMPTS",
   "SESSION_LIFETIME",
+  // Hard cap (ms) per warmup attempt when a tools/call lands in the
+  // reconnect window (invalidateServerConnection tears the pooled
+  // client down before the replacement exists) and has to wait for the
+  // owning server to reconnect before falling back to "Unknown tool".
+  // See config.service.ts's getMcpToolCallReconnectWarmupTimeout.
+  "MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT",
 ]);
 
 // Config schema


### PR DESCRIPTION
## Problem

`tools/call` routes through in-memory `toolToClient`/`toolToServerUuid`
maps (`metamcp-proxy.ts` `originalCallToolHandler`; the OpenAPI bridge's
own copy in `openapi/handlers.ts` `createOriginalCallToolHandler`).
During an upstream reconnect, `McpServerPool.invalidateServerConnection`
tears the pooled client down and fires `list_changed` **before** the
replacement connection exists. A call landing in that gap hits the
dynamic-find fallback, but that loop only reaches the server
name-prefix check *inside* an `if (session)` block — if `getSession`
returns `undefined` (connect in-flight / backing off,
`createNewConnection` resolves `undefined` on a failed attempt), the
owning server is skipped without its name ever being checked. The loop
exhausts, `clientForTool` stays unset, and the handler throws `"Unknown
tool: ..."` — which the OpenAPI bridge (`tool-execution.ts`) maps to a
literal **HTTP 404**, even though the tool is real and the server is
just reconnecting. This is the transient 404 the n8n pipeline already
had to retry-harden around.

## Fix

Bounded stale-while-revalidate on the call path, added to **both**
routing implementations (`metamcp-proxy.ts` and `openapi/handlers.ts`),
right before the existing `"Unknown tool"` throw:

1. **Last-known-good routing** — `namespacesRepository.findServers-
   ForNamespaceToolName(namespaceUuid, originalToolName)` looks up which
   server(s) the DB `toolsTable` (populated by the last successful
   `tools/list` sync) associates with this tool name in this namespace,
   independent of whether a live session currently exists. Candidates
   are filtered by `sanitizeName(serverName) === serverPrefix` to
   disambiguate, same as the existing live-session loop.
2. **Bounded warmup** — if a match is found *and* it's still in the
   namespace's active/non-error server set (`getMcpServers`), give it a
   short race via the new `acquireSessionWithBoundedWarmup` helper
   (`tool-call-warmup.ts`): one `getSession` attempt raced against a
   hard per-attempt cap, one retry if the first doesn't settle in time.
3. **Fall through unchanged** — if the warmup doesn't produce a session
   (or there was no DB match to begin with), the existing `"Unknown
   tool"` throw fires exactly as before.

### Latency bound

Per-attempt cap is a new config knob,
`MCP_TOOL_CALL_RECONNECT_WARMUP_TIMEOUT` (`config.service.ts`
`getMcpToolCallReconnectWarmupTimeout`), **default 5000ms**. With the
default one-retry behavior (`attempts: 2`), worst-case added latency is
**~10s** before falling through to the existing error. This does not
touch or extend `client.ts`'s own internal reconnect backoff (which can
run 30s+ per hop) — an abandoned attempt keeps running in the
background and, if it later succeeds, still lands in the pool for the
next caller (two overlapping `getSession` calls for the same
`(sessionId, serverUuid)` are already safe: the pool de-dupes
post-await).

### Truly-dead / truly-unknown behavior

- **Tool that doesn't exist anywhere**: the DB lookup returns no
  candidates, so the wait is skipped entirely — 404 fires immediately,
  same as today, zero added latency.
- **Server removed/disabled from the namespace**: the DB may still have
  a stale tool row, but `getMcpServers` (already fetched earlier in the
  same handler) won't include it, so there's no `params` to open a
  session with — wait is skipped, falls through to `"Unknown tool"`.
- **Genuinely dead upstream that's still an active namespace member**:
  bounded by `attempts * timeoutMs` (~10s default) — never an unbounded
  hang.

## Files changed

- `packages/zod-types/src/config.zod.ts` — new `ConfigKeyEnum` entry.
- `apps/backend/src/lib/config.service.ts` — `getMcpToolCallReconnect-
  WarmupTimeout`/`setMcpToolCallReconnectWarmupTimeout` (mirrors the
  existing `getMcpTimeout`/`setMcpTimeout` pattern).
- `apps/backend/src/lib/metamcp/tool-call-warmup.ts` (new) — the bounded
  race + retry primitive, structural `ToolCallWarmupPool` interface so
  it's testable without mocking the real pool singleton (same pattern
  as `list-handler-recovery.ts`).
- `apps/backend/src/lib/metamcp/tool-call-warmup.test.ts` (new) — unit
  tests for the fallback decision logic (see Testing below).
- `apps/backend/src/db/repositories/namespaces.repo.ts` —
  `findServersForNamespaceToolName`, the last-known-good DB lookup.
- `apps/backend/src/lib/metamcp/metamcp-proxy.ts` — wires the fallback
  into `originalCallToolHandler`.
- `apps/backend/src/routers/public-metamcp/openapi/handlers.ts` — wires
  the same fallback into the OpenAPI bridge's independent copy of the
  handler.

**Patch-table row lands in the follow-up docs PR** (per lane
instructions, `UMBRELLA_FORK.md` is intentionally not touched here).

## Testing

- `pnpm install` — clean.
- `pnpm run build` (root, turbo across zod-types/trpc/backend/frontend)
  — **exit 0**, all 4 tasks successful.
- `cd apps/backend && npx tsc --noEmit -p tsconfig.json` — **exit 0, 0
  type errors**. (Backend's own `build` script is `tsup`/esbuild and
  does not type-check; `apps/backend/package.json` has no
  `check-types` script, so this was run directly as the real type gate.)
- `pnpm run check-types` (root, covers `zod-types` + `frontend`, the
  only packages with that script) — **exit 0**.
- `cd apps/backend && pnpm run test` (vitest) — **234 passed (234),
  19 test files, 0 failed**, including the 5 new
  `tool-call-warmup.test.ts` cases (fast-path resolve, bounded retry,
  bounded exhaustion returns `undefined` without hanging, custom
  `attempts` override, defensive reject-handling).
- `npx prettier --check` on every changed/new file — clean.
- `pnpm run lint` (backend): **36 warnings, 0 errors, exit 1** — this
  is `--max-warnings 0` against **pre-existing** warnings. Verified
  against the untouched `origin/umbrella` checkout: baseline is also
  36 warnings / exit 1, and none of the flagged lines are in any file
  this PR touches. Root `pnpm run lint` also fails on `frontend`
  (pre-existing; this PR touches zero frontend files). Not fixed here
  — out of scope for this lane, flagged for whoever owns the lint
  baseline.

## Manual repro (for post-merge verification)

The DB-lookup repo method (`findServersForNamespaceToolName`) has no
dedicated unit test — it's a single-purpose join query, same test
coverage floor as its untested sibling `findToolsByNamespaceUuid` in
the same file (no repo file in this codebase unit-tests query shape
except one prior exception with its own doc-comment explaining why).
To validate end-to-end against a live pool: bounce an upstream MCP
server mid-`tools/call` (e.g. `docker restart` one backend container
while firing a `tools/call` at a tool it owns) and confirm the call
either succeeds after a short pause or fails within ~10s instead of
returning an immediate 404.

https://claude.ai/code/session_01TutDdZ9F32tZHx3ajYMsKN