### PR TITLE
fix(compose): quick-start deploys the fork image, not upstream

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,14 @@
 services:
   app:
     container_name: metamcp
-    image: ghcr.io/metatool-ai/metamcp:latest
+    # THE FORK IMAGE, not upstream's. This compose is what the README quick
+    # start tells you to run, so pointing it back at upstream's GHCR namespace
+    # silently deploys upstream MetaMCP from a clone of this fork — you get
+    # none of the fork's fixes (OAuth refresh-token grant, configurable TTLs,
+    # session recovery, RBAC, pool-cap env wiring) and nothing errors to tell
+    # you. Built from `umbrella` on every push by
+    # .github/workflows/umbrella-build.yml.
+    image: ghcr.io/umbrella-it-group/metamcp:latest
     pull_policy: always
     env_file:
       - .env

--- a/example.env
+++ b/example.env
@@ -151,3 +151,31 @@ BOOTSTRAP_ENDPOINTS=[{"name":"Public","description":"Public endpoint","enable_au
 # Extra trusted origins for Better Auth (comma-separated)
 # Useful for cluster deployments where different ports/origins are needed
 # EXTRA_TRUSTED_ORIGINS=http://myapp.example.com,http://myapp.example.com:8080
+
+# ============================================================================
+# UMBRELLA FORK CONFIGURATION
+# ============================================================================
+# Knobs that exist only in this fork (ghcr.io/umbrella-it-group/metamcp).
+# All are optional — each falls back to the code default shown in its comment.
+# This is the subset worth setting on a new deployment; the full list
+# (MCP_* recovery/pruner knobs, LOG_MAX_SIZE_MB, TOOL_AUDIT_RETENTION_DAYS,
+# TOOLS_SWEEP_INTERVAL_SECONDS, PUBLIC_SESSION_TTL_SECONDS, ...) is documented
+# in README.md § Configuration.
+
+# --- OAuth and session lifetimes ---
+# Upstream hardcodes a 1h access token, which disconnects Claude.ai custom
+# connectors hourly. These are the fork's max-connectivity defaults.
+OAUTH_ACCESS_TOKEN_TTL_SECONDS=86400 # MCP OAuth access-token lifetime. Default: 86400 (24h)
+OAUTH_REFRESH_TOKEN_TTL_SECONDS=31536000 # MCP OAuth refresh-token lifetime; rotates on use. Default: 31536000 (365d)
+BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS=2592000 # Better-auth session cookie lifetime. Default: 2592000 (30d)
+BETTER_AUTH_SESSION_UPDATE_AGE_SECONDS=604800 # Better-auth sliding session refresh age. Default: 604800 (7d)
+
+# --- Connection pool caps ---
+# NOTE: the values below are the production-tested settings, NOT the code
+# defaults — both code defaults were exhausted in real incidents. Raise or
+# lower to fit your backend count, but do not leave them at a value your
+# steady-state session population can reach: on saturation every new connect
+# LRU-evicts a live backend connection, and victims see transient
+# "Failed to re-initialize session after backend session loss" tool errors.
+MAX_CONNECTIONS_PER_SERVER=50 # Per-backend connection cap. Code default 5 trips under normal load ("Session not found")
+MAX_TOTAL_CONNECTIONS=400 # Global backend-connection cap (soft LRU bound). Code default 100 saturated in ~3h in prod


### PR DESCRIPTION
## The defect

`docker-compose.yml:4` pulled `ghcr.io/metatool-ai/metamcp:latest` — **upstream's** image — while `README.md` § Quick start tells you to clone *this* repo and run `docker compose up -d` against that exact file.

Anyone following our own documented path got upstream MetaMCP from a clone of the fork: no OAuth refresh-token grant, no configurable TTLs, no session-recovery detectors, no RBAC, no pool-cap env wiring.

**It fails silently in both directions.** The image pulls fine, the container boots, the UI looks normal, nothing logs a warning. The first symptom is Claude.ai connectors dropping hourly on upstream's hardcoded 1h access token — which reads as a client problem, not a wrong-image problem. `pull_policy: always` makes it sticky: a correct local build is replaced by upstream on the next `up -d`.

## Changes

**1. `docker-compose.yml` — point at the fork image.**
Now `ghcr.io/umbrella-it-group/metamcp:latest`, published from `umbrella` on every push by `.github/workflows/umbrella-build.yml`. A comment above the line records the trap so it doesn't get "cleaned up" back to upstream, and deliberately does *not* write the upstream path verbatim, so `grep metatool-ai docker-compose.yml` stays a clean regression tripwire.

**2. `example.env` — document the fork knobs.**
`cp example.env .env` (also from our quick start) produced a config with zero fork knobs. With the image fixed, a new deployment would get the fork but run every fork behaviour at its code default — including the two pool caps that caused production incidents. Adds six knobs under an `UMBRELLA FORK CONFIGURATION` banner matching the file's existing section style, each with its default in a one-line comment.

| Variable | Value set | Rationale |
|---|---|---|
| `OAUTH_ACCESS_TOKEN_TTL_SECONDS` | `86400` | fork default |
| `OAUTH_REFRESH_TOKEN_TTL_SECONDS` | `31536000` | fork default |
| `BETTER_AUTH_SESSION_EXPIRES_IN_SECONDS` | `2592000` | fork default |
| `BETTER_AUTH_SESSION_UPDATE_AGE_SECONDS` | `604800` | fork default |
| `MAX_CONNECTIONS_PER_SERVER` | `50` | **not** the code default (5) — see below |
| `MAX_TOTAL_CONNECTIONS` | `400` | **not** the code default (100) — see below |

### Why the pool caps deviate from the code defaults

Both code defaults were exhausted in production. `5` trips under normal load and surfaces to consumers as JSON-RPC `-32600 "Session not found"`. `100` saturated within ~3h of the 2026-07-13 restart, after which every new connect LRU-evicts a live backend connection (2026-07-14 incident). Shipping an example config at values with two known incidents behind them would be the same silent-default trap as the image itself.

The comments state explicitly which numbers are code defaults and which are the production-tested settings, so this does **not** contradict the README's defaults table — README documents what the code does when unset; `example.env` documents what to start from.

### Scope

Deliberately limited to those six. The fork's other knobs (`MCP_*` recovery/pruner, `LOG_MAX_SIZE_MB`, `TOOL_AUDIT_RETENTION_DAYS`, `TOOLS_SWEEP_INTERVAL_SECONDS`, `PUBLIC_SESSION_TTL_SECONDS`) are fine at defaults on a fresh deployment; a header comment names `README.md` § Configuration as the full list so the file doesn't read as exhaustive.

## Verification

- `grep -c metatool-ai docker-compose.yml` → **0**
- `docker compose config` (this compose + `example.env` as `.env`) → exit 0, `image: ghcr.io/umbrella-it-group/metamcp:latest`
- Same run resolves the six vars to `"86400"`, `"31536000"`, `"2592000"`, `"604800"`, `"50"`, `"400"` — inline comments stripped, matching the file's existing `VAR=value # comment` entries
- All six names verified against real reads in `apps/backend/src` (`routers/oauth/token.ts`, `auth.ts`, `lib/metamcp/mcp-server-pool.ts`) — mirrored from source, not transcribed from the README
- Repo-wide sweep: `docker-compose.yml:4` was the **only** upstream-image reference. `docker-compose.dev.yml` and `docker-compose.test.yml` both `build:` from source and were already correct; remaining `metatool-ai` hits are attribution prose and URLs.

## Noted, not fixed (separate defect class)

`README.md:149` heads the quick-start section **"Build from source with Docker Compose"**, but this compose declares `image:` + `pull_policy: always` — it *pulls* a prebuilt image and never builds. Pre-existing and unaffected by this PR (the path now pulls the *correct* image), but the heading is inaccurate either way.

Claude-Session: https://claude.ai/code/session_01HrN4MBmij4CjBsqDZthBKY