### PR TITLE
build(docker): pin prod deps with --frozen-lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,9 +99,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/packages ./packages
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/package.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/pnpm-workspace.yaml ./
+# Lockfile is required here so the prod install below can run --frozen-lockfile:
+# pin prod deps to the already-resolved graph instead of re-resolving
+# package.json ranges (which can silently drift from the committed lockfile).
+COPY --from=builder --chown=nextjs:nodejs /app/pnpm-lock.yaml ./
 
 # Install production dependencies only
-RUN pnpm install --prod
+RUN pnpm install --prod --frozen-lockfile
 
 # Install drizzle-kit locally in backend for migrations
 RUN cd apps/backend && pnpm add drizzle-kit@0.31.1


### PR DESCRIPTION
The runner stage ran `pnpm install --prod` without `--frozen-lockfile`, so production dependencies could re-resolve `package.json` ranges and drift from the committed lockfile.

**Fix:** copy `pnpm-lock.yaml` into the runner stage (it was only present in the `deps` stage) and add `--frozen-lockfile` to the prod install, so prod deps are pinned to the resolved graph and the build fails loudly on drift — matching the `deps` stage (line 33).

Verified via CI `build-and-push`, which runs the full Dockerfile including this stage.