### PR TITLE
fix(ci): run build check on PRs targeting umbrella

### DIFF
--- a/.github/workflows/umbrella-build.yml
+++ b/.github/workflows/umbrella-build.yml
@@ -4,6 +4,13 @@ name: Umbrella — Build & Push (umbrella branch)
 # Builds and publishes the deployable line on every push to `umbrella`.
 # Image lands at ghcr.io/umbrella-it-group/metamcp:<sha> + :latest.
 # Watchtower on mcp-host-prod (scope=umbrella) picks up :latest within ~5 min.
+#
+# Also runs build-only (no login, no push, no tags) on PRs targeting
+# `umbrella` — this is the only build check a PR gets before merge. Until
+# 2026-07-13 the pull_request trigger below existed but the job's `if` only
+# ever matched push events, so no PR ever ran the build (this is why
+# Dependabot PR #54's break reached the prod image unseen). See
+# fix/ci-pr-build-check-20260713.
 
 on:
   push:
@@ -53,7 +60,12 @@ jobs:
   # these never get noticed there. Tracked as a follow-up — see
   # UMBRELLA_FORK.md "Our own patches" backlog.
   build-and-push:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/umbrella'
+    # push-to-umbrella: unchanged — full build + push. pull_request-to-umbrella:
+    # same job, same build, but every registry-touching step below is gated
+    # off via its own `if` so a PR only ever proves the image builds.
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/umbrella') ||
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -66,13 +78,18 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      # Login, tag metadata, and attestation only make sense on the push
+      # path — a PR build never touches the registry, so there's nothing
+      # to authenticate, tag, or attest.
       - uses: docker/login-action@v3
+        if: github.event_name == 'push'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
+        if: github.event_name == 'push'
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -88,13 +105,18 @@ jobs:
           # for an artifact nothing consumes. Re-add if we ever publish for
           # a community arm64 host.
           platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          # PR builds verify the Dockerfile still produces an image; empty
+          # tags/labels/cache-to below just drop the corresponding docker
+          # buildx flag (confirmed against build-push-action's own arg
+          # builder), so a PR run stays untagged and never writes cache.
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ github.event_name == 'push' && steps.meta.outputs.tags || '' }}
+          labels: ${{ github.event_name == 'push' && steps.meta.outputs.labels || '' }}
           cache-from: type=gha,scope=metamcp-umbrella
-          cache-to: type=gha,mode=max,scope=metamcp-umbrella
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=metamcp-umbrella' || '' }}
 
       - uses: actions/attest-build-provenance@v1
+        if: github.event_name == 'push'
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## What

`.github/workflows/umbrella-build.yml` declared a `pull_request` trigger on
branches `[umbrella]`, but its only job was gated with:

```
if: github.event_name == 'push' && github.ref == 'refs/heads/umbrella'
```

That condition can never be true for a `pull_request` event, so no PR ever
ran a build check — the trigger existed but the job silently never fired.
This is the mechanism behind Dependabot PR #54's build break reaching the
prod image unseen: the workflow *looked* like it covered PRs but didn't.

## Fix

Same job now runs for both events; only the registry-touching steps are
gated to push via their own `if`, so a PR run proves the Dockerfile still
builds without ever logging into the registry, tagging, pushing, or
attesting:

| Step | push → umbrella | pull_request → umbrella (before) | pull_request → umbrella (after) |
|---|---|---|---|
| Job runs at all | yes | **no (job `if` never matched)** | yes |
| `docker/login-action` | yes | — | skipped |
| `docker/metadata-action` (tags) | yes | — | skipped |
| `docker/build-push-action` | yes, `push: true`, tagged | — | yes, `push: false`, untagged, no cache write |
| `attest-build-provenance` | yes | — | skipped |
| Registry image published | yes | — | no |

`paths:` filtering is unchanged for both triggers — same list, same
semantics, just now actually reachable from a PR.

## Verification

- `actionlint` (installed fresh, v1.7.7 linux/amd64): clean, exit 0, both
  before and after the edit.
- `pnpm install && pnpm run build` in a clean worktree off `origin/umbrella`
  with this change applied: `Tasks: 4 successful, 4 total` — full turbo,
  no errors (pre-existing frontend eslint *warnings* surfaced by `next build`
  itself, unrelated to this diff, same set the workflow's own comment already
  documents as excluded from CI gating).
- `pnpm run check-types`: `Tasks: 2 successful, 2 total`, exit 0.
- `pnpm run lint`: exit 1 — but only on the 36 pre-existing warnings the
  workflow file itself already documents (`--max-warnings 0` upstream drift,
  none in a file this PR touches). Not this diff's regression; not gated by
  this workflow either way.
- Live: this PR is its own test. `gh pr checks 63`:
  ```
  build-and-push  pass  2m27s  https://github.com/Umbrella-IT-Group/metamcp/actions/runs/29264210009/job/86865084028
  ```
  `gh run view --job=86865084028` step list confirms the gating fired as
  designed on this actual `pull_request` event — `docker/login-action` and
  `docker/metadata-action` both show skipped (`-`), `docker/build-push-action`
  ran and passed, `actions/attest-build-provenance` skipped (`-`):
  ```
  ✓ Set up job
  ✓ Run actions/checkout@v4
  ✓ Run docker/setup-buildx-action@v3
  - Run docker/login-action@v3
  - Run docker/metadata-action@v5
  ✓ Run docker/build-push-action@v5
  - Run actions/attest-build-provenance@v1
  ✓ Complete job
  ```
  `gh pr view 63`: `"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN"`.

## Note for the operator

First PR-triggered image build has no `cache-to` write on the PR path (by
design — a PR build never writes the shared `metamcp-umbrella` GHA cache
scope), so it may run slower than a push-triggered build. Subsequent PR
builds still get `cache-from` reads against whatever the push path already
wrote.

## Out of scope (not touched)

- `UMBRELLA_FORK.md` patch table — per lane instructions, a follow-up docs
  PR logs this one.
- `workflow_dispatch` trigger is declared but was *already* unreachable
  before this change too (same job-level `if` excluded it, since it matched
  only `push`). Untouched here since the brief scoped this fix to the
  `pull_request` defect specifically; flagging for a separate follow-up if
  manual dispatch is meant to work.
- Pre-existing `pnpm run lint` failures (36 warnings, 0 errors, `--max-warnings 0`)
  and the frontend `next build` eslint warnings — both predate this branch,
  both already called out in this same workflow file's comments, neither
  touched by this diff.

Patch-table row lands in the follow-up docs PR.

https://claude.ai/code/session_01TutDdZ9F32tZHx3ajYMsKN
