### PR TITLE
fix(rbac): promote CI sync account (engineers@) to admin (migration 0022)

### DIFF
--- a/apps/backend/drizzle/0022_promote_ci_admin.sql
+++ b/apps/backend/drizzle/0022_promote_ci_admin.sql
@@ -1,0 +1,19 @@
+-- Promote the CI / GitHub-Actions sync service account to admin. The
+-- `metamcp-sync` workflow (Umbrella-MCP-Server) signs in as
+-- engineers@umbrellaitgroup.com (METAMCP_ADMIN_EMAIL) and drives the
+-- admin-gated tRPC mutations added in 0020 / #68 (mcpServers.update,
+-- namespaces/endpoints/api-keys CRUD). 0020 promotes ONLY alex@, so without
+-- this the sync account defaults to 'member' and every registration sync fails
+-- with FORBIDDEN "This action requires an administrator role." (observed on
+-- prod 2026-07-17: frontend.mcpServers.update 403 on the autotask server row).
+--
+-- Applied live on prod 2026-07-17 via break-glass; this migration CODIFIES it
+-- so a database rebuild re-asserts the CI account's admin role instead of
+-- silently regressing the sync. Keep this list in sync with the accounts the
+-- CI actually uses; add a new statement rather than editing this one.
+--
+-- Idempotent by email (users.email is UNIQUE → touches at most one row);
+-- re-running only re-asserts the role. FRESH INSTALL: the row may not exist yet
+-- (better-auth creates it on first sign-in), so this matches zero rows — an
+-- intentional no-op, re-asserted on the account's next boot after sign-up.
+UPDATE "users" SET "role" = 'admin' WHERE "email" = 'engineers@umbrellaitgroup.com';

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1784678400000,
       "tag": "0021_api_keys_last_used_at",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1784764800000,
+      "tag": "0022_promote_ci_admin",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Why
PR #68 added the `users.role` RBAC gate; `mcpServers.update` (and namespaces/endpoints/api-keys/config mutations) now require `role = 'admin'` via `adminProcedure`. Migration `0020` promotes ONLY `alex@umbrellaitgroup.com`, so the `metamcp-sync` CI account — `engineers@umbrellaitgroup.com` (`METAMCP_ADMIN_EMAIL`) — was left `member`. Result: the CI authenticates fine but every server-registration sync 403s `"This action requires an administrator role."` (observed on prod 2026-07-17: `frontend.mcpServers.update` on the `autotask` server row).

## What changed
- `apps/backend/drizzle/0022_promote_ci_admin.sql` — idempotent `UPDATE users SET role='admin' WHERE email='engineers@umbrellaitgroup.com'`, mirroring `0020`'s pattern + idempotency/fresh-install notes.
- `apps/backend/drizzle/meta/_journal.json` — journal entry `idx 22`.

## Applied live
The promotion was applied to prod on 2026-07-17 via break-glass (verified: `metamcp-sync` run now green end-to-end). This migration **codifies** that live change so a DB rebuild re-asserts it — without it, a rebuild reverts `engineers@` to `member` and the CI regresses.

## Test plan
Idempotent data migration (no schema change → no snapshot, per fork convention for `0018`–`0021`). No-op on the current prod DB (`engineers@` already admin). Applies via `drizzle-kit migrate` in `docker-entrypoint.sh` on next deploy.

## Upstream candidate?
No — Umbrella-specific service-account identity.