### PR TITLE
feat(oauth): atomic sessions upsert + CSRF state validation (upstream #300/#301 slices)

### DIFF
--- a/apps/backend/drizzle/0023_oauth_expected_state.sql
+++ b/apps/backend/drizzle/0023_oauth_expected_state.sql
@@ -1,0 +1,12 @@
+-- OAuth CSRF defence (RFC 6749 §10.12): add oauth_sessions.expected_state, a
+-- per-flow random nonce minted by DbOAuthClientProvider.state() at the
+-- authorize redirect and validated against the upstream's echoed `state` at the
+-- callback (oauth.validateState) before the client-side token exchange runs. A
+-- successful match clears the column (one-shot) so a code+state pair can't be
+-- replayed. Nullable — in-flight flows started before this column existed read
+-- NULL and take the validator's back-compat accept branch; the column is seeded
+-- and enforced on their next authorize attempt.
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS) per fork convention. Ordering-safe
+-- relative to 0022 (independent object, no shared row/column).
+ALTER TABLE "oauth_sessions" ADD COLUMN IF NOT EXISTS "expected_state" text;

--- a/apps/backend/drizzle/0025_oauth_expected_state.sql
+++ b/apps/backend/drizzle/0025_oauth_expected_state.sql
@@ -8,5 +8,11 @@
 -- and enforced on their next authorize attempt.
 --
 -- Idempotent (ADD COLUMN IF NOT EXISTS) per fork convention. Ordering-safe
--- relative to 0022 (independent object, no shared row/column).
+-- relative to 0024 (independent object, no shared row/column).
+--
+-- Numbered 0025 (was 0023 when this branch was cut): #84 and #85 landed
+-- 0023/0024 on umbrella first. The rename alone is NOT enough — drizzle
+-- applies only journal entries whose `when` exceeds the max already applied,
+-- so this entry's `when` must stay STRICTLY above 0024's 1785283200000 or
+-- prod silently skips it and expected_state never materializes.
 ALTER TABLE "oauth_sessions" ADD COLUMN IF NOT EXISTS "expected_state" text;

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -180,8 +180,8 @@
     {
       "idx": 25,
       "version": "7",
-      "when": 1784851200000,
-      "tag": "0023_oauth_expected_state",
+      "when": 1785369600000,
+      "tag": "0025_oauth_expected_state",
       "breakpoints": true
     }
   ]

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1785283200000,
       "tag": "0024_api_key_acts_as_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1784851200000,
