### PR TITLE
fix(rate-limit): key limiter on namespace_uuid, not on has(key) (upstream #258 slice)

### DIFF
--- a/apps/backend/src/lib/rate-limit.test.ts
+++ b/apps/backend/src/lib/rate-limit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for `SlidingWindowRateLimiting.onRequest`.
+ *
+ * Regression test for the has(key) vs has(namespace_uuid) defect ported
+ * from upstream metamcp PR #258 (elvus, "rate-limit-and-deps", commit
+ * adc1e7ee73b0e59e18179ca4b463d4b7f43d5acb): the per-client inner Map is
+ * keyed by `namespace_uuid` (see the `new Map().set(namespace_uuid, ...)`
+ * a few lines above), but the reuse check tested `limiter.has(key)` --
+ * looking for the client key inside a map whose keys are namespace UUIDs,
+ * which is essentially never true. That caused the already-tracked
+ * SlidingWindowRateLimiter for a namespace to be silently replaced (losing
+ * its accumulated request history) instead of reused, so the client rate
+ * limit was never enforced.
+ *
+ * The mock `backgroundIdleSessions` map below always reports "not yet
+ * initialized" (`has()` -> false), modeling the per-(namespace,client)
+ * init gate staying open on every call -- which mirrors the idle-session
+ * churn that repeatedly reopens it in production -- so the test isolates
+ * the has(key) defect itself rather than the gate's own churn semantics.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./metamcp/mcp-server-pool", () => ({
+  mcpServerPool: {
+    getBackgroundIdleSessionsByNamespace: vi.fn(),
+  },
+}));
+
+import { mcpServerPool } from "./metamcp/mcp-server-pool";
+import { RateLimitError, SlidingWindowRateLimiting } from "./rate-limit";
+
+const NAMESPACE_UUID = "ns-1111-1111";
+const CLIENT_KEY = "203.0.113.7";
+
+function makeContext() {
+  return {
+    req: {
+      endpoint: {
+        namespace_uuid: NAMESPACE_UUID,
+        client_max_rate: 2,
+        client_max_rate_seconds: 60,
+        client_max_rate_strategy: "ip",
+        client_max_rate_strategy_key: "x-forwarded-for",
+      },
+      socket: { remoteAddress: "unused" },
+      headers: { "x-forwarded-for": CLIENT_KEY },
+    },
+  };
+}
+
+function mockOpenIdleGate() {
+  // Per-namespace map: status is always "created" and has() always
+  // reports false, so the "not yet initialized for this client" gate in
+  // onRequest stays open on every call -- reproducing the production
+  // idle-session churn that repeatedly reopens it.
+  const perNamespace = {
+    get: (k: string) => (k === "status" ? "created" : undefined),
+    has: () => false,
+    set: vi.fn(),
+  };
+  const backgroundIdleSessions = new Map<string, any>([
+    [NAMESPACE_UUID, perNamespace],
+  ]);
+  (
+    mcpServerPool.getBackgroundIdleSessionsByNamespace as unknown as ReturnType<
+      typeof vi.fn
+    >
+  ).mockReturnValue(backgroundIdleSessions);
+}
+
+describe("SlidingWindowRateLimiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOpenIdleGate();
+  });
+
+  it("keys the per-client limiter map on namespace_uuid and reuses it across calls", async () => {
+    const rateLimiting = new SlidingWindowRateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    await rateLimiting.onRequest(makeContext() as any, callNext);
+    const limiterAfterFirstCall = (rateLimiting as any).limiters
+      .get(CLIENT_KEY)
+      ?.get(NAMESPACE_UUID);
+    expect(limiterAfterFirstCall).toBeDefined();
+
+    await rateLimiting.onRequest(makeContext() as any, callNext);
+    const limiterAfterSecondCall = (rateLimiting as any).limiters
+      .get(CLIENT_KEY)
+      ?.get(NAMESPACE_UUID);
+
+    // The fix keys the reuse check on namespace_uuid, so the SAME
+    // SlidingWindowRateLimiter instance -- and its accumulated request
+    // history -- must survive across calls for the same namespace.
+    expect(limiterAfterSecondCall).toBe(limiterAfterFirstCall);
+  });
+
+  it("enforces client_max_rate once the window fills for the same namespace", async () => {
+    const rateLimiting = new SlidingWindowRateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    // client_max_rate is 2: the first two calls must pass. The third
+    // must be rejected IF the limiter is reused (fix) -- with the
+    // has(key) bug present, every call gets a brand new limiter with an
+    // empty window, so the third call wrongly passes too and the limit
+    // is never hit.
+    await rateLimiting.onRequest(makeContext() as any, callNext);
+    await rateLimiting.onRequest(makeContext() as any, callNext);
+
+    await expect(
+      rateLimiting.onRequest(makeContext() as any, callNext),
+    ).rejects.toThrow(RateLimitError);
+
+    expect(callNext).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/lib/rate-limit.ts
+++ b/apps/backend/src/lib/rate-limit.ts
@@ -185,7 +185,13 @@ export class SlidingWindowRateLimiting {
             );
             limiter = this.limiters.get(key);
           } else {
-            if (!limiter.has(key)) {
+            // `limiter` is keyed by namespace_uuid (set above), not by the
+            // client key -- checking `.has(key)` here almost never matched,
+            // so this branch silently replaced the already-tracked
+            // SlidingWindowRateLimiter (and its accumulated request
+            // history) on every call, and the client rate limit was never
+            // enforced. Ported fix from upstream metamcp PR #258.
+            if (!limiter.has(namespace_uuid)) {
               limiter.set(
                 namespace_uuid,
                 new SlidingWindowRateLimiter(


### PR DESCRIPTION
## What

Slice of upstream metamcp PR #258 (elvus, `rate-limit-and-deps`, merge
504c470, sub-commit adc1e7ee). Takes ONLY the genuine rate-limiter
enforcement fix; drops the dependency bumps (SDK 1.26/pnpm10/zod
migration -- we're already on SDK 1.29 / zod v4), the devcontainer
postgres-port change, and the lockfile churn from #258.

## The bug

`SlidingWindowRateLimiting.onRequest` keeps its per-client limiters in
a `Map<namespace_uuid, SlidingWindowRateLimiter>` (see the
`new Map().set(namespace_uuid, ...)` a few lines above), but the reuse
check on the "already have a map for this client key" branch tested
`limiter.has(key)` -- `key` is the client identifier (IP / header),
never a namespace_uuid, so the check was essentially always true. Every
call that reached this branch silently replaced the already-tracked
`SlidingWindowRateLimiter` -- discarding its accumulated request
history -- instead of reusing it, so the per-client rate limit was
never actually enforced.

Fix: check `limiter.has(namespace_uuid)` instead, matching how the map
is actually keyed.

`rate-limit.middleware.ts` was inspected too (per upstream diff) but
contains no part of this bug -- its changes in #258 are an unrelated
refactor (module-level handler functions instead of factory closures,
503->429 status code change, a new `setInterval` cleanup job) and are
intentionally not ported in this slice.

## Test (red-before-green)

Added `apps/backend/src/lib/rate-limit.test.ts` with two tests against
`SlidingWindowRateLimiting`:

1. The per-client limiter instance for a given namespace is the SAME
   object across repeated calls (proves reuse, not recreation).
2. `client_max_rate` is actually enforced once the window fills for
   repeated calls to the same namespace (the 3rd call of a
   `max_rate=2` window throws `RateLimitError`).

Verified both fail against the pre-fix code and pass against the fix
by temporarily reverting the one-line change locally (`git stash`),
running the suite (red), then restoring it (green) -- see gate output
below.

## Gates (real output, this worktree)

- `pnpm --filter backend test` (after `pnpm --filter @repo/zod-types
  --filter @repo/trpc build` so the workspace package `dist/` entries
  resolve): **39 files / 388 tests passed**, including the 2 new
  tests.
- Red-before-green: reverted the fix locally -> both new tests failed
  (limiter identity changed across calls; 3rd call never rejected).
  Restored the fix -> both pass. Full suite green after restore.
- `pnpm check-types --force` (bypassing turbo's shared-worktree cache):
  `@repo/zod-types` + `frontend` check-types both pass. `backend` has
  no dedicated `check-types` script in this fork (type-checked via
  `tsup` build instead).
- `pnpm --filter backend build`: succeeds (tsup, dist/index.js
  619.72 KB).
- `pnpm --filter backend lint` (`eslint . --max-warnings 0`): **fails
  with 32 pre-existing warnings, 0 errors** -- verified this is a
  pre-existing baseline failure on `origin/umbrella` itself (stashed
  this PR's two changed files and re-ran lint: identical 32
  warnings/0 errors, same file set, same line numbers modulo the
  comment-line shift in `rate-limit.ts`). This PR's diff adds zero new
  lint warnings.

## Cherry-pick-log row (proposed, for the foreman's UMBRELLA_FORK.md pass)

| Upstream PR | Merge SHA | What we took | What we dropped | Our PR |
|---|---|---|---|---|
| #258 (elvus, rate-limit-and-deps) | 504c470 | Sliding-window rate limiter enforcement fix (`has(key)` -> `has(namespace_uuid)`) in `apps/backend/src/lib/rate-limit.ts` | SDK 1.26 migration + pnpm 9->10 + security override bumps (already on SDK 1.29/zod v4), devcontainer postgres-port sharing, lockfile churn, `rate-limit.middleware.ts` refactor (handler closures, 503->429, `setInterval` cleanup) | this PR |

## Out of scope / not wired

Per brief: the rate-limit module is already wired into the request
path in this fork (`sse.ts`, `streamable-http.ts` both import
`rateLimitMiddleware`) -- that wiring predates this PR and is
untouched here. This PR only corrects the enforcement bug in the
already-wired module; it does not add new wiring.