### PR TITLE
build(deps): migrate to zod v4 and MCP SDK 1.29

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -22,7 +22,7 @@
     "db:migrate:dev": "dotenv -e ../../.env.local -- drizzle-kit migrate"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "1.16.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@repo/trpc": "workspace:*",
     "@repo/zod-types": "workspace:*",
     "@trpc/server": "^11.18.0",
@@ -39,7 +39,7 @@
     "pg": "^8.16.0",
     "shell-quote": "^1.8.4",
     "spawn-rx": "^5.1.2",
-    "zod": "^3.25.64"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/apps/backend/src/db/repositories/mcp-servers.repo.ts
+++ b/apps/backend/src/db/repositories/mcp-servers.repo.ts
@@ -257,9 +257,9 @@ export class McpServersRepository {
     const updated = await db
       .update(mcpServersTable)
       .set({
-        error_status: McpServerErrorStatusEnum.Enum.NONE,
+        error_status: McpServerErrorStatusEnum.enum.NONE,
       })
-      .where(eq(mcpServersTable.error_status, McpServerErrorStatusEnum.Enum.ERROR))
+      .where(eq(mcpServersTable.error_status, McpServerErrorStatusEnum.enum.ERROR))
       .returning();
 
     return updated.length;

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -1,6 +1,9 @@
 import { OAuthClientInformation } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import {
+  MCP_SERVER_ERROR_STATUSES,
+  MCP_SERVER_STATUSES,
+  MCP_SERVER_TYPES,
   McpServerErrorStatusEnum,
   McpServerStatusEnum,
   McpServerTypeEnum,
@@ -19,17 +22,17 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 
-export const mcpServerTypeEnum = pgEnum(
-  "mcp_server_type",
-  McpServerTypeEnum.options,
-);
+// Build the drizzle enums from the shared literal tuples (not
+// `SomeEnum.options`, which zod 4 widens to string[] and breaks pgEnum's
+// literal-union inference — see MCP_SERVER_TYPES in @repo/zod-types).
+export const mcpServerTypeEnum = pgEnum("mcp_server_type", MCP_SERVER_TYPES);
 export const mcpServerStatusEnum = pgEnum(
   "mcp_server_status",
-  McpServerStatusEnum.options,
+  MCP_SERVER_STATUSES,
 );
 export const mcpServerErrorStatusEnum = pgEnum(
   "mcp_server_error_status",
-  McpServerErrorStatusEnum.options,
+  MCP_SERVER_ERROR_STATUSES,
 );
 
 export const mcpServersTable = pgTable(
@@ -40,7 +43,7 @@ export const mcpServersTable = pgTable(
     description: text("description"),
     type: mcpServerTypeEnum("type")
       .notNull()
-      .default(McpServerTypeEnum.Enum.STDIO),
+      .default(McpServerTypeEnum.enum.STDIO),
     command: text("command"),
     args: text("args")
       .array()
@@ -53,7 +56,7 @@ export const mcpServersTable = pgTable(
     url: text("url"),
     error_status: mcpServerErrorStatusEnum("error_status")
       .notNull()
-      .default(McpServerErrorStatusEnum.Enum.NONE),
+      .default(McpServerErrorStatusEnum.enum.NONE),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -299,7 +302,7 @@ export const namespaceServerMappingsTable = pgTable(
       .references(() => mcpServersTable.uuid, { onDelete: "cascade" }),
     status: mcpServerStatusEnum("status")
       .notNull()
-      .default(McpServerStatusEnum.Enum.ACTIVE),
+      .default(McpServerStatusEnum.enum.ACTIVE),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -335,7 +338,7 @@ export const namespaceToolMappingsTable = pgTable(
       .references(() => mcpServersTable.uuid, { onDelete: "cascade" }),
     status: mcpServerStatusEnum("status")
       .notNull()
-      .default(McpServerStatusEnum.Enum.ACTIVE),
+      .default(McpServerStatusEnum.enum.ACTIVE),
     override_name: text("override_name"),
     override_title: text("override_title"),
     override_description: text("override_description"),

--- a/apps/backend/src/lib/bootstrap.service.ts
+++ b/apps/backend/src/lib/bootstrap.service.ts
@@ -989,7 +989,7 @@ export async function initializeEnvironmentConfiguration(): Promise<void> {
   console.log("🔧 Setting registration controls...");
   try {
     await upsertConfig(
-      ConfigKeyEnum.Enum.DISABLE_SIGNUP,
+      ConfigKeyEnum.enum.DISABLE_SIGNUP,
       config.disableUiRegistration.toString(),
       "Whether new user signup is disabled",
     );
@@ -999,7 +999,7 @@ export async function initializeEnvironmentConfiguration(): Promise<void> {
 
   try {
     await upsertConfig(
-      ConfigKeyEnum.Enum.DISABLE_SSO_SIGNUP,
+      ConfigKeyEnum.enum.DISABLE_SSO_SIGNUP,
       config.disableSsoRegistration.toString(),
       "Whether new user signup via SSO/OAuth is disabled",
     );

--- a/apps/backend/src/lib/config.service.ts
+++ b/apps/backend/src/lib/config.service.ts
@@ -5,14 +5,14 @@ import { configRepo } from "../db/repositories/config.repo";
 export const configService = {
   async isSignupDisabled(): Promise<boolean> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.DISABLE_SIGNUP,
+      ConfigKeyEnum.enum.DISABLE_SIGNUP,
     );
     return config?.value === "true";
   },
 
   async setSignupDisabled(disabled: boolean): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.DISABLE_SIGNUP,
+      ConfigKeyEnum.enum.DISABLE_SIGNUP,
       disabled.toString(),
       "Whether new user signup is disabled",
     );
@@ -20,14 +20,14 @@ export const configService = {
 
   async isSsoSignupDisabled(): Promise<boolean> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.DISABLE_SSO_SIGNUP,
+      ConfigKeyEnum.enum.DISABLE_SSO_SIGNUP,
     );
     return config?.value === "true";
   },
 
   async setSsoSignupDisabled(disabled: boolean): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.DISABLE_SSO_SIGNUP,
+      ConfigKeyEnum.enum.DISABLE_SSO_SIGNUP,
       disabled.toString(),
       "Whether new user signup via SSO/OAuth is disabled",
     );
@@ -35,14 +35,14 @@ export const configService = {
 
   async isBasicAuthDisabled(): Promise<boolean> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.DISABLE_BASIC_AUTH,
+      ConfigKeyEnum.enum.DISABLE_BASIC_AUTH,
     );
     return config?.value === "true";
   },
 
   async setBasicAuthDisabled(disabled: boolean): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.DISABLE_BASIC_AUTH,
+      ConfigKeyEnum.enum.DISABLE_BASIC_AUTH,
       disabled.toString(),
       "Whether basic email/password authentication is disabled",
     );
@@ -50,27 +50,27 @@ export const configService = {
 
   async getMcpResetTimeoutOnProgress(): Promise<boolean> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.MCP_RESET_TIMEOUT_ON_PROGRESS,
+      ConfigKeyEnum.enum.MCP_RESET_TIMEOUT_ON_PROGRESS,
     );
     return config?.value === "true" || true;
   },
 
   async setMcpResetTimeoutOnProgress(enabled: boolean): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.MCP_RESET_TIMEOUT_ON_PROGRESS,
+      ConfigKeyEnum.enum.MCP_RESET_TIMEOUT_ON_PROGRESS,
       enabled.toString(),
       "Whether to reset timeout on progress for MCP requests",
     );
   },
 
   async getMcpTimeout(): Promise<number> {
-    const config = await configRepo.getConfig(ConfigKeyEnum.Enum.MCP_TIMEOUT);
+    const config = await configRepo.getConfig(ConfigKeyEnum.enum.MCP_TIMEOUT);
     return config?.value ? parseInt(config.value, 10) : 60000;
   },
 
   async setMcpTimeout(timeout: number): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.MCP_TIMEOUT,
+      ConfigKeyEnum.enum.MCP_TIMEOUT,
       timeout.toString(),
       "MCP request timeout in milliseconds",
     );
@@ -78,14 +78,14 @@ export const configService = {
 
   async getMcpMaxTotalTimeout(): Promise<number> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.MCP_MAX_TOTAL_TIMEOUT,
+      ConfigKeyEnum.enum.MCP_MAX_TOTAL_TIMEOUT,
     );
     return config?.value ? parseInt(config.value, 10) : 60000;
   },
 
   async setMcpMaxTotalTimeout(timeout: number): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.MCP_MAX_TOTAL_TIMEOUT,
+      ConfigKeyEnum.enum.MCP_MAX_TOTAL_TIMEOUT,
       timeout.toString(),
       "MCP maximum total timeout in milliseconds",
     );