+      "tag": "0023_oauth_expected_state",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/oauth-sessions.repo.test.ts
+++ b/apps/backend/src/db/repositories/oauth-sessions.repo.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the `oauth_sessions` repository upsert contract.
+ *
+ * These run against an in-memory fake keyed by mcp_server_uuid that mimics
+ * `INSERT ... ON CONFLICT (mcp_server_uuid) DO UPDATE SET ...` and the
+ * `UPDATE ... WHERE mcp_server_uuid = ?` used by clearExpectedState. They pin:
+ *   - the upsert is a SINGLE atomic statement (no SELECT-then-INSERT race);
+ *   - concurrent callers for one server converge on ONE row instead of the
+ *     loser crashing on the unique constraint;
+ *   - the conditional spread never clears a column a partial update omits;
+ *   - expected_state (CSRF nonce) is written on upsert and cleared via the
+ *     dedicated NULL-write path.
+ * They do NOT exercise the postgres engine; the ON CONFLICT + NULL semantics
+ * themselves are a drizzle/postgres contract validated at deploy.
+ */
+
+import type {
+  OAuthClientInformation,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const valuesCalls: Record<string, unknown>[] = [];
+const onConflictSetCalls: Record<string, unknown>[] = [];
+const onConflictTargetCalls: unknown[] = [];
+const updateSetCalls: Record<string, unknown>[] = [];
+
+// In-memory store keyed by mcp_server_uuid.
+const store = new Map<string, Record<string, unknown>>();
+
+vi.mock("../index", () => ({
+  db: {
+    insert: () => ({
+      values: (values: Record<string, unknown>) => {
+        valuesCalls.push(values);
+        return {
+          onConflictDoUpdate: ({
+            target,
+            set,
+          }: {
+            target: unknown;
+            set: Record<string, unknown>;
+          }) => {
+            onConflictTargetCalls.push(target);
+            onConflictSetCalls.push(set);
+            return {
+              returning: async () => {
+                const key = values.mcp_server_uuid as string;
+                const now = new Date();
+                const existing = store.get(key);
+                if (existing) {
+                  // ON CONFLICT DO UPDATE: merge only the keys present in `set`.
+                  // Drop the sql`NOW()` updated_at the fake can't execute.
+                  const { updated_at: _ignored, ...applicable } = set;
+                  const updated = {
+                    ...existing,
+                    ...applicable,
+                    updated_at: now,
+                  };
+                  store.set(key, updated);
+                  return [updated];
+                }
+                const row = {
+                  uuid: `uuid-${store.size}`,
+                  mcp_server_uuid: values.mcp_server_uuid,
+                  client_information: values.client_information ?? {},
+                  tokens: values.tokens ?? null,
+                  code_verifier: values.code_verifier ?? null,
+                  expected_state: values.expected_state ?? null,
+                  created_at: now,
+                  updated_at: now,
+                };
+                store.set(key, row);
+                return [row];
+              },
+            };
+          },
+        };
+      },
+    }),
+    // Only clearExpectedState reaches update() in these tests. The WHERE clause
+    // is a real drizzle `eq(...)` object we can't introspect from the fake, so
+    // we apply the SET to every stored row — tests operate on a single server.
+    update: () => ({
+      set: (set: Record<string, unknown>) => {
+        updateSetCalls.push(set);
+        return {
+          where: () => ({
+            returning: async () => {
+              const now = new Date();
+              const { updated_at: _ignored, ...applicable } = set;
+              const rows: Record<string, unknown>[] = [];
+              for (const [key, row] of store) {
+                const updated = { ...row, ...applicable, updated_at: now };
+                store.set(key, updated);
+                rows.push(updated);
+              }
+              return rows;
+            },
+          }),
+        };
+      },
+    }),
+  },
+}));
+
+// schema.ts imports @repo/zod-types (a workspace package) plus every table;
+// stub only the columns the repo touches so the import graph stays satisfiable.
+vi.mock("../schema", () => ({
+  oauthSessionsTable: {
+    mcp_server_uuid: { name: "mcp_server_uuid" },
+    client_information: { name: "client_information" },
+    tokens: { name: "tokens" },
+    code_verifier: { name: "code_verifier" },
+    expected_state: { name: "expected_state" },
+    updated_at: { name: "updated_at" },
+  },
+}));
+
+const { OAuthSessionsRepository } = await import("./oauth-sessions.repo");
+
+describe("OAuthSessionsRepository.upsert", () => {
+  const repo = new OAuthSessionsRepository();
+  const serverId = "00000000-0000-0000-0000-000000000001";
+
+  beforeEach(() => {
+    store.clear();
+    valuesCalls.length = 0;
+    onConflictSetCalls.length = 0;
+    onConflictTargetCalls.length = 0;
+    updateSetCalls.length = 0;
+  });
+
+  it("uses a single ON CONFLICT statement (not check-then-insert)", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      client_information: { client_id: "client-A" } as OAuthClientInformation,
+    });
+
+    // Exactly one insert chain per call: this is what makes the upsert atomic
+    // and removes the SELECT-then-INSERT race window.
+    expect(valuesCalls).toHaveLength(1);
+    expect(onConflictSetCalls).toHaveLength(1);
+    expect(onConflictTargetCalls[0]).toBeDefined();
+  });
+
+  it("concurrent upserts for one server converge on a single row, no throw", async () => {
+    // The racy SELECT-then-INSERT crashed the loser with a unique-constraint
+    // violation. The atomic ON CONFLICT path must let every concurrent caller
+    // resolve against the same row.
+    const results = await Promise.all([
+      repo.upsert({
+        mcp_server_uuid: serverId,
+        client_information: { client_id: "A" } as OAuthClientInformation,
+      }),
+      repo.upsert({
+        mcp_server_uuid: serverId,
+        tokens: { access_token: "t", token_type: "Bearer" } as OAuthTokens,
+      }),
+      repo.upsert({
+        mcp_server_uuid: serverId,
+        code_verifier: "verifier",
+      }),
+    ]);
+
+    expect(results).toHaveLength(3);
+    for (const row of results) {
+      expect(row.mcp_server_uuid).toBe(serverId);
+    }
+    expect(store.size).toBe(1);
+  });
+
+  it("partial upsert with only tokens does not write code_verifier into the SET", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      tokens: { access_token: "tok", token_type: "Bearer" } as OAuthTokens,
+    });
+
+    const set = onConflictSetCalls[0];
+    expect(set).toHaveProperty("tokens");
+    expect(set).not.toHaveProperty("code_verifier");
+    expect(set).not.toHaveProperty("client_information");
+    expect(set).not.toHaveProperty("expected_state");
+  });
+
+  it("partial upsert with only code_verifier does not clear existing tokens", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      tokens: { access_token: "tok", token_type: "Bearer" } as OAuthTokens,
+    });
+    const second = await repo.upsert({
+      mcp_server_uuid: serverId,
+      code_verifier: "the-verifier",
+    });
+
+    expect(second.tokens).toEqual({
+      access_token: "tok",
+      token_type: "Bearer",
+    });
+    expect(second.code_verifier).toBe("the-verifier");
+
+    const setOnSecond = onConflictSetCalls[1];
+    expect(setOnSecond).toHaveProperty("code_verifier");
+    expect(setOnSecond).not.toHaveProperty("tokens");
+  });
+
+  it("writes expected_state on upsert and does not touch it on an unrelated update", async () => {
+    const withState = await repo.upsert({
+      mcp_server_uuid: serverId,
+      expected_state: "csrf-nonce",
+    });
+    expect(withState.expected_state).toBe("csrf-nonce");
+    expect(onConflictSetCalls[0]).toHaveProperty(
+      "expected_state",
+      "csrf-nonce",
+    );
+
+    // A later tokens-only upsert must leave expected_state intact (the guard
+    // that keeps the CSRF nonce alive until validation clears it).
+    const afterTokens = await repo.upsert({
+      mcp_server_uuid: serverId,
+      tokens: { access_token: "x", token_type: "Bearer" } as OAuthTokens,
+    });
+    expect(afterTokens.expected_state).toBe("csrf-nonce");
+    expect(onConflictSetCalls[1]).not.toHaveProperty("expected_state");
+  });
+});
+
+describe("OAuthSessionsRepository.clearExpectedState", () => {
+  const repo = new OAuthSessionsRepository();
+  const serverId = "00000000-0000-0000-0000-000000000002";
+
+  beforeEach(() => {
+    store.clear();
+    updateSetCalls.length = 0;
+  });
+
+  it("writes NULL to expected_state via an UPDATE (not the truthy-spread path)", async () => {
+    await repo.upsert({
+      mcp_server_uuid: serverId,
+      expected_state: "to-be-cleared",
+    });
+
+    const cleared = await repo.clearExpectedState(serverId);
+
+    expect(cleared?.expected_state).toBeNull();
+    // The SET must explicitly carry expected_state: null — the upsert spread
+    // could never produce this (a null value is elided by its `&&` guard).
+    expect(updateSetCalls[0]).toHaveProperty("expected_state", null);
+  });
+
+  it("returns undefined when no row exists for the server", async () => {
+    const result = await repo.clearExpectedState(
+      "00000000-0000-0000-0000-0000000000ff",
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/backend/src/db/repositories/oauth-sessions.repo.ts
+++ b/apps/backend/src/db/repositories/oauth-sessions.repo.ts
@@ -31,6 +31,9 @@ export class OAuthSessionsRepository {
         }),
         ...(input.tokens && { tokens: input.tokens }),
         ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        ...(input.expected_state && {
+          expected_state: input.expected_state,
+        }),
       })
       .returning();
 
@@ -48,6 +51,9 @@ export class OAuthSessionsRepository {
         }),
         ...(input.tokens && { tokens: input.tokens }),
         ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        ...(input.expected_state && {
+          expected_state: input.expected_state,
+        }),
         updated_at: sql`NOW()`,
       })
       .where(eq(oauthSessionsTable.mcp_server_uuid, input.mcp_server_uuid))
