### PR TITLE
feat(docker): persist uv cache across container recreates (upstream #312)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update && apt-get install -y curl postgresql-client && apt-get clean
 # Create non-root user with proper home directory
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 --home /home/nextjs nextjs && \
-    mkdir -p /home/nextjs/.cache/node/corepack && \
+    mkdir -p /home/nextjs/.cache/node/corepack /home/nextjs/.cache/uv && \
     chown -R nextjs:nodejs /home/nextjs
 
 # Copy built applications

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,14 @@ services:
       postgres:
         condition: service_healthy
     restart: "no"
+    volumes:
+      # Persist the uv cache across container recreates. Without this, every
+      # `docker compose up -d`/recreate wipes the writable layer and the next
+      # `uvx <pkg>@latest` spawn for each STDIO server cold-installs from
+      # scratch — slow enough to trip the crash detector and stick the server
+      # in error_status=ERROR. The image ships /home/nextjs/.cache/uv owned by
+      # nextjs (uid 1001) so a fresh named volume inherits correct ownership.
+      - uv_cache:/home/nextjs/.cache/uv
     networks:
       - metamcp-network
 
@@ -190,6 +198,8 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
+  uv_cache:
     driver: local
 
 networks:


### PR DESCRIPTION
## Summary

Ports upstream `metatool-ai/metamcp` PR #312 (bobbyhyam, "persist uv cache across container recreates") — a clean full take, adapted to our Dockerfile/compose.

STDIO MCP servers launched via `uvx <pkg>@latest` cold-install their dependencies on first spawn. With no volume at the uv cache directory, every `docker compose up -d`/recreate wipes the writable layer and forces a cold install again — slow enough to trip the crash detector and stick the server in `error_status=ERROR`.

## Changes

- **`Dockerfile`** (runner stage): `mkdir -p` now also creates `/home/nextjs/.cache/uv` alongside the existing `.cache/node/corepack` dir, before the existing `chown -R nextjs:nodejs /home/nextjs`. A fresh named volume mounted at that path inherits ownership by uid 1001 (`nextjs`) on first mount instead of `root:root`.
- **`docker-compose.yml`**: new named volume `uv_cache` mounted at `/home/nextjs/.cache/uv` on the `app` service, declared under the top-level `volumes:` block (same pattern as the existing `postgres_data` volume).

Both hunks mirror upstream's own diff for the equivalent file — same directory, same volume name, same ownership rationale. Verified the pre-patch `docker-compose.yml` blob hash (`ef29813`) and post-patch blob hash (`75bc31e`) in our diff are byte-identical to upstream's diff for the same file — this file hadn't diverged from upstream at all before this change.

## Constituent-commit note (upstream grouping correction)

The brief for this port pointed at two upstream commits — `7e3d252` and `225f552` — as "constituent commits" of PR #312. I read both (`git show` on each) and traced ancestry: **only `7e3d252` is actually part of PR #312** (merge commit `ad68628`, single non-merge parent). `225f552` ("Self-heal server error_status on successful reconnect") is a *different*, separately-merged upstream PR — **#311** (`self-heal-error-status`, merge `42aa36f`) — by the same author, same day, thematically adjacent (also touches uvx cold-start timing) but a distinct backend behavior change (drops the early-return for ERROR-state servers in `connectMetaMcpClient`, raises `MCP_MAX_ATTEMPTS` default 1→3). Confirmed via `git merge-base --is-ancestor` and `git branch --all --contains` against both SHAs — neither is an ancestor of our `umbrella` HEAD, and each sits on a distinct upstream merge commit with a distinct PR number. This PR ports **only #312 / `7e3d252`** (the uv-cache volume), matching the PR title and the brief's actual scope (Dockerfile + compose). #311's self-heal/retry-count change is out of scope here — flagging it as a separate cherry-pick candidate if wanted, not bundling it into this diff.

## Proposed cherry-pick-log row (UMBRELLA_FORK.md — not edited in this PR)

For the foreman's docs PR, under "Cherry-pick log":

| Date | Source | Upstream PR | Commit on `umbrella` | Notes |
|---|---|---|---|---|
| 2026-07-21 | `bobbyhyam` | [#312](https://github.com/metatool-ai/metamcp/pull/312) | `<squash-sha-after-merge>` | Persist uv cache across container recreates — named volume `uv_cache` at `/home/nextjs/.cache/uv`, pre-created + chowned in the Dockerfile runner stage. Faithful port; `docker-compose.yml` hunk is byte-identical to upstream's. |

## Follow-up needed in the sibling repo (NOT done here)

Our actual prod compose lives in `Umbrella-MCP-Server/metamcp/compose.fragment.yml` (separate repo), not in this one — this repo's `docker-compose.yml` is the local/quickstart compose (pulls the published image, mirrors upstream's own file). **The `uv_cache` named volume + mount needs to be added to `compose.fragment.yml` for the running prod container (`mcp.umbrellaitgroup.com`) to actually benefit from this fix.** I did not touch that repo per scope. Filing this explicitly so it doesn't get lost: without that follow-up, this PR only fixes the Dockerfile's image-side prep (dir exists + owned correctly) but the prod deployment still won't have a volume mounted there, so the cache still won't persist across Watchtower-driven recreates.

Also noting, not acting on: `docker-compose.dev.yml` (builds via `Dockerfile.dev`, runs as root, full source bind-mounted) and `docker-compose.test.yml` (builds via this repo's `Dockerfile`, CI-oriented/ephemeral) were left untouched — the brief's scope was "any docker-compose.yml in THIS repo used for dev," which I read as the one file matching upstream's own naming/shape. Both are plausible candidates for the same volume as an optional follow-up; call it out if you want them included.

## Verification

- **Dockerfile syntax**: `docker build` on the legacy builder (no buildx/BuildKit available in this sandbox) parsed and enumerated all 52 build steps without error before starting the layer pull — a malformed Dockerfile fails at parse time, before any pull, so this confirms the modified `RUN`/`mkdir -p` line and surrounding COPY/RUN syntax are valid.
- **docker-compose.yml syntax + structure**: `docker compose` CLI plugin is not installed in this sandbox (no `~/.docker/cli-plugins/`, no standalone `docker-compose`), so validated via `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly; confirmed `services.app.volumes == ['uv_cache:/home/nextjs/.cache/uv']` and `volumes.uv_cache == {'driver': 'local'}` in the parsed structure.
- **Full `docker build`**: attempted for real (not skipped). Kicked off `docker build -t metamcp-uvcache-test:latest -f Dockerfile .` in the background. It ran 6.5 minutes and got through 3 of the base image's 5 layers (141MB of the 406MB `ghcr.io/astral-sh/uv:debian` image) before I stopped it — measured sustained network throughput was ~349 KB/s (two independent 5-8s samples), consistent and not stalled, just this sandbox's egress bandwidth to `ghcr.io` is slow enough that the base-image pull alone projects to ~12+ more minutes, before the `pnpm install`/`pnpm build` stages inside the container even start. Did not complete within a reasonable session window; killed cleanly (confirmed no orphaned containers/images via `docker ps -a` / `docker images`, network traffic dropped to baseline after kill). This is the sandbox constraint the brief anticipated ("if docker unavailable... at minimum lint...") — docker itself is available and functioning, but full-build verification isn't practical here in reasonable time. Reporting this honestly rather than claiming a completed build I didn't get.
- **pnpm gates** (unaffected by a Dockerfile/compose-only change, run anyway per instructions):
  - `pnpm install --frozen-lockfile` — clean, 681 packages resolved.
  - `pnpm build` (`turbo run build`) — 4/4 tasks successful.
  - `pnpm check-types` (`turbo run check-types`) — clean, 2/2 tasks (after `pnpm build` populated `@repo/zod-types`/`@repo/trpc` dist output; check-types alone fails on a fresh checkout without a prior build — pre-existing turbo task-graph gap, confirmed present on unmodified `origin/umbrella` too via a stash test, unrelated to this diff).
  - `pnpm lint` (`turbo run lint`) — `frontend#lint` fails on `--max-warnings 0` against pre-existing warnings in files this PR never touches (`layout.tsx`, `notifications-panel.tsx`, `tool-management.tsx`, `i18n.ts`, `validation-utils.ts`, `zod-resolver.ts`). Confirmed pre-existing lint debt, not introduced here — this PR's diff is Dockerfile + YAML only, outside ESLint's purview entirely.
  - `pnpm --filter backend test` (vitest) — **386 passed (38 files)**.

No behavior-changing source code in this diff (Dockerfile + docker-compose.yml only), so no new test was added — matches the nature of the change (build/deploy config, not application logic).