@@ -93,14 +93,14 @@ export const configService = {
 
   async getMcpMaxAttempts(): Promise<number> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.MCP_MAX_ATTEMPTS,
+      ConfigKeyEnum.enum.MCP_MAX_ATTEMPTS,
     );
     return config?.value ? parseInt(config.value, 10) : 3;
   },
 
   async setMcpMaxAttempts(maxAttempts: number): Promise<void> {
     await configRepo.setConfig(
-      ConfigKeyEnum.Enum.MCP_MAX_ATTEMPTS,
+      ConfigKeyEnum.enum.MCP_MAX_ATTEMPTS,
       maxAttempts.toString(),
       "Maximum number of crash attempts before marking MCP server as ERROR",
     );
@@ -108,7 +108,7 @@ export const configService = {
 
   async getSessionLifetime(): Promise<number | null> {
     const config = await configRepo.getConfig(
-      ConfigKeyEnum.Enum.SESSION_LIFETIME,
+      ConfigKeyEnum.enum.SESSION_LIFETIME,
     );
     if (!config?.value) {
       // Fallback to env var (milliseconds), then null (infinite sessions)
@@ -126,10 +126,10 @@ export const configService = {
   async setSessionLifetime(lifetime?: number | null): Promise<void> {
     if (lifetime === null || lifetime === undefined) {
       // Remove the config to indicate infinite session lifetime
-      await configRepo.deleteConfig(ConfigKeyEnum.Enum.SESSION_LIFETIME);
+      await configRepo.deleteConfig(ConfigKeyEnum.enum.SESSION_LIFETIME);
     } else {
       await configRepo.setConfig(
-        ConfigKeyEnum.Enum.SESSION_LIFETIME,
+        ConfigKeyEnum.enum.SESSION_LIFETIME,
         lifetime.toString(),
         "Session lifetime in milliseconds before automatic cleanup",
       );

--- a/apps/backend/src/lib/metamcp/client.test.ts
+++ b/apps/backend/src/lib/metamcp/client.test.ts
@@ -65,11 +65,9 @@ async function buildRig() {
   const client = new Client(
     { name: "test-metamcp-client", version: "0.0.0" },
     {
-      capabilities: {
-        prompts: {},
-        resources: { subscribe: true },
-        tools: {},
-      },
+      // Mirror connectMetaMcpClient: no client-side capabilities advertised
+      // (prompts/resources/tools are server capabilities, stripped by SDK 1.29).
+      capabilities: {},
     },
   );
 

--- a/apps/backend/src/lib/metamcp/client.ts
+++ b/apps/backend/src/lib/metamcp/client.ts
@@ -258,11 +258,13 @@ export const createMetaMcpClient = (
       version: "2.0.0",
     },
     {
-      capabilities: {
-        prompts: {},
-        resources: { subscribe: true },
-        tools: {},
-      },
+      // prompts/resources/tools are SERVER capabilities; they were never
+      // valid on a client. SDK <=1.16 tolerated them, but SDK 1.29's
+      // ClientCapabilities schema strips unknown keys, so advertising them
+      // was always inert. An empty object is the exact wire-equivalent and
+      // keeps metamcp's downstream client advertising no client-side
+      // capabilities, as before.
+      capabilities: {},
     },
   );
   return { client, transport };

--- a/apps/backend/src/lib/metamcp/fetch-metamcp.ts
+++ b/apps/backend/src/lib/metamcp/fetch-metamcp.ts
@@ -30,14 +30,14 @@ export async function getMcpServers(
       whereConditions.push(
         eq(
           namespaceServerMappingsTable.status,
-          McpServerStatusEnum.Enum.ACTIVE,
+          McpServerStatusEnum.enum.ACTIVE,
         ),
       );
     }
 
     // Always exclude servers with ERROR status (these are crashed servers)
     whereConditions.push(
-      eq(mcpServersTable.error_status, McpServerErrorStatusEnum.Enum.NONE),
+      eq(mcpServersTable.error_status, McpServerErrorStatusEnum.enum.NONE),
     );
 
     // Fetch MCP servers for the specific namespace using a join query

--- a/apps/backend/src/lib/metamcp/server-error-tracker.ts
+++ b/apps/backend/src/lib/metamcp/server-error-tracker.ts
@@ -120,7 +120,7 @@ export class ServerErrorTracker {
       // Update the server-level error status
       await mcpServersRepository.updateServerErrorStatus({
         serverUuid,
-        errorStatus: McpServerErrorStatusEnum.Enum.ERROR,
+        errorStatus: McpServerErrorStatusEnum.enum.ERROR,
       });
 
       logger.error(`Server ${serverUuid} marked as ERROR at server level`);
@@ -168,7 +168,7 @@ export class ServerErrorTracker {
   async isServerInErrorState(serverUuid: string): Promise<boolean> {
     try {
       const server = await mcpServersRepository.findByUuid(serverUuid);
-      return server?.error_status === McpServerErrorStatusEnum.Enum.ERROR;
+      return server?.error_status === McpServerErrorStatusEnum.enum.ERROR;
     } catch (error) {
       logger.error(
         `Error checking server error state for ${serverUuid}:`,
@@ -189,7 +189,7 @@ export class ServerErrorTracker {
       // Update the database to clear the error status
       await mcpServersRepository.updateServerErrorStatus({
         serverUuid,
-        errorStatus: McpServerErrorStatusEnum.Enum.NONE,
+        errorStatus: McpServerErrorStatusEnum.enum.NONE,
       });
 
       logger.info(`Reset error state for server ${serverUuid}`);

--- a/apps/backend/src/lib/metamcp/transport-recovery-hydration.test.ts
+++ b/apps/backend/src/lib/metamcp/transport-recovery-hydration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the lazy-recovery transport hydration shim.
  *
- * These exercise the REAL `@modelcontextprotocol/sdk` 1.16.0
+ * These exercise the REAL `@modelcontextprotocol/sdk` 1.29.0
  * `StreamableHTTPServerTransport` — NO mock — because the whole point of
  * the shim is to satisfy the SDK's internal `validateSession` gate that
  * a mocked transport would paper over. The original wedge
@@ -9,10 +9,13 @@
  * gateway restart) slipped through precisely because the existing
  * recovery tests mocked the transport and never hit `_initialized`.
  *
- * The behavioural assertion drives the transport's private
- * `validateSession(req, res)` with a minimal Node req/res pair:
- *   - before hydration -> false + 400 {-32000 "Server not initialized"}
- *   - after  hydration -> true (session id matches, no response written)
+ * As of SDK 1.29 the Node transport is a thin wrapper whose session state
+ * lives on an inner `_webStandardTransport`, and its `validateSession`
+ * takes a Web Standard `Request` and returns a `Response` (invalid) or
+ * `undefined` (valid) instead of the old boolean + Node `res` write. The
+ * behavioural assertion drives that inner `validateSession`:
+ *   - before hydration -> 400 {-32000 "Server not initialized"}
+ *   - after  hydration -> undefined (session id matches, no error)
  */
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { describe, expect, it, vi } from "vitest";
@@ -35,51 +38,37 @@ function freshTransport(): StreamableHTTPServerTransport {
 }
 
 /**
- * Minimal stand-ins for the Node req/res `validateSession` touches. The
- * res records the status it writes so we can assert the 400 path.
+ * SDK 1.29's `validateSession` lives on the inner `_webStandardTransport`,
+ * takes a Web Standard `Request`, and returns a `Response` (invalid) or
+ * `undefined` (valid). Reach it through a cast for the behavioural test.
  */
-function mockReq(sessionId?: string) {
-  return {
-    headers: sessionId ? { "mcp-session-id": sessionId } : {},
-  } as unknown as Parameters<
-    StreamableHTTPServerTransport["handleRequest"]
-  >[0];
-}
-
-function mockRes() {
-  const state: { status?: number; body?: string } = {};
-  const res = {
-    writeHead(status: number) {
-      state.status = status;
-      return res;
-    },
-    end(body?: string) {
-      state.body = body;
-      return res;
-    },
-  };
-  return { res, state };
-}
-
-// `validateSession` is private in the SDK; reach it through a cast for
-// the behavioural test.
-function callValidateSession(
+async function callValidateSession(
   transport: StreamableHTTPServerTransport,
   sessionId?: string,
-): { ok: boolean; status?: number; body?: string } {
-  const { res, state } = mockRes();
-  const ok = (
+): Promise<{ ok: boolean; status?: number; body?: string }> {
+  const inner = (
     transport as unknown as {
-      validateSession: (req: unknown, res: unknown) => boolean;
+      _webStandardTransport: {
+        validateSession: (req: Request) => Response | undefined;
+      };
     }
-  ).validateSession(mockReq(sessionId), res);
-  return { ok, status: state.status, body: state.body };
+  )._webStandardTransport;
+
+  const headers: Record<string, string> = {};
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  const req = new Request("http://localhost/mcp", { method: "POST", headers });
+
+  const response = inner.validateSession(req);
+  if (response === undefined) {
+    return { ok: true };
+  }
+  return { ok: false, status: response.status, body: await response.text() };
 }
 
 describe("hydrateRecoveredTransport", () => {
-  it("a fresh (un-hydrated) transport rejects a sessioned request — reproduces the wedge", () => {
+  it("a fresh (un-hydrated) transport rejects a sessioned request — reproduces the wedge", async () => {
     const transport = freshTransport();
-    const result = callValidateSession(transport, SESSION_ID);
+    const result = await callValidateSession(transport, SESSION_ID);
 
     expect(result.ok).toBe(false);
     expect(result.status).toBe(400);
@@ -89,23 +78,24 @@ describe("hydrateRecoveredTransport", () => {
     expect(result.body).toContain("-32000");
   });
 
-  it("after hydration the transport accepts the matching session id", () => {
+  it("after hydration the transport accepts the matching session id", async () => {
     const transport = freshTransport();
 
     const hydrated = hydrateRecoveredTransport(transport, SESSION_ID);
     expect(hydrated).toBe(true);
 
-    const result = callValidateSession(transport, SESSION_ID);
+    const result = await callValidateSession(transport, SESSION_ID);
     expect(result.ok).toBe(true);
-    expect(result.status).toBeUndefined(); // nothing written = passed
+    expect(result.status).toBeUndefined(); // no error response = passed
   });
 
   it("sets the SDK internals the skipped handshake would have set", () => {
     const transport = freshTransport();
-    const internals = transport as unknown as {
-      _initialized: boolean;
-      sessionId?: string;
-    };
+    const internals = (
+      transport as unknown as {
+        _webStandardTransport: { _initialized: boolean; sessionId?: string };
+      }
+    )._webStandardTransport;
 
     expect(internals._initialized).toBe(false);
     expect(internals.sessionId).toBeUndefined();
@@ -116,21 +106,35 @@ describe("hydrateRecoveredTransport", () => {
     expect(internals.sessionId).toBe(SESSION_ID);
   });
 
-  it("a hydrated transport still rejects a DIFFERENT session id (404), not a blanket allow", () => {
+  it("a hydrated transport still rejects a DIFFERENT session id (404), not a blanket allow", async () => {
     const transport = freshTransport();
     hydrateRecoveredTransport(transport, SESSION_ID);
 
-    const result = callValidateSession(transport, "00000000-dead-beef-0000-000000000000");
+    const result = await callValidateSession(
+      transport,
+      "00000000-dead-beef-0000-000000000000",
+    );
     expect(result.ok).toBe(false);
     expect(result.status).toBe(404); // -32001 "Session not found"
   });
 
   it("returns false (refuses) if the SDK internal field shape changed", () => {
-    // Simulate an SDK upgrade that renamed `_initialized`: a plain object
-    // whose `_initialized` is not a boolean.
+    // Simulate an SDK upgrade that renamed `_initialized`: an inner
+    // web-standard transport whose `_initialized` is not a boolean.
     const notATransport = {
-      _initialized: "yes",
-      sessionId: undefined,
+      _webStandardTransport: {
+        _initialized: "yes",
+        sessionId: undefined,
+      },
+    } as unknown as StreamableHTTPServerTransport;
+
+    expect(hydrateRecoveredTransport(notATransport, SESSION_ID)).toBe(false);
+  });
+
+  it("returns false (refuses) if the wrapper no longer exposes _webStandardTransport", () => {
+    // Simulate an SDK that dropped the wrapper indirection entirely.
+    const notATransport = {
+      _initialized: false,
     } as unknown as StreamableHTTPServerTransport;
 
     expect(hydrateRecoveredTransport(notATransport, SESSION_ID)).toBe(false);

--- a/apps/backend/src/lib/metamcp/transport-recovery-hydration.ts
+++ b/apps/backend/src/lib/metamcp/transport-recovery-hydration.ts
@@ -11,14 +11,22 @@
  * sends `initialize` exactly ONCE per client session and a reconnecting
  * client won't send it again.
  *
- * In `@modelcontextprotocol/sdk` 1.16.0 the transport flips
- * `_initialized=true` and assigns `sessionId` ONLY inside the
- * initialize-request branch (`server/streamableHttp.js:337-338`). A
- * rebuilt-but-not-initialized transport therefore rejects the client's
- * first real request in `validateSession`:
+ * As of `@modelcontextprotocol/sdk` 1.29.0 the Node
+ * `StreamableHTTPServerTransport` is a thin wrapper that delegates all
+ * session state to an inner `_webStandardTransport`
+ * (`WebStandardStreamableHTTPServerTransport`). That inner transport
+ * flips `_initialized=true` and assigns `sessionId` ONLY inside the
+ * initialize-request branch of `server/webStandardStreamableHttp.js`
+ * (`this.sessionId = this.sessionIdGenerator?.(); this._initialized =
+ * true`). A rebuilt-but-not-initialized transport therefore rejects the
+ * client's first real request in the inner `validateSession`:
  *
  *     if (!this._initialized) -> 400 {-32000 "Bad Request: Server not
- *     initialized"}   (server/streamableHttp.js:442)
+ *     initialized"}   (webStandardStreamableHttp.js validateSession)
+ *
+ * (In SDK 1.16 these same fields lived directly on the Node transport;
+ * 1.29 moved them one level down into `_webStandardTransport`, so the
+ * hydration and its contract check reach through that wrapper.)
  *
  * The Anthropic claude.ai MCP connector relays that 400 as
  * `-32600 "Anthropic Proxy: Invalid content from server"`, wedging the
@@ -44,9 +52,16 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import logger from "@/utils/logger";
 
 /** SDK-internal fields the hydration depends on (private in the SDK). */
-interface TransportInternals {
+interface WebStandardTransportInternals {
   _initialized?: unknown;
   sessionId?: unknown;
+}
+/**
+ * The Node transport is a wrapper; the initialize state the handshake sets
+ * lives on the inner `_webStandardTransport` since SDK 1.29.
+ */
+interface TransportInternals {
+  _webStandardTransport?: WebStandardTransportInternals;
 }
 
 /**
@@ -62,19 +77,22 @@ export function hydrateRecoveredTransport(
   transport: StreamableHTTPServerTransport,
   sessionId: string,
 ): boolean {
-  const internals = transport as unknown as TransportInternals;
-  // A fresh transport has `_initialized === false`. Anything else means
-  // the SDK renamed/removed the field — bail loudly.
-  if (typeof internals._initialized !== "boolean") {
+  const inner = (transport as unknown as TransportInternals)
+    ._webStandardTransport;
+  // A fresh transport's inner web-standard transport has
+  // `_initialized === false`. A missing wrapper or non-boolean field means
+  // the SDK renamed/removed the internals — bail loudly.
+  if (!inner || typeof inner._initialized !== "boolean") {
     logger.error(
-      "SDK shape change: StreamableHTTPServerTransport._initialized is not a " +
-        "boolean on a fresh transport; cannot hydrate recovered session " +
-        `${sessionId}. Update hydrateRecoveredTransport for the new SDK shape.`,
+      "SDK shape change: StreamableHTTPServerTransport._webStandardTransport." +
+        "_initialized is not a boolean on a fresh transport; cannot hydrate " +
+        `recovered session ${sessionId}. Update hydrateRecoveredTransport for ` +
+        "the new SDK shape.",
     );
     return false;
   }
-  internals._initialized = true;
-  internals.sessionId = sessionId;
+  inner._initialized = true;
+  inner.sessionId = sessionId;
   return true;
 }
 
@@ -92,20 +110,21 @@ export function assertRecoveryHydrationContract(): boolean {
   const probe = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => "contract-probe",
   });
-  const internals = probe as unknown as Record<string, unknown>;
-  // `_initialized` is the gate field validateSession checks and the SDK
-  // sets it (=false) in the constructor, so it must be a boolean on a
-  // fresh transport. `sessionId` is NOT declared until an `initialize`
-  // request assigns it, so it's legitimately absent here — we only ever
-  // assign it (always valid on a JS object), never read the SDK's value,
-  // so it isn't part of the contract.
-  const ok = typeof internals._initialized === "boolean";
+  const inner = (probe as unknown as TransportInternals)._webStandardTransport;
+  // `_initialized` is the gate field the inner validateSession checks and
+  // the SDK sets it (=false) in the web-standard transport's constructor,
+  // so it must be a boolean on a fresh transport. `sessionId` is NOT
+  // declared until an `initialize` request assigns it, so it's legitimately
+  // absent here — we only ever assign it (always valid on a JS object),
+  // never read the SDK's value, so it isn't part of the contract.
+  const ok = !!inner && typeof inner._initialized === "boolean";
   if (!ok) {
     logger.error(
       "STARTUP CONTRACT VIOLATION: StreamableHTTPServerTransport no longer " +
-        "exposes a boolean `_initialized` internal. Lazy session recovery will " +
-        "refuse all recoveries until hydrateRecoveredTransport is updated for " +
-        "the new SDK shape (currently pinned @modelcontextprotocol/sdk 1.16.0).",
+        "exposes `_webStandardTransport._initialized` as a boolean internal. " +
+        "Lazy session recovery will refuse all recoveries until " +
+        "hydrateRecoveredTransport is updated for the new SDK shape " +
+        "(currently pinned @modelcontextprotocol/sdk 1.29.0).",
     );
   }
   return ok;

--- a/apps/backend/src/routers/mcp-proxy/server.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.ts
@@ -135,7 +135,7 @@ const checkServerErrorStatus = async (serverUuid: string): Promise<boolean> => {
     }
 
     const isInError =
-      server.error_status === McpServerErrorStatusEnum.Enum.ERROR;
+      server.error_status === McpServerErrorStatusEnum.enum.ERROR;
     if (isInError) {
       logger.info(`Server ${server.name} (${serverUuid}) is in ERROR state`);
     }
@@ -157,12 +157,12 @@ const getHttpHeaders = (
 ): Record<string, string> => {
   const headers: Record<string, string> = {
     Accept:
-      transportType === McpServerTypeEnum.Enum.SSE
+      transportType === McpServerTypeEnum.enum.SSE
         ? "text/event-stream"
         : "text/event-stream, application/json",
   };
   const defaultHeaders =
-    transportType === McpServerTypeEnum.Enum.SSE
+    transportType === McpServerTypeEnum.enum.SSE
       ? SSE_HEADERS_PASSTHROUGH
       : STREAMABLE_HTTP_HEADERS_PASSTHROUGH;
 
@@ -236,7 +236,7 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
 
   const transportType = query.transportType as string;
 
-  if (transportType === McpServerTypeEnum.Enum.STDIO) {
+  if (transportType === McpServerTypeEnum.enum.STDIO) {
     const command = query.command as string;
     const origArgs = shellParseArgs(query.args as string) as string[];
     const queryEnv = query.env ? JSON.parse(query.env as string) : {};
@@ -292,7 +292,7 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
       );
       throw error;
     }
-  } else if (transportType === McpServerTypeEnum.Enum.SSE) {
+  } else if (transportType === McpServerTypeEnum.enum.SSE) {
     const url = transformDockerUrl(query.url as string);
 
     // Check if the server is in error state (for SSE, we need to find server by URL)
@@ -329,7 +329,7 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
     });
     await transport.start();
     return transport;
-  } else if (transportType === McpServerTypeEnum.Enum.STREAMABLE_HTTP) {
+  } else if (transportType === McpServerTypeEnum.enum.STREAMABLE_HTTP) {
     const url = transformDockerUrl(query.url as string);
 
     // Check if the server is in error state (for STREAMABLE_HTTP, we need to find server by URL)

--- a/apps/backend/src/routers/public-metamcp/openapi/tool-execution.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/tool-execution.ts
@@ -56,9 +56,16 @@ export const executeToolWithMiddleware = async (
 
     // Check if the result indicates an error (from middleware)
     if (result.isError) {
+      // SDK 1.29 types content as a discriminated ContentBlock union; .text
+      // only exists on the text variant, so narrow before reading it.
+      const firstBlock = result.content?.[0];
+      const errorMessage =
+        firstBlock?.type === "text" && firstBlock.text
+          ? firstBlock.text
+          : "Tool is inactive";
       return res.status(403).json({
         error: "Tool access denied",
-        message: result.content?.[0]?.text || "Tool is inactive",
+        message: errorMessage,
         timestamp: new Date().toISOString(),
       });
     }

--- a/apps/backend/src/trpc/mcp-servers.impl.ts
+++ b/apps/backend/src/trpc/mcp-servers.impl.ts
@@ -375,7 +375,7 @@ export const mcpServersImplementations = {
       }
 
       // Reset error status for stdio servers when they are updated
-      if (updatedServer.type === McpServerTypeEnum.Enum.STDIO) {
+      if (updatedServer.type === McpServerTypeEnum.enum.STDIO) {
         try {
           await serverErrorTracker.resetServerErrorState(updatedServer.uuid);
           logger.info(

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-inspector/components/inspector/inspector-prompts.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-inspector/components/inspector/inspector-prompts.tsx
@@ -229,12 +229,19 @@ export function InspectorPrompts({
               <div className="font-mono text-xs break-all">
                 URI: {message.content.resource?.uri}
               </div>
-              {message.content.resource?.text ? (
+              {/* SDK 1.29 types resource as a TextResourceContents |
+                  BlobResourceContents discriminated union; narrow with `in`
+                  before reading text/blob (was a merged shape under 1.16). */}
+              {message.content.resource &&
+              "text" in message.content.resource &&
+              message.content.resource.text ? (
                 <div className="mt-1 text-sm">
                   {String(message.content.resource.text)}
                 </div>
               ) : null}
-              {message.content.resource?.blob ? (
+              {message.content.resource &&
+              "blob" in message.content.resource &&
+              message.content.resource.blob ? (
                 <div className="mt-1 text-xs">
                   [
                   {t("inspector:promptsComponent.binaryData", {

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-inspector/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-inspector/page.tsx
@@ -90,7 +90,7 @@ function McpInspectorContent() {
   // MCP Connection setup - only enable when server data is loaded and valid
   const connection = useConnection({
     mcpServerUuid: selectedServerUuid,
-    transportType: selectedServer?.type || McpServerTypeEnum.Enum.STDIO,
+    transportType: selectedServer?.type || McpServerTypeEnum.enum.STDIO,
     command: selectedServer?.command || "",
     args: selectedServer?.args?.join(" ") || "",
     url: selectedServer?.url || "",

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/[uuid]/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/[uuid]/page.tsx
@@ -142,7 +142,7 @@ export default function McpServerDetailPage({
   // MCP Connection setup - only enable when server data is loaded and not in error state
   const connection = useConnection({
     mcpServerUuid: uuid,
-    transportType: server?.type || McpServerTypeEnum.Enum.STDIO,
+    transportType: server?.type || McpServerTypeEnum.enum.STDIO,
     command: server?.command || "",
     args: server?.args?.join(" ") || "",
     url: server?.url || "",
@@ -157,7 +157,7 @@ export default function McpServerDetailPage({
     enabled: Boolean(
       server &&
         !isLoading &&
-        server.error_status !== McpServerErrorStatusEnum.Enum.ERROR,
+        server.error_status !== McpServerErrorStatusEnum.enum.ERROR,
     ),
   });
 
@@ -167,7 +167,7 @@ export default function McpServerDetailPage({
       connection &&
       server &&
       !isLoading &&
-      server.error_status !== McpServerErrorStatusEnum.Enum.ERROR &&
+      server.error_status !== McpServerErrorStatusEnum.enum.ERROR &&
       connection.connectionStatus === "disconnected"
     ) {
       connection.connect();
@@ -188,7 +188,7 @@ export default function McpServerDetailPage({
 
   // Handle manual connect/disconnect
   const handleConnectionToggle = () => {
-    if (server?.error_status === McpServerErrorStatusEnum.Enum.ERROR) {
+    if (server?.error_status === McpServerErrorStatusEnum.enum.ERROR) {
       // Don't allow connection if server is in error state
       return;
     }
@@ -202,7 +202,7 @@ export default function McpServerDetailPage({
   // Get connection status display info
   const getConnectionStatusInfo = () => {
     // If server is in error state, show error status
-    if (server?.error_status === McpServerErrorStatusEnum.Enum.ERROR) {
+    if (server?.error_status === McpServerErrorStatusEnum.enum.ERROR) {
       return {
         text: t("mcp-servers:detail.serverError"),
         color: "text-destructive",
@@ -501,13 +501,13 @@ export default function McpServerDetailPage({
                     <Badge
                       variant={
                         server.error_status ===
-                        McpServerErrorStatusEnum.Enum.ERROR
+                        McpServerErrorStatusEnum.enum.ERROR
                           ? "destructive"
                           : "success"
                       }
                     >
                       {server.error_status ===
-                      McpServerErrorStatusEnum.Enum.ERROR
+                      McpServerErrorStatusEnum.enum.ERROR
                         ? t("mcp-servers:detail.error")
                         : t("mcp-servers:detail.noError")}
                     </Badge>
@@ -693,7 +693,7 @@ export default function McpServerDetailPage({
             <h3 className="text-lg font-semibold mb-4">
               {t("mcp-servers:detail.toolsManagement")}
             </h3>
-            {server.error_status === McpServerErrorStatusEnum.Enum.ERROR ? (
+            {server.error_status === McpServerErrorStatusEnum.enum.ERROR ? (
               <div className="space-y-4">
                 <div className="rounded-lg border border-dashed p-8 text-center">
                   <div className="flex flex-col items-center justify-center mx-auto max-w-md">

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/export-import-buttons.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/export-import-buttons.tsx
@@ -105,7 +105,7 @@ export function ExportImportButtons() {
         config.description = server.description;
       }
 
-      if (server.type === McpServerTypeEnum.Enum.STDIO) {
+      if (server.type === McpServerTypeEnum.enum.STDIO) {
         if (server.command) {
           config.command = server.command;
         }
@@ -116,8 +116,8 @@ export function ExportImportButtons() {
           config.env = server.env;
         }
       } else if (
-        server.type === McpServerTypeEnum.Enum.SSE ||
-        server.type === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+        server.type === McpServerTypeEnum.enum.SSE ||
+        server.type === McpServerTypeEnum.enum.STREAMABLE_HTTP
       ) {
         if (server.url) {
           config.url = server.url;

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/mcp-servers-list.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/mcp-servers-list.tsx
@@ -208,7 +208,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
       },
       cell: ({ row }) => {
         const errorStatus = row.getValue("error_status") as string;
-        const hasError = errorStatus === McpServerErrorStatusEnum.Enum.ERROR;
+        const hasError = errorStatus === McpServerErrorStatusEnum.enum.ERROR;
         return (
           <div className="px-3 py-2">
             <Badge variant={hasError ? "destructive" : "success"}>
@@ -327,7 +327,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
             config.description = server.description;
           }
 
-          if (server.type === McpServerTypeEnum.Enum.STDIO) {
+          if (server.type === McpServerTypeEnum.enum.STDIO) {
             if (server.command) {
               config.command = server.command;
             }
@@ -338,8 +338,8 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
               config.env = server.env;
             }
           } else if (
-            server.type === McpServerTypeEnum.Enum.SSE ||
-            server.type === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+            server.type === McpServerTypeEnum.enum.SSE ||
+            server.type === McpServerTypeEnum.enum.STREAMABLE_HTTP
           ) {
             if (server.url) {
               config.url = server.url;

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/page.tsx
@@ -52,7 +52,7 @@ export default function McpServersPage() {
     defaultValues: {
       name: "",
       description: "",
-      type: McpServerTypeEnum.Enum.STDIO,
+      type: McpServerTypeEnum.enum.STDIO,
       command: "",
       args: "",
       env: "",
@@ -227,12 +227,12 @@ export default function McpServersPage() {
                               variant="outline"
                               className="w-full justify-between"
                             >
-                              {field.value === McpServerTypeEnum.Enum.STDIO
+                              {field.value === McpServerTypeEnum.enum.STDIO
                                 ? t("mcp-servers:stdio")
-                                : field.value === McpServerTypeEnum.Enum.SSE
+                                : field.value === McpServerTypeEnum.enum.SSE
                                   ? t("mcp-servers:sse")
                                   : field.value ===
-                                      McpServerTypeEnum.Enum.STREAMABLE_HTTP
+                                      McpServerTypeEnum.enum.STREAMABLE_HTTP
                                     ? "Streamable HTTP"
                                     : t("mcp-servers:selectType")}
                               <ChevronDown className="ml-2 h-4 w-4" />
@@ -244,14 +244,14 @@ export default function McpServersPage() {
                           >
                             <DropdownMenuItem
                               onClick={() =>
-                                field.onChange(McpServerTypeEnum.Enum.STDIO)
+                                field.onChange(McpServerTypeEnum.enum.STDIO)
                               }
                             >
                               {t("mcp-servers:stdio")}
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() =>
-                                field.onChange(McpServerTypeEnum.Enum.SSE)
+                                field.onChange(McpServerTypeEnum.enum.SSE)
                               }
                             >
                               {t("mcp-servers:sse")}
@@ -259,7 +259,7 @@ export default function McpServersPage() {
                             <DropdownMenuItem
                               onClick={() =>
                                 field.onChange(
-                                  McpServerTypeEnum.Enum.STREAMABLE_HTTP,
+                                  McpServerTypeEnum.enum.STREAMABLE_HTTP,
                                 )
                               }
                             >
@@ -315,7 +315,7 @@ export default function McpServersPage() {
                   />
 
                   {/* STDIO specific fields */}
-                  {form.watch("type") === McpServerTypeEnum.Enum.STDIO && (
+                  {form.watch("type") === McpServerTypeEnum.enum.STDIO && (
                     <>
                       <FormField
                         control={form.control}
@@ -375,9 +375,9 @@ export default function McpServersPage() {
                   )}
 
                   {/* SSE and STREAMABLE_HTTP specific fields */}
-                  {(form.watch("type") === McpServerTypeEnum.Enum.SSE ||
+                  {(form.watch("type") === McpServerTypeEnum.enum.SSE ||
                     form.watch("type") ===
-                      McpServerTypeEnum.Enum.STREAMABLE_HTTP) && (
+                      McpServerTypeEnum.enum.STREAMABLE_HTTP) && (
                     <>
                       <FormField
                         control={form.control}

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/enhanced-namespace-tools-table.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/enhanced-namespace-tools-table.tsx
@@ -359,9 +359,9 @@ export function EnhancedNamespaceToolsTable({
     }
 
     const newStatus =
-      tool.status === ToolStatusEnum.Enum.ACTIVE
-        ? ToolStatusEnum.Enum.INACTIVE
-        : ToolStatusEnum.Enum.ACTIVE;
+      tool.status === ToolStatusEnum.enum.ACTIVE
+        ? ToolStatusEnum.enum.INACTIVE
+        : ToolStatusEnum.enum.ACTIVE;
 
     updateToolStatusMutation.mutate({
       namespaceUuid,

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/namespace-servers-table.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/namespace-servers-table.tsx
@@ -277,7 +277,7 @@ export function NamespaceServersTable({
       },
       cell: ({ row }) => {
         const errorStatus = row.getValue("error_status") as string;
-        const hasError = errorStatus === McpServerErrorStatusEnum.Enum.ERROR;
+        const hasError = errorStatus === McpServerErrorStatusEnum.enum.ERROR;
         return (
           <div className="px-3 py-2">
             <Badge variant={hasError ? "destructive" : "success"}>
@@ -366,7 +366,7 @@ export function NamespaceServersTable({
             config.description = server.description;
           }
 
-          if (server.type === McpServerTypeEnum.Enum.STDIO) {
+          if (server.type === McpServerTypeEnum.enum.STDIO) {
             if (server.command) {
               config.command = server.command;
             }
@@ -377,8 +377,8 @@ export function NamespaceServersTable({
               config.env = server.env;
             }
           } else if (
-            server.type === McpServerTypeEnum.Enum.SSE ||
-            server.type === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+            server.type === McpServerTypeEnum.enum.SSE ||
+            server.type === McpServerTypeEnum.enum.STREAMABLE_HTTP
           ) {
             if (server.url) {
               config.url = server.url;

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/namespace-tool-management.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/namespace-tool-management.tsx
@@ -214,11 +214,11 @@ export function NamespaceToolManagement({
   // Calculate counts
   const serverCount = servers.length;
   const activeServerCount = servers.filter(
-    (s) => s.status === ToolStatusEnum.Enum.ACTIVE,
+    (s) => s.status === ToolStatusEnum.enum.ACTIVE,
   ).length;
   const savedToolCount = namespaceTools.length;
   const activeToolCount = namespaceTools.filter(
-    (t) => t.status === ToolStatusEnum.Enum.ACTIVE,
+    (t) => t.status === ToolStatusEnum.enum.ACTIVE,
   ).length;
   const mcpToolCount = mcpTools.length;
 

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/page.tsx
@@ -91,7 +91,7 @@ export default function NamespaceDetailPage({
   // MetaMCP Connection setup - connect to the metamcp proxy endpoint for this namespace
   const connection = useConnection({
     mcpServerUuid: uuid, // Using namespace UUID as the "server" UUID for connection
-    transportType: McpServerTypeEnum.Enum.SSE,
+    transportType: McpServerTypeEnum.enum.SSE,
     command: "", // Not needed for metamcp proxy
     args: "",
     url: `/mcp-proxy/metamcp/${uuid}/sse`, // Connect to metamcp proxy endpoint

--- a/apps/frontend/app/[locale]/(sidebar)/search/components/CardGrid.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/search/components/CardGrid.tsx
@@ -288,12 +288,12 @@ function CreateServerDialog({
                         variant="outline"
                         className="w-full justify-between"
                       >
-                        {field.value === McpServerTypeEnum.Enum.STDIO
+                        {field.value === McpServerTypeEnum.enum.STDIO
                           ? "STDIO"
-                          : field.value === McpServerTypeEnum.Enum.SSE
+                          : field.value === McpServerTypeEnum.enum.SSE
                             ? "SSE"
                             : field.value ===
-                                McpServerTypeEnum.Enum.STREAMABLE_HTTP
+                                McpServerTypeEnum.enum.STREAMABLE_HTTP
                               ? "Streamable HTTP"
                               : t("search:dialog.form.placeholders.selectType")}
                         <ChevronDown className="ml-2 h-4 w-4" />
@@ -305,21 +305,21 @@ function CreateServerDialog({
                     >
                       <DropdownMenuItem
                         onClick={() =>
-                          field.onChange(McpServerTypeEnum.Enum.STDIO)
+                          field.onChange(McpServerTypeEnum.enum.STDIO)
                         }
                       >
                         STDIO
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={() =>
-                          field.onChange(McpServerTypeEnum.Enum.SSE)
+                          field.onChange(McpServerTypeEnum.enum.SSE)
                         }
                       >
                         SSE
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         onClick={() =>
-                          field.onChange(McpServerTypeEnum.Enum.STREAMABLE_HTTP)
+                          field.onChange(McpServerTypeEnum.enum.STREAMABLE_HTTP)
                         }
                       >
                         Streamable HTTP
@@ -373,7 +373,7 @@ function CreateServerDialog({
               )}
             />
 
-            {form.watch("type") === McpServerTypeEnum.Enum.STDIO && (
+            {form.watch("type") === McpServerTypeEnum.enum.STDIO && (
               <>
                 <FormField
                   control={form.control}
@@ -436,9 +436,9 @@ function CreateServerDialog({
               </>
             )}
 
-            {(form.watch("type") === McpServerTypeEnum.Enum.SSE ||
+            {(form.watch("type") === McpServerTypeEnum.enum.SSE ||
               form.watch("type") ===
-                McpServerTypeEnum.Enum.STREAMABLE_HTTP) && (
+                McpServerTypeEnum.enum.STREAMABLE_HTTP) && (
               <>
                 <FormField
                   control={form.control}
@@ -524,7 +524,7 @@ export default function CardGrid({ items }: { items: SearchIndex }) {
     const defaultValues: CreateServerFormData = {
       name: sanitizedName,
       description: item.description,
-      type: McpServerTypeEnum.Enum.STDIO,
+      type: McpServerTypeEnum.enum.STDIO,
       command: item.command,
       args: item.args?.join(" ") || "",
       url: "",

--- a/apps/frontend/components/edit-mcp-server.tsx
+++ b/apps/frontend/components/edit-mcp-server.tsx
@@ -151,7 +151,7 @@ export function EditMcpServer({
     defaultValues: {
       name: "",
       description: "",
-      type: McpServerTypeEnum.Enum.STDIO,
+      type: McpServerTypeEnum.enum.STDIO,
       command: "",
       args: "",
       url: "",
@@ -166,14 +166,14 @@ export function EditMcpServer({
   useEffect(() => {
     const subscription = editForm.watch((value, { name }) => {
       if (name === "type" && value.type) {
-        if (value.type === McpServerTypeEnum.Enum.STDIO) {
+        if (value.type === McpServerTypeEnum.enum.STDIO) {
           // Clear URL, bearer token, and headers when switching to stdio
           editForm.setValue("url", "");
           editForm.setValue("bearerToken", "");
           editForm.setValue("headers", "");
         } else if (
-          value.type === McpServerTypeEnum.Enum.SSE ||
-          value.type === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+          value.type === McpServerTypeEnum.enum.SSE ||
+          value.type === McpServerTypeEnum.enum.STREAMABLE_HTTP
         ) {
           // Clear command, args, and env when switching to sse or streamable_http
           editForm.setValue("command", "");
@@ -371,12 +371,12 @@ export function EditMcpServer({
                   className="w-full justify-between"
                   type="button"
                 >
-                  {editForm.watch("type") === McpServerTypeEnum.Enum.STDIO
+                  {editForm.watch("type") === McpServerTypeEnum.enum.STDIO
                     ? t("mcp-servers:stdio")
-                    : editForm.watch("type") === McpServerTypeEnum.Enum.SSE
+                    : editForm.watch("type") === McpServerTypeEnum.enum.SSE
                       ? t("mcp-servers:sse")
                       : editForm.watch("type") ===
-                          McpServerTypeEnum.Enum.STREAMABLE_HTTP
+                          McpServerTypeEnum.enum.STREAMABLE_HTTP
                         ? "Streamable HTTP"
                         : t("mcp-servers:selectType")}
                   <ChevronDown className="h-4 w-4" />
@@ -385,14 +385,14 @@ export function EditMcpServer({
               <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-[var(--radix-dropdown-menu-trigger-width)]">
                 <DropdownMenuItem
                   onClick={() =>
-                    editForm.setValue("type", McpServerTypeEnum.Enum.STDIO)
+                    editForm.setValue("type", McpServerTypeEnum.enum.STDIO)
                   }
                 >
                   {t("mcp-servers:stdio")}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() =>
-                    editForm.setValue("type", McpServerTypeEnum.Enum.SSE)
+                    editForm.setValue("type", McpServerTypeEnum.enum.SSE)
                   }
                 >
                   {t("mcp-servers:sse")}
@@ -401,7 +401,7 @@ export function EditMcpServer({
                   onClick={() =>
                     editForm.setValue(
                       "type",
-                      McpServerTypeEnum.Enum.STREAMABLE_HTTP,
+                      McpServerTypeEnum.enum.STREAMABLE_HTTP,
                     )
                   }
                 >
@@ -411,7 +411,7 @@ export function EditMcpServer({
             </DropdownMenu>
           </div>
 
-          {editForm.watch("type") === McpServerTypeEnum.Enum.STDIO && (
+          {editForm.watch("type") === McpServerTypeEnum.enum.STDIO && (
             <>
               <div className="flex flex-col gap-2">
                 <label htmlFor="edit-command" className="text-sm font-medium">
@@ -460,9 +460,9 @@ export function EditMcpServer({
             </>
           )}
 
-          {(editForm.watch("type") === McpServerTypeEnum.Enum.SSE ||
+          {(editForm.watch("type") === McpServerTypeEnum.enum.SSE ||
             editForm.watch("type") ===
-              McpServerTypeEnum.Enum.STREAMABLE_HTTP) && (
+              McpServerTypeEnum.enum.STREAMABLE_HTTP) && (
             <>
               <div className="flex flex-col gap-2">
                 <label htmlFor="edit-url" className="text-sm font-medium">

--- a/apps/frontend/hooks/useConnection.ts
+++ b/apps/frontend/hooks/useConnection.ts
@@ -114,7 +114,7 @@ export function useConnection({
       enabled: enabled,
     });
 
-  const pushHistory = useMemoizedFn((request: object, response?: object) => {
+  const pushHistory = useMemoizedFn((request: object, response?: unknown) => {
     setRequestHistory((prev) => [
       ...prev,
       {
@@ -124,6 +124,11 @@ export function useConnection({
     ]);
   });
 
+  // useMemoizedFn (ahooks) erases the generic <T> from the wrapped function's
+  // type, collapsing makeRequest's return to Promise<unknown> and breaking
+  // schema-inferred call sites (zod 4 tightened output<T> from any to
+  // unknown). The memoized function's runtime behavior is unchanged, so we
+  // cast back to the real generic signature it implements.
   const makeRequest = useMemoizedFn(
     async <T extends z.ZodType>(
       request: ClientRequest,
@@ -187,7 +192,11 @@ export function useConnection({
         throw e;
       }
     },
-  );
+  ) as <T extends z.ZodType>(
+    request: ClientRequest,
+    schema: T,
+    options?: RequestOptions & { suppressToast?: boolean },
+  ) => Promise<z.output<T>>;
 
   const handleCompletion = useMemoizedFn(
     async (
@@ -408,7 +417,7 @@ export function useConnection({
           };
         } else {
           switch (transportType) {
-            case McpServerTypeEnum.Enum.STDIO:
+            case McpServerTypeEnum.enum.STDIO:
               mcpProxyServerUrl = new URL(
                 `/mcp-proxy/server/stdio`,
                 getAppUrl(),
@@ -443,7 +452,7 @@ export function useConnection({
               };
               break;
 
-            case McpServerTypeEnum.Enum.SSE:
+            case McpServerTypeEnum.enum.SSE:
               mcpProxyServerUrl = new URL(`/mcp-proxy/server/sse`, getAppUrl());
               mcpProxyServerUrl.searchParams.append("url", url);
               transportOptions = {
@@ -472,7 +481,7 @@ export function useConnection({
               };
               break;
 
-            case McpServerTypeEnum.Enum.STREAMABLE_HTTP:
+            case McpServerTypeEnum.enum.STREAMABLE_HTTP:
               mcpProxyServerUrl = new URL(`/mcp-proxy/server/mcp`, getAppUrl());
               mcpProxyServerUrl.searchParams.append("url", url);
               transportOptions = {
@@ -542,7 +551,7 @@ export function useConnection({
         try {
           const transport = isMetaMCP
             ? new SSEClientTransport(mcpProxyServerUrl, transportOptions)
-            : transportType === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+            : transportType === McpServerTypeEnum.enum.STREAMABLE_HTTP
               ? new StreamableHTTPClientTransport(mcpProxyServerUrl, {
                   sessionId: undefined,
                   ...transportOptions,
@@ -617,7 +626,7 @@ export function useConnection({
   const disconnect = useMemoizedFn(async () => {
     try {
       if (
-        transportType === McpServerTypeEnum.Enum.STREAMABLE_HTTP &&
+        transportType === McpServerTypeEnum.enum.STREAMABLE_HTTP &&
         clientTransport
       ) {
         await (

--- a/apps/frontend/lib/validation-utils.ts
+++ b/apps/frontend/lib/validation-utils.ts
@@ -11,6 +11,8 @@ const issueCodeToTranslationKey: Record<string, string> = {
   required_error: "validation:required",
   invalid_type: "validation:invalidFormat",
   invalid_string: "validation:invalidFormat",
+  // zod 4 renamed the string-format issue code invalid_string -> invalid_format
+  invalid_format: "validation:invalidFormat",
   too_small: "validation:minLength",
   too_big: "validation:maxLength",
   invalid_url: "validation:urlFormat",
@@ -58,22 +60,24 @@ export function translateZodIssue(
 
   // Handle specific issue codes with parameters
   switch (issue.code) {
+    // zod 4 dropped .type on too_small/too_big issues; guard on the bound
+    // property directly instead of the removed .type discriminant.
     case "too_small":
-      if (issue.type === "string") {
+      if ("minimum" in issue) {
         return t("validation:minLength", { min: issue.minimum });
       }
       break;
     case "too_big":
-      if (issue.type === "string") {
+      if ("maximum" in issue) {
         return t("validation:maxLength", { max: issue.maximum });
       }
       break;
-    case "invalid_string":
-      if (issue.validation === "email") {
-        return t("validation:email");
-      }
-      if (issue.validation === "url") {
-        return t("validation:urlFormat");
+    // zod 4 renamed invalid_string -> invalid_format and exposes the format
+    // name on issue.format (was issue.validation in zod 3).
+    case "invalid_format":
+      if ("format" in issue) {
+        if (issue.format === "email") return t("validation:email");
+        if (issue.format === "url") return t("validation:urlFormat");
       }
       break;
     case "custom":

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@better-fetch/fetch": "^1.3.1",
     "@hookform/resolvers": "^5.1.1",
-    "@modelcontextprotocol/sdk": "1.16.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dialog": "^1.1.14",
@@ -55,7 +55,7 @@
     "swr": "^2.3.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.18",
-    "zod": "^3.25.64",
+    "zod": "^4.4.3",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@repo/zod-types": "workspace:*",
     "@trpc/server": "^11.18.0",
-    "zod": "^3.25.64"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/zod-types/package.json
+++ b/packages/zod-types/package.json
@@ -21,7 +21,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/packages/zod-types/src/mcp-servers.zod.ts
+++ b/packages/zod-types/src/mcp-servers.zod.ts
@@ -1,9 +1,18 @@
 import { z } from "zod";
 
-export const McpServerTypeEnum = z.enum(["STDIO", "SSE", "STREAMABLE_HTTP"]);
-export const McpServerStatusEnum = z.enum(["ACTIVE", "INACTIVE"]);
+// zod 4 types z.enum(...).options as a plain string[] rather than the
+// readonly literal tuple zod 3 produced. Drizzle's pgEnum needs a non-empty
+// literal tuple ([string, ...string[]]) to infer its column as the literal
+// union, so we keep the values as `as const` tuples and build both the zod
+// enum and the drizzle pgEnum from the same single source of truth.
+export const MCP_SERVER_TYPES = ["STDIO", "SSE", "STREAMABLE_HTTP"] as const;
+export const MCP_SERVER_STATUSES = ["ACTIVE", "INACTIVE"] as const;
+export const MCP_SERVER_ERROR_STATUSES = ["NONE", "ERROR"] as const;
 
-export const McpServerErrorStatusEnum = z.enum(["NONE", "ERROR"]);
+export const McpServerTypeEnum = z.enum(MCP_SERVER_TYPES);
+export const McpServerStatusEnum = z.enum(MCP_SERVER_STATUSES);
+
+export const McpServerErrorStatusEnum = z.enum(MCP_SERVER_ERROR_STATUSES);
 
 // Define the form schema (includes UI-specific fields)
 export const createServerFormSchema = z
@@ -29,7 +38,7 @@ export const createServerFormSchema = z
   .refine(
     (data) => {
       // Command is required for stdio type
-      if (data.type === McpServerTypeEnum.Enum.STDIO) {
+      if (data.type === McpServerTypeEnum.enum.STDIO) {
         return data.command && data.command.trim() !== "";
       }
       return true;
@@ -43,8 +52,8 @@ export const createServerFormSchema = z
     (data) => {
       // URL is required for SSE and Streamable HTTP types
       if (
-        data.type === McpServerTypeEnum.Enum.SSE ||
-        data.type === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+        data.type === McpServerTypeEnum.enum.SSE ||
+        data.type === McpServerTypeEnum.enum.STREAMABLE_HTTP
       ) {
         if (!data.url || data.url.trim() === "") {
           return false;
@@ -91,7 +100,7 @@ export const EditServerFormSchema = z
   .refine(
     (data) => {
       // Command is required for stdio type
-      if (data.type === McpServerTypeEnum.Enum.STDIO) {
+      if (data.type === McpServerTypeEnum.enum.STDIO) {
         return data.command && data.command.trim() !== "";
       }
       return true;
@@ -105,8 +114,8 @@ export const EditServerFormSchema = z
     (data) => {
       // URL is required for SSE and Streamable HTTP types
       if (
-        data.type === McpServerTypeEnum.Enum.SSE ||
-        data.type === McpServerTypeEnum.Enum.STREAMABLE_HTTP
+        data.type === McpServerTypeEnum.enum.SSE ||
+        data.type === McpServerTypeEnum.enum.STREAMABLE_HTTP
       ) {
         if (!data.url || data.url.trim() === "") {
           return false;
@@ -146,10 +155,10 @@ export const CreateMcpServerRequestSchema = z
     type: McpServerTypeEnum,
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
-    env: z.record(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
     url: z.string().optional(),
     bearerToken: z.string().optional(),
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     user_id: z.string().nullable().optional(),
   })
   .refine(
@@ -184,11 +193,11 @@ export const McpServerSchema = z.object({
   type: McpServerTypeEnum,
   command: z.string().nullable(),
   args: z.array(z.string()),
-  env: z.record(z.string()),
+  env: z.record(z.string(), z.string()),
   url: z.string().nullable(),
   created_at: z.string(),
   bearerToken: z.string().nullable(),
-  headers: z.record(z.string()),
+  headers: z.record(z.string(), z.string()),
   user_id: z.string().nullable(),
   error_status: McpServerErrorStatusEnum.optional(),
 });
@@ -216,9 +225,9 @@ export const BulkImportMcpServerSchema = z
   .object({
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
-    env: z.record(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
     url: z.string().optional(),
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     description: z.string().optional(),
     type: z
       .string()
@@ -242,10 +251,10 @@ export const BulkImportMcpServerSchema = z
   })
   .refine(
     (data) => {
-      const serverType = data.type || McpServerTypeEnum.Enum.STDIO;
+      const serverType = data.type || McpServerTypeEnum.enum.STDIO;
 
       // For STDIO type, URL can be empty
-      if (serverType === McpServerTypeEnum.Enum.STDIO) {
+      if (serverType === McpServerTypeEnum.enum.STDIO) {
         return true;
       }
 
@@ -269,7 +278,7 @@ export const BulkImportMcpServerSchema = z
   );
 
 export const BulkImportMcpServersRequestSchema = z.object({
-  mcpServers: z.record(BulkImportMcpServerSchema),
+  mcpServers: z.record(z.string(), BulkImportMcpServerSchema),
 });
 
 export const BulkImportMcpServersResponseSchema = z.object({
@@ -328,10 +337,10 @@ export const UpdateMcpServerRequestSchema = z
     type: McpServerTypeEnum,
     command: z.string().optional(),
     args: z.array(z.string()).optional(),
-    env: z.record(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
     url: z.string().optional(),
     bearerToken: z.string().optional(),
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     user_id: z.string().nullable().optional(),
   })
   .refine(
@@ -398,10 +407,10 @@ export const McpServerCreateInputSchema = z.object({
   type: McpServerTypeEnum,
   command: z.string().nullable().optional(),
   args: z.array(z.string()).optional(),
-  env: z.record(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
   url: z.string().nullable().optional(),
   bearerToken: z.string().nullable().optional(),
-  headers: z.record(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
   user_id: z.string().nullable().optional(),
 });
 
@@ -422,10 +431,10 @@ export const McpServerUpdateInputSchema = z.object({
   type: McpServerTypeEnum.optional(),
   command: z.string().nullable().optional(),
   args: z.array(z.string()).optional(),
-  env: z.record(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
   url: z.string().nullable().optional(),
   bearerToken: z.string().nullable().optional(),
-  headers: z.record(z.string()).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
   user_id: z.string().nullable().optional(),
 });
 
@@ -440,12 +449,12 @@ export const DatabaseMcpServerSchema = z.object({
   type: McpServerTypeEnum,
   command: z.string().nullable(),
   args: z.array(z.string()),
-  env: z.record(z.string()),
+  env: z.record(z.string(), z.string()),
   url: z.string().nullable(),
   error_status: McpServerErrorStatusEnum,
   created_at: z.date(),
   bearerToken: z.string().nullable(),
-  headers: z.record(z.string()),
+  headers: z.record(z.string(), z.string()),
   user_id: z.string().nullable(),
 });
 

--- a/packages/zod-types/src/metamcp.zod.ts
+++ b/packages/zod-types/src/metamcp.zod.ts
@@ -9,18 +9,18 @@ export const ServerParametersSchema = z.object({
   uuid: z.string(),
   name: z.string(),
   description: z.string(),
-  type: McpServerTypeEnum.optional().default(McpServerTypeEnum.Enum.STDIO),
+  type: McpServerTypeEnum.optional().default(McpServerTypeEnum.enum.STDIO),
   command: z.string().nullable().optional(),
   args: z.array(z.string()).nullable().optional(),
-  env: z.record(z.string()).nullable().optional(),
-  stderr: IOTypeSchema.optional().default(IOTypeSchema.Enum.ignore),
+  env: z.record(z.string(), z.string()).nullable().optional(),
+  stderr: IOTypeSchema.optional().default(IOTypeSchema.enum.ignore),
   url: z.string().nullable().optional(),
   created_at: z.string(),
   status: z.string(),
   error_status: z.string().optional(),
   oauth_tokens: OAuthTokensSchema.nullable().optional(),
   bearerToken: z.string().nullable().optional(),
-  headers: z.record(z.string()).nullable().optional(),
+  headers: z.record(z.string(), z.string()).nullable().optional(),
 });
 
 export type ServerParameters = z.infer<typeof ServerParametersSchema>;

--- a/packages/zod-types/src/namespaces.zod.ts
+++ b/packages/zod-types/src/namespaces.zod.ts
@@ -7,7 +7,7 @@ import {
 } from "./mcp-servers.zod";
 import { ToolSchema, ToolStatusEnum } from "./tools.zod";
 
-const ToolAnnotationsSchema = z.record(z.unknown());
+const ToolAnnotationsSchema = z.record(z.string(), z.unknown());
 
 // Namespace schema definitions
 export const createNamespaceFormSchema = z.object({
@@ -165,7 +165,7 @@ export const RefreshNamespaceToolsRequestSchema = z.object({
     z.object({
       name: z.string(), // This will contain "ServerName__toolName" format
       description: z.string().optional(),
-      inputSchema: z.record(z.any()),
+      inputSchema: z.record(z.string(), z.any()),
       // Remove serverUuid since we'll resolve it from the tool name
     }),
   ),
@@ -299,9 +299,9 @@ export const DatabaseNamespaceServerSchema = z.object({
   command: z.string().nullable(),
   args: z.array(z.string()),
   url: z.string().nullable(),
-  env: z.record(z.string()),
+  env: z.record(z.string(), z.string()),
   bearerToken: z.string().nullable(),
-  headers: z.record(z.string()),
+  headers: z.record(z.string(), z.string()),
   created_at: z.date(),
   user_id: z.string().nullable(),
   status: McpServerStatusEnum,
@@ -319,7 +319,7 @@ export const DatabaseNamespaceToolSchema = z.object({
   description: z.string().nullable(),
   toolSchema: z.object({
     type: z.literal("object"),
-    properties: z.record(z.any()).optional(),
+    properties: z.record(z.string(), z.any()).optional(),
   }),
   created_at: z.date(),
   updated_at: z.date(),

--- a/packages/zod-types/src/tools.zod.ts
+++ b/packages/zod-types/src/tools.zod.ts
@@ -12,7 +12,7 @@ export const ToolSchema = z.object({
   description: z.string().nullable(),
   toolSchema: z.object({
     type: z.literal("object"),
-    properties: z.record(z.any()).optional(),
+    properties: z.record(z.string(), z.any()).optional(),
     required: z.array(z.string()).optional(),
   }),
   created_at: z.string().datetime(),
@@ -42,7 +42,7 @@ export const CreateToolRequestSchema = z.object({
       description: z.string().optional(),
       inputSchema: z.object({
         type: z.literal("object").optional(),
-        properties: z.record(z.any()).optional(),
+        properties: z.record(z.string(), z.any()).optional(),
         required: z.array(z.string()).optional(),
       }),
     }),
@@ -73,7 +73,7 @@ export const ToolCreateInputSchema = z.object({
   description: z.string().nullable().optional(),
   toolSchema: z.object({
     type: z.literal("object"),
-    properties: z.record(z.any()).optional(),
+    properties: z.record(z.string(), z.any()).optional(),
     required: z.array(z.string()).optional(),
   }),
   mcp_server_uuid: z.string(),
@@ -86,7 +86,7 @@ export const ToolUpsertInputSchema = z.object({
       description: z.string().nullable().optional(),
       inputSchema: z
         .object({
-          properties: z.record(z.any()).optional(),
+          properties: z.record(z.string(), z.any()).optional(),
           required: z.array(z.string()).optional(),
         })
         .optional(),
@@ -106,7 +106,7 @@ export const DatabaseToolSchema = z.object({
   description: z.string().nullable(),
   toolSchema: z.object({
     type: z.literal("object"),
-    properties: z.record(z.any()).optional(),
+    properties: z.record(z.string(), z.any()).optional(),
     required: z.array(z.string()).optional(),
   }),
   created_at: z.date(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   apps/backend:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@repo/trpc':
         specifier: workspace:*
         version: link:../../packages/trpc
@@ -99,8 +99,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.2
       zod:
-        specifier: ^3.25.64
-        version: 3.25.64
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -160,8 +160,8 @@ importers:
         specifier: ^5.1.1
         version: 5.1.1(react-hook-form@7.58.0(react@19.1.2))
       '@modelcontextprotocol/sdk':
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.1.2(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
@@ -283,8 +283,8 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18
       zod:
-        specifier: ^3.25.64
-        version: 3.25.64
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.6
         version: 5.0.6(@types/react@19.1.2)(react@19.1.2)(use-sync-external-store@1.5.0(react@19.1.2))
@@ -371,8 +371,8 @@ importers:
         specifier: ^11.18.0
         version: 11.18.0(typescript@5.8.2)
       zod:
-        specifier: ^3.25.64
-        version: 3.25.64
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -395,8 +395,8 @@ importers:
   packages/zod-types:
     dependencies:
       zod:
-        specifier: ^3.23.8
-        version: 3.25.64
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -914,6 +914,12 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.1.1':
     resolution: {integrity: sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==}
     peerDependencies:
@@ -1102,9 +1108,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/sdk@1.16.0':
-    resolution: {integrity: sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@next/env@15.5.18':
     resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
@@ -2144,8 +2156,19 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2801,8 +2824,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@7.5.1:
-    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2830,6 +2853,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3012,6 +3038,10 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hono@4.12.30:
+    resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3053,6 +3083,10 @@ packages:
   intersection-observer@0.12.2:
     resolution: {integrity: sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==}
     deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3243,6 +3277,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3803,6 +3843,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
@@ -4400,16 +4444,13 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
-  zod-to-json-schema@3.25.0:
-    resolution: {integrity: sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.25.28 || ^4
 
-  zod@3.25.64:
-    resolution: {integrity: sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==}
-
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.6:
     resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
@@ -4455,50 +4496,50 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)':
+  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.43.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.7(zod@3.25.64)
+      better-call: 1.3.7(zod@4.4.3)
       jose: 6.1.3
       kysely: 0.29.3
       nanostores: 1.4.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))':
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       drizzle-orm: 0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0)
 
-  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.3
 
-  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -4746,6 +4787,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.30)':
+    dependencies:
+      hono: 4.12.30
+
   '@hookform/resolvers@5.1.1(react-hook-form@7.58.0(react@19.1.2))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -4891,20 +4936,25 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.16.0':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      ajv: 6.15.0
+      '@hono/node-server': 1.19.14(hono@4.12.30)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.30
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.64
-      zod-to-json-schema: 3.25.0(zod@3.25.64)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5897,12 +5947,23 @@ snapshots:
       screenfull: 5.2.0
       tslib: 2.8.1
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -6001,23 +6062,23 @@ snapshots:
 
   better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))(next@15.5.18(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(pg@8.16.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(vitest@4.1.10(@types/node@20.19.1)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@20.19.1)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.0))):
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.0.1
-      better-call: 1.3.7(zod@3.25.64)
+      better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.1.3
       kysely: 0.29.3
       nanostores: 1.4.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0)
@@ -6032,23 +6093,23 @@ snapshots:
 
   better-auth@1.6.23(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))(next@15.5.18(react-dom@19.1.2(react@19.1.2))(react@19.1.2))(pg@8.16.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(vitest@4.1.10(@types/node@22.15.3)(@vitest/coverage-v8@4.1.10)(vite@7.3.6(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.0))):
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.1.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.0.1
-      better-call: 1.3.7(zod@3.25.64)
+      better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.1.3
       kysely: 0.29.3
       nanostores: 1.4.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@types/pg@8.15.4)(kysely@0.29.3)(pg@8.16.0)
@@ -6061,14 +6122,14 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.7(zod@3.25.64):
+  better-call@1.3.7(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.1.2
     optionalDependencies:
-      zod: 3.25.64
+      zod: 4.4.3
 
   body-parser@2.2.2:
     dependencies:
@@ -6618,9 +6679,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@7.5.1(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -6678,6 +6740,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.3: {}
 
   fastq@1.19.1:
     dependencies:
@@ -6868,6 +6932,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hono@4.12.30: {}
+
   html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
@@ -6904,6 +6970,8 @@ snapshots:
       side-channel: 1.1.1
 
   intersection-observer@0.12.2: {}
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -7086,6 +7154,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -7603,6 +7675,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resize-observer-polyfill@1.5.1: {}
 
@@ -8333,13 +8407,11 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
-  zod-to-json-schema@3.25.0(zod@3.25.64):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.64
+      zod: 4.4.3
 
-  zod@3.25.64: {}
-
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zustand@5.0.6(@types/react@19.1.2)(react@19.1.2)(use-sync-external-store@1.5.0(react@19.1.2)):
     optionalDependencies:


### PR DESCRIPTION
## What

Bumps `@modelcontextprotocol/sdk` **1.16.0 → 1.29.0** (`apps/backend`, `apps/frontend`) to clear all 9 open HIGH Dependabot alerts. The SDK's schemas carry zod-4 internal markers while its public generics are checked against the local zod, so the SDK bump only type-checks once the repo is also on zod 4 — this PR migrates the whole monorepo **zod ^3 → ^4.4.3** (`@repo/zod-types`, `@repo/trpc`, `backend`, `frontend`).

Reference: the `Janhouse/metamcp` fork did this same dependency line; its migration commit was studied for breaking-change patterns, not blind cherry-picked (our fork has diverged — e.g. it never type-checks its backend, so it never hit the pgEnum or session-recovery issues below).

## Alerts this merge clears

All 9 open HIGH alerts are `@modelcontextprotocol/sdk` (3 GHSAs × 3 manifests). 1.29.0 is ≥ every patched version (1.24.0 / 1.25.2 / 1.26.0):

| GHSA | Patched | Manifests (alert #) |
|---|---|---|
| GHSA-w48q-cv73-mx4w | 1.24.0 | backend #1, frontend #5, lock #15 |
| GHSA-8r9q-7v3j-jr4g | 1.25.2 | backend #2, frontend #6, lock #18 |
| GHSA-345p-7cg4-v4c7 | 1.26.0 | backend #3, frontend #7, lock #23 |

## zod 4 breaking-change classes touched

- **`z.record(value)` → `z.record(z.string(), value)`** — the single-arg overload was removed in zod 4. Applied to env/headers/tool-schema maps in `@repo/zod-types`. Semantics preserved (`Record<string, T>`).
- **`.Enum` accessor → `.enum`** (111 sites) — zod 4 removed `.Enum`/`.Values`. Runtime-verified: v4 `.enum.STDIO === "STDIO"` and `.Enum` is now `undefined`, so this was a **runtime** fix (the old code would throw), not cosmetic.
- **`z.enum(...).options` widened from a literal tuple to `string[]`** — this broke drizzle `pgEnum`'s literal-union inference and cascaded into ~20 backend repo type errors (`type: string` vs the `"STDIO"|"SSE"|...` union). Fixed at the source: enum values now live as `as const` tuples (`MCP_SERVER_TYPES` / `MCP_SERVER_STATUSES` / `MCP_SERVER_ERROR_STATUSES`) feeding **both** the zod enum and the drizzle `pgEnum` from one source of truth.
- **`ZodError.issues` shape** (`validation-utils.ts`) — `invalid_string` → `invalid_format` (format name now on `issue.format`); `too_small`/`too_big` dropped `.type` (guard on `minimum`/`maximum` presence instead).

## MCP SDK 1.29 breaking-change classes touched

- **`ClientCapabilities` is now strict** — `prompts`/`resources`/`tools` were only ever *server* capabilities and are stripped by the SDK, so the downstream client now advertises `{}` (exact wire-equivalent; behaviour preserved). Mirrored in `client.test.ts`.
- **`ContentBlock` is a discriminated union** — narrow by `type` before reading `.text` (openapi `tool-execution.ts`) and `text`/`blob` on `EmbeddedResource` (`inspector-prompts.tsx`).
- **`StreamableHTTPServerTransport` is now a wrapper** delegating session state to an inner `_webStandardTransport`. The **lazy session-recovery hydration** — which prevents the claude.ai MCP connector from wedging with `-32600` on the first request after a gateway restart — and its startup contract check are ported to the inner transport. The no-mock test is rewritten against 1.29's `Request → Response | undefined` `validateSession`. This is the load-bearing runtime path; **230 backend tests green**.
- **`useMemoizedFn` (ahooks) erases `makeRequest`'s generic `<T>`** — cast the memoized fn back to its real signature so schema-inferred return types survive (zod 4 tightened `output<T>` from `any` to `unknown`). Chosen over the reference fork's `any`-spread to keep call-site type safety.

## better-auth

`better-auth` 1.6.23 (installed) already depends on `zod ^4.3.6`, which `^4.4.3` satisfies — **no better-auth bump needed**.

## Local gates (CI does not run on `pull_request` — verified locally)

- `pnpm install` — clean (peer warnings for `@trpc/react-query` / `next-runtime-env` are pre-existing, unrelated).
- `pnpm run build --force` (turbo, incl. `next build`) — **exit 0**, 4/4 tasks.
- `pnpm run check-types` (turbo) — **exit 0**.
- `apps/backend` `tsc --noEmit` — **0 errors** (backend builds via tsup/esbuild, which strips types; run explicitly because this is the live gateway).
- `apps/backend` `vitest run` — **230 passed** (18 files), including the rewritten session-recovery hydration test.

**Lint (`--max-warnings 0`) is intentionally not a gate** per `umbrella-build.yml` — the frontend (22) and backend (36) have pre-existing eslint warnings on `umbrella` (documented in the workflow). Verified via stash: baseline counts are identical to this branch, so **this PR introduces zero new lint warnings**. (`check-types` is now green, incidentally clearing the pre-existing `trpc.ts` type error the CI note references.)

## Notes

- Patch-table row lands in the follow-up docs PR (per lane instructions — `UMBRELLA_FORK.md` untouched here to avoid same-file conflicts).
- Not merged — mergeable and left for operator review.

https://claude.ai/code/session_01TutDdZ9F32tZHx3ajYMsKN