@@ -56,23 +62,68 @@ export class OAuthSessionsRepository {
     return updatedSession;
   }
 
-  async upsert(input: OAuthSessionUpdateInput): Promise<DatabaseOAuthSession> {
-    // Check if session exists
-    const existingSession = await this.findByMcpServerUuid(
-      input.mcp_server_uuid,
-    );
+  // Dedicated clear path for `expected_state`. The truthy-spread upsert below
+  // cannot write NULL through `input.expected_state` (a `null`/absent value is
+  // elided by the `&&` guard, which is what protects the other columns from
+  // being clobbered by a partial update), so the one-shot clear after the CSRF
+  // state is validated goes through this method instead. Returns the updated
+  // row, or undefined if no row exists for the server.
+  async clearExpectedState(
+    mcpServerUuid: string,
+  ): Promise<DatabaseOAuthSession | undefined> {
+    const [updatedSession] = await db
+      .update(oauthSessionsTable)
+      .set({
+        expected_state: null,
+        updated_at: sql`NOW()`,
+      })
+      .where(eq(oauthSessionsTable.mcp_server_uuid, mcpServerUuid))
+      .returning();
 
-    if (existingSession) {
-      // Update existing session
-      const updatedSession = await this.update(input);
-      if (!updatedSession) {
-        throw new Error("Failed to update OAuth session");
-      }
-      return updatedSession;
-    } else {
-      // Create new session
-      return await this.create(input);
+    return updatedSession;
+  }
+
+  async upsert(input: OAuthSessionUpdateInput): Promise<DatabaseOAuthSession> {
+    // Single-statement atomic upsert. Concurrent callers for the same
+    // mcp_server_uuid resolve via ON CONFLICT instead of racing a
+    // SELECT-then-INSERT, which previously crashed the loser of the race with
+    // a unique-constraint violation on oauth_sessions_unique_per_server_idx.
+    // Only fields present on `input` are written, so a partial update (e.g.
+    // tokens only) does not clear unrelated columns such as code_verifier.
+    const [row] = await db
+      .insert(oauthSessionsTable)
+      .values({
+        mcp_server_uuid: input.mcp_server_uuid,
+        ...(input.client_information && {
+          client_information: input.client_information,
+        }),
+        ...(input.tokens && { tokens: input.tokens }),
+        ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        ...(input.expected_state && {
+          expected_state: input.expected_state,
+        }),
+      })
+      .onConflictDoUpdate({
+        target: oauthSessionsTable.mcp_server_uuid,
+        set: {
+          ...(input.client_information && {
+            client_information: input.client_information,
+          }),
+          ...(input.tokens && { tokens: input.tokens }),
+          ...(input.code_verifier && { code_verifier: input.code_verifier }),
+          ...(input.expected_state && {
+            expected_state: input.expected_state,
+          }),
+          updated_at: sql`NOW()`,
+        },
+      })
+      .returning();
+
+    if (!row) {
+      throw new Error("Failed to upsert OAuth session");
     }
+
+    return row;
   }
 
   async deleteByMcpServerUuid(

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -100,6 +100,15 @@ export const oauthSessionsTable = pgTable(
       .default(sql`'{}'::jsonb`),
     tokens: jsonb("tokens").$type<OAuthTokens>(),
     code_verifier: text("code_verifier"),
+    // CSRF defence (RFC 6749 §10.12). A per-flow random nonce minted by
+    // DbOAuthClientProvider.state() at the authorize-redirect step, persisted
+    // here, and compared against the upstream's echoed `state` at the callback
+    // (oauth.validateState) before the client-side token exchange runs. Cleared
+    // on a successful match so a replay cannot reuse the same code+state pair.
+    // Nullable: rows from before this column existed, and rows already cleared,
+    // both read NULL. NEVER serialized to the frontend — the OAuth session
+    // serializer omits it.
+    expected_state: text("expected_state"),
     created_at: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/backend/src/trpc/admin-gate-sweep.test.ts
+++ b/apps/backend/src/trpc/admin-gate-sweep.test.ts
@@ -107,6 +107,7 @@ describe("oauth.upsert — admin gate", () => {
         },
         message: "ok",
       }),
+      validateState: vi.fn().mockResolvedValue({ valid: true }),
     });
 
   const upsertInput = {
@@ -121,6 +122,23 @@ describe("oauth.upsert — admin gate", () => {
 
     await expect(
       router.createCaller(memberCtx).upsert(upsertInput),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("validateState — admin allowed, member FORBIDDEN", async () => {
+    const router = buildRouter();
+    const stateInput = {
+      mcp_server_uuid: "11111111-1111-4111-8111-111111111111",
+      state: "nonce",
+    };
+
+    const adminResult = await router
+      .createCaller(adminCtx)
+      .validateState(stateInput);
+    expect(adminResult.valid).toBe(true);
+
+    await expect(
+      router.createCaller(memberCtx).validateState(stateInput),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });

--- a/apps/backend/src/trpc/oauth.impl.test.ts
+++ b/apps/backend/src/trpc/oauth.impl.test.ts
@@ -1,0 +1,185 @@
+/**
+ * RFC 6749 §10.12 state CSRF validation for the OAuth client flow.
+ *
+ * Our fork exchanges the authorization code CLIENT-side (the MCP SDK's auth()
+ * runs in the browser), so there is no backend exchangeToken. The CSRF check
+ * therefore lives in `oauth.validateState`, invoked by the callback BEFORE the
+ * client-side exchange. These tests pin its behaviour:
+ *   - expected_state truthy → must match input.state (missing input.state is a
+ *     mismatch, NOT a bypass); on match the nonce is cleared one-shot.
+ *   - no session / expected_state null → back-compat accept for in-flight
+ *     pre-fix flows; the nonce is NOT cleared (nothing to clear).
+ *   - a repo failure fails CLOSED so a validation outage can't silently
+ *     complete an unvalidated exchange.
+ * They also pin that the upsert handler FORWARDS expected_state to the repo —
+ * dropping it there would leave the column NULL and disable the check.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../db/repositories", () => ({
+  oauthSessionsRepository: {
+    findByMcpServerUuid: vi.fn(),
+    upsert: vi.fn(),
+    clearExpectedState: vi.fn(),
+  },
+}));
+
+const SERVER_UUID = "00000000-0000-0000-0000-0000000000aa";
+
+const loadModule = async () => {
+  const repos = await import("../db/repositories");
+  const impl = await import("./oauth.impl");
+  return {
+    oauthImplementations: impl.oauthImplementations,
+    findByMcpServerUuid: repos.oauthSessionsRepository
+      .findByMcpServerUuid as ReturnType<typeof vi.fn>,
+    upsert: repos.oauthSessionsRepository.upsert as ReturnType<typeof vi.fn>,
+    clearExpectedState: repos.oauthSessionsRepository
+      .clearExpectedState as ReturnType<typeof vi.fn>,
+  };
+};
+
+describe("oauthImplementations.validateState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("no session in DB → valid, no clear (back-compat)", async () => {
+    const { oauthImplementations, findByMcpServerUuid, clearExpectedState } =
+      await loadModule();
+    findByMcpServerUuid.mockResolvedValue(undefined);
+
+    const result = await oauthImplementations.validateState({
+      mcp_server_uuid: SERVER_UUID,
+      state: "anything",
+    });
+
+    expect(result).toEqual({ valid: true });
+    expect(clearExpectedState).not.toHaveBeenCalled();
+  });
+
+  it("expected_state null → valid, no clear (in-flight pre-fix flow)", async () => {
+    const { oauthImplementations, findByMcpServerUuid, clearExpectedState } =
+      await loadModule();
+    findByMcpServerUuid.mockResolvedValue({
+      mcp_server_uuid: SERVER_UUID,
+      expected_state: null,
+    });
+
+    const result = await oauthImplementations.validateState({
+      mcp_server_uuid: SERVER_UUID,
+      state: "from-upstream",
+    });
+
+    expect(result).toEqual({ valid: true });
+    expect(clearExpectedState).not.toHaveBeenCalled();
+  });
+
+  it("expected_state matches input.state → valid, clears the nonce once", async () => {
+    const { oauthImplementations, findByMcpServerUuid, clearExpectedState } =
+      await loadModule();
+    findByMcpServerUuid.mockResolvedValue({
+      mcp_server_uuid: SERVER_UUID,
+      expected_state: "the-nonce",
+    });
+    clearExpectedState.mockResolvedValue({});
+
+    const result = await oauthImplementations.validateState({
+      mcp_server_uuid: SERVER_UUID,
+      state: "the-nonce",
+    });
+
+    expect(result).toEqual({ valid: true });
+    expect(clearExpectedState).toHaveBeenCalledWith(SERVER_UUID);
+    expect(clearExpectedState).toHaveBeenCalledTimes(1);
+  });
+
+  it("expected_state mismatches input.state → invalid_state, no clear", async () => {
+    const { oauthImplementations, findByMcpServerUuid, clearExpectedState } =
+      await loadModule();
+    findByMcpServerUuid.mockResolvedValue({
+      mcp_server_uuid: SERVER_UUID,
+      expected_state: "the-nonce",
+    });
+
+    const result = await oauthImplementations.validateState({
+      mcp_server_uuid: SERVER_UUID,
+      state: "different-value",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("invalid_state");
+    expect(clearExpectedState).not.toHaveBeenCalled();
+  });
+
+  it("expected_state present but input.state missing → invalid_state (no bypass)", async () => {
+    const { oauthImplementations, findByMcpServerUuid, clearExpectedState } =
+      await loadModule();
+    findByMcpServerUuid.mockResolvedValue({
+      mcp_server_uuid: SERVER_UUID,
+      expected_state: "the-nonce",
+    });
+
+    const result = await oauthImplementations.validateState({
+      mcp_server_uuid: SERVER_UUID,
+      // no state
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("invalid_state");
+    expect(clearExpectedState).not.toHaveBeenCalled();
+  });
+
+  it("repo failure fails CLOSED (validation_error, not a silent pass)", async () => {
+    const { oauthImplementations, findByMcpServerUuid } = await loadModule();
+    findByMcpServerUuid.mockRejectedValue(new Error("db down"));
+
+    const result = await oauthImplementations.validateState({
+      mcp_server_uuid: SERVER_UUID,
+      state: "x",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toBe("validation_error");
+  });
+});
+
+describe("oauthImplementations.upsert forwards expected_state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression guard: the tRPC upsert handler previously stripped
+  // expected_state before calling the repo, leaving the column NULL and
+  // silently disabling the CSRF check (validateState then hits the back-compat
+  // branch). Pins the forward-through so a spread refactor can't regress it.
+  it("passes expected_state through to the repository", async () => {
+    const { oauthImplementations, upsert } = await loadModule();
+    upsert.mockResolvedValue({
+      uuid: "sess",
+      mcp_server_uuid: SERVER_UUID,
+      client_information: null,
+      tokens: null,
+      code_verifier: null,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+
+    await oauthImplementations.upsert({
+      mcp_server_uuid: SERVER_UUID,
+      expected_state: "the-csrf-nonce",
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mcp_server_uuid: SERVER_UUID,
+        expected_state: "the-csrf-nonce",
+      }),
+    );
+  });
+});

--- a/apps/backend/src/trpc/oauth.impl.ts
+++ b/apps/backend/src/trpc/oauth.impl.ts
@@ -3,6 +3,8 @@ import {
   GetOAuthSessionResponseSchema,
   UpsertOAuthSessionRequestSchema,
   UpsertOAuthSessionResponseSchema,
+  ValidateOAuthStateRequestSchema,
+  ValidateOAuthStateResponseSchema,
 } from "@repo/zod-types";
 import { z } from "zod";
 
@@ -52,6 +54,13 @@ export const oauthImplementations = {
         }),
         ...(input.tokens && { tokens: input.tokens }),
         ...(input.code_verifier && { code_verifier: input.code_verifier }),
+        // CSRF-defence nonce. MUST be forwarded — omitting it here silently
+        // disables state validation at validateState because the DB column
+        // stays NULL and the validator takes the back-compat bypass. Pinned by
+        // the "forwards expected_state to the repo" test.
+        ...(input.expected_state && {
+          expected_state: input.expected_state,
+        }),
       });
 
       if (!session) {
@@ -71,6 +80,70 @@ export const oauthImplementations = {
       return {
         success: false as const,
         error: error instanceof Error ? error.message : "Internal server error",
+      };
+    }
+  },
+
+  validateState: async (
+    input: z.infer<typeof ValidateOAuthStateRequestSchema>,
+  ): Promise<z.infer<typeof ValidateOAuthStateResponseSchema>> => {
+    // RFC 6749 §10.12 CSRF defence. `expected_state` was persisted at the
+    // authorize-redirect step by DbOAuthClientProvider.state(). Our upstream
+    // token exchange runs client-side in the browser via the MCP SDK's auth(),
+    // so this runs at the callback BEFORE that exchange: a mismatch aborts the
+    // flow before the browser POSTs the authorization code upstream, so a code
+    // obtained under a forged flow is never redeemed.
+    //
+    // Three cases:
+    //   - no session, OR expected_state IS NULL → the flow started before this
+    //     column existed, or a previous validation already cleared it. Accept
+    //     for backward compat with in-flight pre-fix flows; the column is
+    //     populated on the NEXT authorize attempt and validated then. This is
+    //     fail-open on ABSENCE only, never on a present-but-wrong nonce.
+    //   - expected_state non-null AND matches input.state → valid; clear the
+    //     column so the row can't be replayed with the same code+state pair.
+    //   - expected_state non-null AND input.state missing OR mismatched →
+    //     fail-closed. The missing case is explicit: an attacker who omits
+    //     state must not bypass the check via a truthy-undefined comparison.
+    try {
+      const session = await oauthSessionsRepository.findByMcpServerUuid(
+        input.mcp_server_uuid,
+      );
+
+      if (!session || !session.expected_state) {
+        return { valid: true as const };
+      }
+
+      if (!input.state || input.state !== session.expected_state) {
+        logger.warn(
+          `[oauth] state mismatch — server=${input.mcp_server_uuid} ` +
+            `expected_present=true got_present=${Boolean(input.state)}`,
+        );
+        return {
+          valid: false as const,
+          error: "invalid_state",
+          error_description:
+            "OAuth state mismatch — possible CSRF. The authorize flow must be re-initiated.",
+        };
+      }
+
+      // One-shot clear on a successful match. A replayed callback then falls
+      // through the back-compat NULL branch above, but the authorization code
+      // is already burned by the upstream at that point so a replayed exchange
+      // fails with invalid_grant regardless. Belt-and-braces.
+      await oauthSessionsRepository.clearExpectedState(input.mcp_server_uuid);
+
+      return { valid: true as const };
+    } catch (error) {
+      // A validation-path failure (e.g. DB unavailable) must not silently
+      // disable CSRF defence: fail closed so the callback aborts rather than
+      // completing an unvalidated exchange.
+      logger.error("Error validating OAuth state:", error);
+      return {
+        valid: false as const,
+        error: "validation_error",
+        error_description:
+          "Failed to validate OAuth state. The authorize flow must be re-initiated.",
       };
     }
   },

--- a/apps/frontend/components/OAuthCallback.tsx
+++ b/apps/frontend/components/OAuthCallback.tsx
@@ -23,6 +23,9 @@ const OAuthCallback = () => {
 
       const params = new URLSearchParams(window.location.search);
       const code = params.get("code");
+      // Echoed by the upstream authorization server (RFC 6749 §4.1.2). Used
+      // for the server-side CSRF check below before the code is exchanged.
+      const state = params.get("state");
       const serverUrl = sessionStorage.getItem(SESSION_KEYS.SERVER_URL);
       const mcpServerUuid = sessionStorage.getItem(
         SESSION_KEYS.MCP_SERVER_UUID,
@@ -35,6 +38,24 @@ const OAuthCallback = () => {
       }
 
       try {
+        // RFC 6749 §10.12 CSRF defence. Validate the echoed `state` against the
+        // per-flow nonce persisted at authorize time BEFORE completing the
+        // exchange — auth() below redeems the code client-side, so a forged
+        // callback must be rejected here or the code would be exchanged.
+        const stateResult =
+          await vanillaTrpcClient.frontend.oauth.validateState.mutate({
+            mcp_server_uuid: mcpServerUuid,
+            state: state ?? undefined,
+          });
+
+        if (!stateResult.valid) {
+          console.error(
+            `OAuth state validation failed: ${stateResult.error} — ${stateResult.error_description}`,
+          );
+          window.location.href = "/mcp-servers";
+          return;
+        }
+
         // Create auth provider with existing server UUID and URL
         const authProvider = createAuthProvider(mcpServerUuid, serverUrl);
 

--- a/apps/frontend/lib/oauth-provider.ts
+++ b/apps/frontend/lib/oauth-provider.ts
@@ -12,6 +12,20 @@ import { getServerSpecificKey, SESSION_KEYS } from "./constants";
 import { getAppUrl } from "./env";
 import { vanillaTrpcClient } from "./trpc";
 
+// base64url (RFC 4648 §5) encoding of a byte array: classic base64 via btoa,
+// then trimmed/replaced to the url-safe variant. Browser-only — state() runs
+// in the browser path of the SDK's auth(), so no Node fallback is needed.
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
 // OAuth client provider that works with a specific MCP server
 class DbOAuthClientProvider implements OAuthClientProvider {
   private mcpServerUuid: string;
@@ -160,6 +174,39 @@ class DbOAuthClientProvider implements OAuthClientProvider {
 
   redirectToAuthorization(authorizationUrl: URL) {
     window.location.href = authorizationUrl.href;
+  }
+
+  // RFC 6749 §10.12 CSRF defence: generate a per-flow random `state`, persist
+  // it server-side (oauth_sessions.expected_state), and return it for inclusion
+  // in the upstream's /authorize URL. The MCP SDK invokes this once per
+  // authorize attempt (auth.js: `provider.state ? await provider.state() : …`)
+  // and copies the return value into the authorization URL. On the callback the
+  // backend compares the echoed value to the persisted one (oauth.validateState)
+  // and clears the column on a match.
+  async state(): Promise<string> {
+    // 16 random bytes → ~22 base64url chars, well over the ~128-bit entropy
+    // bar in RFC 6749 §10.10.
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    const stateValue = base64UrlEncode(bytes);
+
+    if (await this.serverExists()) {
+      try {
+        await vanillaTrpcClient.frontend.oauth.upsert.mutate({
+          mcp_server_uuid: this.mcpServerUuid,
+          expected_state: stateValue,
+        });
+      } catch (error) {
+        // Best-effort persistence. If the upsert fails the upstream redirect
+        // still carries `stateValue`, but callback validation then falls
+        // through the back-compat NULL branch — the CSRF check degrades to
+        // "skipped" rather than rejecting the flow. Logged so a sustained
+        // persistence failure (CSRF layer silently off) is visible.
+        console.error("Error persisting expected_state to database:", error);
+      }
+    }
+
+    return stateValue;
   }
 
   async saveCodeVerifier(codeVerifier: string) {

--- a/packages/trpc/src/routers/frontend/oauth.ts
+++ b/packages/trpc/src/routers/frontend/oauth.ts
@@ -3,6 +3,8 @@ import {
   GetOAuthSessionResponseSchema,
   UpsertOAuthSessionRequestSchema,
   UpsertOAuthSessionResponseSchema,
+  ValidateOAuthStateRequestSchema,
+  ValidateOAuthStateResponseSchema,
 } from "@repo/zod-types";
 import { z } from "zod";
 
@@ -19,6 +21,9 @@ export const createOAuthRouter = (
     upsert: (
       input: z.infer<typeof UpsertOAuthSessionRequestSchema>,
     ) => Promise<z.infer<typeof UpsertOAuthSessionResponseSchema>>;
+    validateState: (
+      input: z.infer<typeof ValidateOAuthStateRequestSchema>,
+    ) => Promise<z.infer<typeof ValidateOAuthStateResponseSchema>>;
   },
 ) => {
   return router({
@@ -37,6 +42,18 @@ export const createOAuthRouter = (
       .output(UpsertOAuthSessionResponseSchema)
       .mutation(async ({ input }) => {
         return await implementations.upsert(input);
+      }),
+
+    // Admin only: CSRF state validation at the OAuth callback. Gated the same
+    // as upsert because it reads and clears the same server-config surface
+    // (oauth_sessions.expected_state) that upsert seeds — the connecting user
+    // who minted the nonce is the admin who validates it. Mutation because a
+    // successful match clears the nonce (one-shot).
+    validateState: adminProcedure
+      .input(ValidateOAuthStateRequestSchema)
+      .output(ValidateOAuthStateResponseSchema)
+      .mutation(async ({ input }) => {
+        return await implementations.validateState(input);
       }),
   });
 };

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -130,13 +130,39 @@ export const GetOAuthSessionResponseSchema = z.union([
   }),
 ]);
 
-// Upsert OAuth Session Request - all fields optional for updates
+// Upsert OAuth Session Request - all fields optional for updates.
+// `expected_state` is the CSRF-defence per-flow nonce written by the
+// frontend's DbOAuthClientProvider.state() and validated server-side at
+// oauth.validateState. Optional (omit = "do not touch"); the one-shot clear
+// after validation is a dedicated repo method, NOT a null write.
 export const UpsertOAuthSessionRequestSchema = z.object({
   mcp_server_uuid: z.string().uuid(),
   client_information: OAuthClientInformationSchema.optional(),
   tokens: OAuthTokensSchema.nullable().optional(),
   code_verifier: z.string().nullable().optional(),
+  expected_state: z.string().optional(),
 });
+
+// Validate OAuth State Request - CSRF check at the callback. `state` is the
+// value echoed back by the upstream authorization server; the backend compares
+// it to the persisted `expected_state` and clears the column on a match.
+export const ValidateOAuthStateRequestSchema = z.object({
+  mcp_server_uuid: z.string().uuid(),
+  state: z.string().optional(),
+});
+
+// Validate OAuth State Response - a discriminated result the callback gates on
+// before completing the token exchange.
+export const ValidateOAuthStateResponseSchema = z.union([
+  z.object({
+    valid: z.literal(true),
+  }),
+  z.object({
+    valid: z.literal(false),
+    error: z.string(),
+    error_description: z.string(),
+  }),
+]);
 
 // Upsert OAuth Session Response
 export const UpsertOAuthSessionResponseSchema = z.union([
@@ -151,12 +177,15 @@ export const UpsertOAuthSessionResponseSchema = z.union([
   }),
 ]);
 
-// Repository-specific schemas
+// Repository-specific schemas. `expected_state` mirrors the upsert contract:
+// omitted means "leave the column alone"; clearing goes through the dedicated
+// repo method, not a null write here.
 export const OAuthSessionCreateInputSchema = z.object({
   mcp_server_uuid: z.string(),
   client_information: OAuthClientInformationSchema.optional(),
   tokens: OAuthTokensSchema.nullable().optional(),
   code_verifier: z.string().nullable().optional(),
+  expected_state: z.string().optional(),
 });
 
 export const OAuthSessionUpdateInputSchema = z.object({
@@ -164,6 +193,7 @@ export const OAuthSessionUpdateInputSchema = z.object({
   client_information: OAuthClientInformationSchema.optional(),
   tokens: OAuthTokensSchema.nullable().optional(),
   code_verifier: z.string().nullable().optional(),
+  expected_state: z.string().optional(),
 });
 
 // Export repository types
@@ -181,6 +211,10 @@ export const DatabaseOAuthSessionSchema = z.object({
   client_information: OAuthClientInformationSchema.nullable(),
   tokens: OAuthTokensSchema.nullable(),
   code_verifier: z.string().nullable(),
+  // Per-flow CSRF nonce. Nullable on the DB read side: rows from before this
+  // column was added, and rows where validation already cleared the value,
+  // both carry NULL. NEVER serialized to the frontend.
+  expected_state: z.string().nullable(),
   created_at: z.date(),
   updated_at: z.date(),
 });


### PR DESCRIPTION
## Summary

Two carefully-limited slices from raphaelbarreiros's upstream PRs, adapted to our fork (client-side token exchange, zod v4, RBAC admin gate). Surgical and backend-focused; touches the OAuth-sessions repo/schema/impl plus the two frontend hooks the CSRF flow needs.

## SLICE A — atomic OAuthSessions upsert (from #300, merge `ecf354a`)

**Taken:** replaced the racy `SELECT`-then-`INSERT` in `OAuthSessionsRepository.upsert` with a single atomic `INSERT ... onConflictDoUpdate` on the `mcp_server_uuid` conflict target. Concurrent callers for one server now resolve via `ON CONFLICT` instead of the loser crashing on `oauth_sessions_unique_per_server_idx`. Conditional spreads preserved, so a partial update (e.g. tokens only) never clears unrelated columns.

**Deliberately dropped:**
- #300's zod hunk tightening `tokens`/`code_verifier` from `.nullable().optional()` to `.optional()`. Not applied — kept our nullable schemas so we don't disturb the OAuth-refresh contract. The conditional spread already treats `null` as "do not touch", so nullable is safe with the atomic upsert.
- #300's frontend SSR/StrictMode changes (`ensureServerUrlStored`, the `page.tsx` `useRef` auto-connect guard). Skipped to keep this PR backend-focused; not needed for either slice.

## SLICE B — CSRF `expected_state` validation (from #301, merge `7559e1c`)

RFC 6749 §10.12 state CSRF defence.

**Taken:**
- **(a)** New idempotent migration `0023_oauth_expected_state.sql` adds nullable `oauth_sessions.expected_state` (`ADD COLUMN IF NOT EXISTS`, matching the fork's hand-written 00NN convention — the fork stopped generating drizzle snapshots at 0013) + `_journal.json` entry (idx 23). Drizzle column added to `schema.ts`.
- **(b)** `DbOAuthClientProvider.state()` mints a per-flow 128-bit random nonce (base64url), persists it via `oauth.upsert`, and returns it. MCP SDK 1.29's `auth()` invokes `provider.state()` and injects it into the authorize URL (verified against the installed SDK: `auth.js` line 299 / `startAuthorization`).
- **(c)** New `oauth.validateState` tRPC procedure (admin-gated, same as `upsert`) compares the echoed callback `state` to the stored nonce and clears it one-shot on match; `OAuthCallback.tsx` gates on it **before** the client-side code exchange, so a forged callback is rejected before the code is redeemed.

**Adaptation note:** #301 put the CSRF check inside a backend `exchangeToken`. Our fork has **no** backend `exchangeToken` — the token exchange runs client-side in the browser via the MCP SDK's `auth()`. So the validate-and-clear logic lives in the new server-authoritative `oauth.validateState` procedure, invoked from the callback before `auth()`. Semantics preserved: expected_state absent/NULL → back-compat accept (fail-open on absence only); present + match → clear + accept; present + mismatch/missing → fail-closed; validation-path error → fail-closed.

**Skipped:** #301's `client.ts` post-auth handshake retry loop entirely — it collides with our heavily-rewritten (~700-line) M365-mint OAuth client path. `client.ts` is untouched.

## Tests (vitest)

- `oauth-sessions.repo.test.ts` (new): single `ON CONFLICT` statement (no check-then-insert), concurrent callers converge on one row without throwing, partial-update column preservation, `expected_state` written on upsert + untouched by unrelated updates, `clearExpectedState` NULL-write path.
- `oauth.impl.test.ts` (new): `validateState` — back-compat accept (no session / null), match clears once, mismatch rejects (no clear), missing-state rejects (no bypass), repo failure fails closed; upsert forwards `expected_state`.
- `admin-gate-sweep.test.ts` (updated): added `validateState` to the mock + an admin/member gate assertion.

**Red-before-green verified:** repo tests fail 7/7 against the original SELECT-then-INSERT repo; the two CSRF-rejection tests fail when the mismatch check is disabled. Restored to green.

## Gates

- `tsc --noEmit` (backend): clean. `turbo check-types` (zod-types + frontend): pass.
- backend vitest: **401 passed** (40 files).
- `turbo build`: pass (4/4, incl. frontend `/fe-oauth/callback`).
- Migration/journal integrity: valid JSON, sequential idx 0-23, tag ↔ filename match.
- **Lint (pre-existing baseline issue, not introduced here):** `backend:lint` runs `eslint . --max-warnings 0` and fails on **32 pre-existing warnings in 16 files none of which this PR touches** (auth.ts, oauth/token.ts, mcp-servers.impl.ts, etc.). All files changed in this PR lint clean (exit 0). Flagged for the foreman — not fixed here to respect scope.

## Cherry-pick-log row (for the foreman's UMBRELLA_FORK.md docs PR)

`#300 (ecf354a) — atomic OAuthSessions upsert only (zod nullable hunk + FE SSR/StrictMode dropped); #301 (7559e1c) — CSRF expected_state slice only, adapted to client-side exchange via new oauth.validateState (post-auth retry loop skipped). Migration 0023.`