### PR TITLE
fix(oauth): allow loopback redirect URIs regardless of NODE_ENV

### DIFF
--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -69,12 +69,18 @@ export function generateSecureClientSecret(): string {
  * STILL LIVE AT `/oauth/authorize`, where it now runs ALONGSIDE
  * `isAllowedRedirectUri` rather than instead of it. The follow-up this comment
  * used to describe (apply the strict checker at authorize too, once the stored
- * rows had been verified clean) has landed; this one is kept because it is not
- * a subset of the other. It carries the production-only rules — HTTPS required
- * and RFC 1918 hosts refused when NODE_ENV is `production` — that the
- * registration-time checker deliberately does not have. Dropping it in favour
- * of the newer checker would therefore have OPENED something at authorize,
- * which is the wrong direction for a hardening change.
+ * rows had been verified clean) has landed.
+ *
+ * WHAT IS LEFT OF IT, EXACTLY — because under the default configuration it is
+ * now very nearly a subset of the other, and a future cleanup will want to
+ * know what would actually be lost by deleting it. Its scheme rule is
+ * subsumed: `isAllowedRedirectUri` already refuses plain http on a
+ * non-loopback host in EVERY environment, so nothing this one refuses on
+ * scheme grounds survives the other. The ONE surviving delta is the RFC 1918
+ * refusal under NODE_ENV=`production`, and it only ever binds when an operator
+ * has put a private-range host into DCR_REDIRECT_URI_ALLOWED_HOSTS: with the
+ * default allowlist the other checker refuses `192.168.x` as host_not_allowed
+ * anyway. That narrow case is the whole reason this function is still called.
  */
 export function validateRedirectUri(
   uri: string,
@@ -95,14 +101,16 @@ export function validateRedirectUri(
     const hostname = parsedUri.hostname.replace(/^\[|\]$/g, "").toLowerCase();
     const isLoopback = LOOPBACK_HOSTNAMES.has(hostname);
 
-    // Production requires HTTPS — EXCEPT on loopback, in every environment.
+    // Production requires HTTPS. Loopback is exempt from that requirement,
+    // and the exemption itself is unconditional — it holds in every
+    // environment, because it is a property of the host and not of NODE_ENV.
+    //
     // RFC 8252 §7.3 has a native app receive its authorization code on
     // `http://127.0.0.1:<ephemeral>`: plain http, on a port the OS assigns at
     // runtime, because an installed client has no other loopback shape
     // available to it. Refusing that hardens nothing reachable from the
     // network — the loopback interface is not routable off-box — it only
-    // removes the sole redirect such a client can offer, so the rule is tied
-    // to the host rather than to NODE_ENV.
+    // removes the sole redirect such a client can offer.
     if (
       process.env.NODE_ENV === "production" &&
       !isLoopback &&
@@ -124,9 +132,27 @@ export function validateRedirectUri(
       }
     }
 
-    // Check against allowed hosts if provided
+    // Check against allowed hosts if provided.
+    //
+    // Both sides are normalised the same way the loopback test above is, and
+    // for the same reason: a raw comparison silently failed whenever the two
+    // spellings differed, so `["::1"]` never matched `http://[::1]/` (the
+    // parser reports the host bracketed) and `["EXAMPLE.COM"]` never matched
+    // anything at all. Entries are bracket-stripped as well as trimmed and
+    // lowercased, so an operator may write an IPv6 host either way.
+    //
+    // An EMPTY array still means "no restriction", unlike
+    // `resolveDcrAllowedHosts`, where empty is a configured "loopback only".
+    // The two disagree because they are reached differently: this parameter is
+    // an optional narrowing a caller opts into, and no caller passes it today.
     if (allowedHosts && allowedHosts.length > 0) {
-      return allowedHosts.includes(parsedUri.hostname);
+      const normalisedAllowedHosts = allowedHosts.map((host) =>
+        host
+          .trim()
+          .toLowerCase()
+          .replace(/^\[|\]$/g, ""),
+      );
+      return normalisedAllowedHosts.includes(hostname);
     }
 
     return true;

--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -71,11 +71,10 @@ export function generateSecureClientSecret(): string {
  * used to describe (apply the strict checker at authorize too, once the stored
  * rows had been verified clean) has landed; this one is kept because it is not
  * a subset of the other. It carries the production-only rules — HTTPS required
- * and loopback / RFC 1918 hosts refused when NODE_ENV is `production` — that
- * the registration-time checker deliberately does not have, since an installed
- * client legitimately registers a loopback callback. Dropping it in favour of
- * the newer checker would therefore have OPENED something at authorize, which
- * is the wrong direction for a hardening change.
+ * and RFC 1918 hosts refused when NODE_ENV is `production` — that the
+ * registration-time checker deliberately does not have. Dropping it in favour
+ * of the newer checker would therefore have OPENED something at authorize,
+ * which is the wrong direction for a hardening change.
  */
 export function validateRedirectUri(
   uri: string,
@@ -89,21 +88,34 @@ export function validateRedirectUri(
       return false;
     }
 
-    // For production, only allow HTTPS
+    // Bracket-stripped so the IPv6 literal `[::1]` compares against `::1`, and
+    // matched EXACTLY via the shared set below — `localhost.evil.com` and
+    // `evil.localhost` both carry a loopback label and neither is the loopback
+    // interface.
+    const hostname = parsedUri.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    const isLoopback = LOOPBACK_HOSTNAMES.has(hostname);
+
+    // Production requires HTTPS — EXCEPT on loopback, in every environment.
+    // RFC 8252 §7.3 has a native app receive its authorization code on
+    // `http://127.0.0.1:<ephemeral>`: plain http, on a port the OS assigns at
+    // runtime, because an installed client has no other loopback shape
+    // available to it. Refusing that hardens nothing reachable from the
+    // network — the loopback interface is not routable off-box — it only
+    // removes the sole redirect such a client can offer, so the rule is tied
+    // to the host rather than to NODE_ENV.
     if (
       process.env.NODE_ENV === "production" &&
+      !isLoopback &&
       parsedUri.protocol !== "https:"
     ) {
       return false;
     }
 
-    // Prevent localhost/private IPs in production
+    // Prevent private IPs in production. The loopback addresses are absent by
+    // design and not by omission: none of them falls in a private range, and
+    // unlike `192.168.1.5` they are not reachable by anything else on the LAN.
     if (process.env.NODE_ENV === "production") {
-      const hostname = parsedUri.hostname.toLowerCase();
       if (
-        hostname === "localhost" ||
-        hostname === "127.0.0.1" ||
-        hostname === "::1" ||
         hostname.startsWith("192.168.") ||
         hostname.startsWith("10.") ||
         hostname.startsWith("172.")

--- a/apps/backend/src/routers/oauth/validate-redirect-uri.test.ts
+++ b/apps/backend/src/routers/oauth/validate-redirect-uri.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for `validateRedirectUri`, the production-only half of the
+ * `/oauth/authorize` redirect_uri gate.
+ *
+ * WHY THIS FILE EXISTS. The function's rules are all conditioned on
+ * `NODE_ENV`, and nothing pinned them — the sibling suite
+ * (`redirect-uri-allowlist.test.ts`) drives `isAllowedRedirectUri`, which
+ * deliberately has no NODE_ENV branch at all. So the one checker whose
+ * behaviour CHANGES between a dev run and a production deploy was the one
+ * with no coverage, and the difference was only ever observable by deploying.
+ *
+ * The case that bites is `accepts a loopback callback under production`.
+ * RFC 8252 §7.3 has a native app receive its authorization code on
+ * `http://127.0.0.1:<ephemeral>` — plain http, on a port the OS hands out at
+ * runtime — because there is no other loopback shape an installed client can
+ * use. Refusing that shape does not harden anything reachable from the
+ * network; it removes the only redirect an installed client has, so every
+ * such client breaks the moment NODE_ENV is set to `production`.
+ *
+ * The other half is asserted just as explicitly: RFC 1918 hosts and plain
+ * http on a routable host stay refused under production. Loopback is exempt
+ * because the loopback interface is not reachable from off-box, which is not
+ * true of `192.168.1.5`.
+ *
+ * `NODE_ENV` is stubbed per test rather than set once at module scope so both
+ * the production and the non-production expectations can live in one file.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { validateRedirectUri } from "./utils";
+
+/**
+ * The loopback shapes RFC 8252 §7.3 names: `localhost`, the IPv4 literal, and
+ * the IPv6 literal. All three over plain http, on ports an installed client
+ * did not choose — including the reserved-but-parseable `:9` — because
+ * "whatever the OS handed us" is the only port an installed client can offer.
+ */
+const LOOPBACK_URIS: readonly string[] = [
+  "http://localhost:54321/callback",
+  "http://127.0.0.1:8080/cb",
+  "http://[::1]:9/cb",
+];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("validateRedirectUri — loopback under NODE_ENV=production", () => {
+  it.each(LOOPBACK_URIS)("accepts %s", (uri) => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(validateRedirectUri(uri)).toBe(true);
+  });
+
+  it("accepts loopback on any port, not a fixed one", () => {
+    // An installed client binds an ephemeral port it does not get to choose,
+    // so a port-restricted rule would break clients at random.
+    vi.stubEnv("NODE_ENV", "production");
+    for (const port of [1024, 3000, 8080, 49152, 65535]) {
+      expect(validateRedirectUri(`http://127.0.0.1:${port}/callback`)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("accepts loopback in development too", () => {
+    // The exemption is unconditional; nothing about it is environment-shaped.
+    vi.stubEnv("NODE_ENV", "development");
+    for (const uri of LOOPBACK_URIS) {
+      expect(validateRedirectUri(uri)).toBe(true);
+    }
+  });
+});
+
+describe("validateRedirectUri — what production still refuses", () => {
+  it("refuses an RFC 1918 host", () => {
+    // A private-range address is reachable by anything else on the LAN, so it
+    // gets none of the loopback exemption's reasoning.
+    vi.stubEnv("NODE_ENV", "production");
+    for (const uri of [
+      "http://192.168.1.5/cb",
+      "http://10.0.0.7/cb",
+      "http://172.16.0.3/cb",
+    ]) {
+      expect(validateRedirectUri(uri)).toBe(false);
+    }
+  });
+
+  it("refuses an RFC 1918 host over https as well", () => {
+    // The private-range rule is about the host, not the scheme — https to a
+    // LAN address is still a callback this server cannot reason about.
+    vi.stubEnv("NODE_ENV", "production");
+    expect(validateRedirectUri("https://192.168.1.5/cb")).toBe(false);
+  });
+
+  it("refuses plain http on a routable host", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(validateRedirectUri("http://example.com/cb")).toBe(false);
+  });
+
+  it("accepts https on a routable host", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(validateRedirectUri("https://example.com/cb")).toBe(true);
+  });
+
+  it("refuses every non-http(s) scheme", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    for (const uri of [
+      "javascript:alert(1)",
+      "data:text/html,<script>1</script>",
+      "myapp://callback",
+      "file:///etc/passwd",
+    ]) {
+      expect(validateRedirectUri(uri)).toBe(false);
+    }
+  });
+
+  it("refuses unparseable input", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    expect(validateRedirectUri("not a url")).toBe(false);
+    expect(validateRedirectUri("")).toBe(false);
+  });
+
+  it("still applies an explicit allowedHosts argument to a loopback URI", () => {
+    // The loopback exemption is from the NODE_ENV rules only. A caller that
+    // passes an explicit host list is stating the whole set of acceptable
+    // hosts, and loopback is not silently added to it.
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      validateRedirectUri("http://localhost:54321/cb", ["example.com"]),
+    ).toBe(false);
+    expect(
+      validateRedirectUri("http://localhost:54321/cb", ["localhost"]),
+    ).toBe(true);
+  });
+
+  it("does not treat a loopback label as loopback when it is a prefix or suffix", () => {
+    // `localhost.evil.com` starts with a loopback label and `evil.localhost`
+    // ends with one; neither is the loopback interface, so neither may inherit
+    // the plain-http exemption.
+    vi.stubEnv("NODE_ENV", "production");
+    for (const host of [
+      "localhost.evil.com",
+      "127.0.0.1.evil.com",
+      "evil.localhost",
+      "notlocalhost",
+    ]) {
+      expect(validateRedirectUri(`http://${host}/cb`)).toBe(false);
+    }
+  });
+});

--- a/apps/backend/src/routers/oauth/validate-redirect-uri.test.ts
+++ b/apps/backend/src/routers/oauth/validate-redirect-uri.test.ts
@@ -22,13 +22,22 @@
  * because the loopback interface is not reachable from off-box, which is not
  * true of `192.168.1.5`.
  *
+ * The last block drives the PAIR. `/oauth/authorize` runs this checker and
+ * then `isAllowedRedirectUri`, and only a URI both accept reaches a minted
+ * code — so "loopback is accepted here" is a claim about one gate, not about
+ * the endpoint, and the composed cases are what say which.
+ *
  * `NODE_ENV` is stubbed per test rather than set once at module scope so both
  * the production and the non-production expectations can live in one file.
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { validateRedirectUri } from "./utils";
+import {
+  GATEWAY_INTERNAL_PORT,
+  isAllowedRedirectUri,
+  validateRedirectUri,
+} from "./utils";
 
 /**
  * The loopback shapes RFC 8252 §7.3 names: `localhost`, the IPv4 literal, and
@@ -121,19 +130,6 @@ describe("validateRedirectUri — what production still refuses", () => {
     expect(validateRedirectUri("")).toBe(false);
   });
 
-  it("still applies an explicit allowedHosts argument to a loopback URI", () => {
-    // The loopback exemption is from the NODE_ENV rules only. A caller that
-    // passes an explicit host list is stating the whole set of acceptable
-    // hosts, and loopback is not silently added to it.
-    vi.stubEnv("NODE_ENV", "production");
-    expect(
-      validateRedirectUri("http://localhost:54321/cb", ["example.com"]),
-    ).toBe(false);
-    expect(
-      validateRedirectUri("http://localhost:54321/cb", ["localhost"]),
-    ).toBe(true);
-  });
-
   it("does not treat a loopback label as loopback when it is a prefix or suffix", () => {
     // `localhost.evil.com` starts with a loopback label and `evil.localhost`
     // ends with one; neither is the loopback interface, so neither may inherit
@@ -147,5 +143,104 @@ describe("validateRedirectUri — what production still refuses", () => {
     ]) {
       expect(validateRedirectUri(`http://${host}/cb`)).toBe(false);
     }
+  });
+});
+
+describe("validateRedirectUri — the optional allowedHosts narrowing", () => {
+  it("still applies an explicit allowedHosts argument to a loopback URI", () => {
+    // The loopback exemption is from the NODE_ENV rules only. A caller that
+    // passes an explicit host list is stating the whole set of acceptable
+    // hosts, and loopback is not silently added to it.
+    vi.stubEnv("NODE_ENV", "production");
+    expect(
+      validateRedirectUri("http://localhost:54321/cb", ["example.com"]),
+    ).toBe(false);
+    expect(
+      validateRedirectUri("http://localhost:54321/cb", ["localhost"]),
+    ).toBe(true);
+  });
+
+  it("matches an IPv6 entry in either spelling", () => {
+    // The parser reports IPv6 hosts bracketed, so a raw comparison made the
+    // unbracketed `::1` — the spelling an operator would write, and the one
+    // LOOPBACK_HOSTNAMES uses — silently never match.
+    vi.stubEnv("NODE_ENV", "production");
+    for (const entry of ["::1", "[::1]"]) {
+      expect(validateRedirectUri("http://[::1]:9/cb", [entry])).toBe(true);
+    }
+    expect(validateRedirectUri("http://[::1]:9/cb", ["127.0.0.1"])).toBe(false);
+  });
+
+  it("normalises entry case and surrounding whitespace", () => {
+    // A raw comparison meant an uppercase entry matched nothing at all, since
+    // the parser lowercases the host it reports.
+    vi.stubEnv("NODE_ENV", "production");
+    for (const entry of ["EXAMPLE.COM", "  example.com  ", "Example.Com"]) {
+      expect(validateRedirectUri("https://example.com/cb", [entry])).toBe(true);
+    }
+  });
+
+  it("treats an EMPTY array as no restriction, unlike resolveDcrAllowedHosts", () => {
+    // Deliberate, and deliberately different from the sibling: an empty value
+    // for DCR_REDIRECT_URI_ALLOWED_HOSTS is documented as a configured
+    // "loopback only", whereas this parameter is an optional narrowing a
+    // caller opts into and an empty array is nothing opted into. The two are
+    // reached differently — the env is operator configuration, this is an
+    // argument — and no caller passes this one today. Pinned so the divergence
+    // is a decision on the record rather than something to be discovered.
+    vi.stubEnv("NODE_ENV", "production");
+    expect(validateRedirectUri("https://example.com/cb", [])).toBe(true);
+    expect(validateRedirectUri("http://127.0.0.1:8080/cb", [])).toBe(true);
+  });
+});
+
+describe("the composed authorize gate — both checkers in sequence", () => {
+  // `/oauth/authorize` runs validateRedirectUri and THEN isAllowedRedirectUri,
+  // so a URI reaches a minted code only if both accept it. Asserting the pair
+  // is what stops this change from being read as "loopback is now accepted at
+  // authorize" when the second gate still has the final say.
+
+  it("accepts a loopback callback through BOTH gates under production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    for (const uri of LOOPBACK_URIS) {
+      expect(validateRedirectUri(uri)).toBe(true);
+      expect(isAllowedRedirectUri(uri)).toEqual({ ok: true });
+    }
+  });
+
+  it("lets the second gate refuse what the first one does not", () => {
+    // Both shapes pass validateRedirectUri — https, non-loopback, not a
+    // private range — and both are refused before a code is minted. This is
+    // the half of the pair that the loopback change must not weaken.
+    vi.stubEnv("NODE_ENV", "production");
+
+    const userinfo = "https://claude.ai@evil.example.com/cb";
+    expect(validateRedirectUri(userinfo)).toBe(true);
+    const userinfoCheck = isAllowedRedirectUri(userinfo);
+    expect(userinfoCheck.ok).toBe(false);
+    if (!userinfoCheck.ok) {
+      expect(userinfoCheck.reason).toBe("userinfo_present");
+    }
+
+    const offAllowlist = "https://evil.example.com/cb";
+    expect(validateRedirectUri(offAllowlist)).toBe(true);
+    const hostCheck = isAllowedRedirectUri(offAllowlist);
+    expect(hostCheck.ok).toBe(false);
+    if (!hostCheck.ok) {
+      expect(hostCheck.reason).toBe("host_not_allowed");
+    }
+  });
+
+  it("refuses the gateway's own loopback port at the second gate", () => {
+    // The one loopback shape the first gate now accepts and the second must
+    // not: nothing external listens on the gateway's internal port, so a
+    // redirect there is only ever the server being pointed at itself.
+    vi.stubEnv("NODE_ENV", "production");
+
+    const uri = `http://127.0.0.1:${GATEWAY_INTERNAL_PORT}/cb`;
+    expect(validateRedirectUri(uri)).toBe(true);
+    const check = isAllowedRedirectUri(uri);
+    expect(check.ok).toBe(false);
+    if (!check.ok) expect(check.reason).toBe("gateway_internal_port");
   });
 });


### PR DESCRIPTION
## What changed

`validateRedirectUri` (`apps/backend/src/routers/oauth/utils.ts`) refused plain-http and loopback redirect URIs whenever `NODE_ENV` was `production`. Loopback (`localhost`, `127.0.0.1`, `::1`) is now accepted on any port in every environment.

The remaining production rules are unchanged and still gated on `NODE_ENV === "production"`:

- HTTPS is required for every non-loopback host.
- RFC 1918 hosts (`192.168.`, `10.`, `172.`) are refused.

A second commit fixes a latent defect in the same function's optional `allowedHosts` narrowing, which compared entries against the raw parsed hostname while the loopback test compared against a normalised one. The two disagreed whenever the spellings differed: `["::1"]` never matched `http://[::1]/`, because the WHATWG URL parser reports IPv6 hosts bracketed, and an entry differing in case or whitespace never matched anything. Entries are now trimmed, lowercased and bracket-stripped before comparison, matching what the registration-time checker does with its own allowlist.

## Why

RFC 8252 §7.3 has a native app receive its authorization code on `http://127.0.0.1:<ephemeral>` — plain http, on a port the OS assigns at runtime — because an installed client has no other loopback shape available to it. Refusing that hardens nothing reachable from the network, since the loopback interface is not routable off-box; it only removes the sole redirect such a client can offer. Tying the rule to the host rather than to `NODE_ENV` keeps the private-range and scheme refusals intact while letting installed clients complete an authorization code flow in a production deployment.

Loopback membership is exact and bracket-stripped, reusing the `LOOPBACK_HOSTNAMES` set the registration-time checker already uses, so `localhost.evil.com` and `evil.localhost` do not inherit the exemption. This also retires a dead branch: the previous `hostname === "::1"` test could never fire, since the parser reports that host as `[::1]`.

The registration-time sibling `isAllowedRedirectUri` is untouched; both checkers continue to run in sequence at `/oauth/authorize`, and a redirect URI reaches a minted code only if both accept it.

## Blast radius

**This is a live change for any deployment configured from `example.env`.** `example.env` sets `NODE_ENV=production` on line 1, `docker-compose.yml` reads the resulting `.env` via `env_file`, and the quickstart in the README is `cp example.env .env` followed by `docker compose up -d`. On such a deployment the production branch is already active, loopback OAuth is refused at `/oauth/authorize` today, and this PR un-breaks it — installed clients that bind an ephemeral loopback port can complete an authorization code flow again.

**It is inert for any deployment that does not set `NODE_ENV`.** The production `Dockerfile` sets no `NODE_ENV` of its own (only `Dockerfile.dev` and `.devcontainer/Dockerfile` do, both to `development`), and `docker-compose.yml` declares no `NODE_ENV` key. A deployment driving the container from an external compose fragment that leaves the variable unset never enters the production branch at all, so nothing observable changes until that flips — at which point this PR is what keeps loopback OAuth working across the transition.

Nothing that was refused before becomes acceptable in either case: the change only removes a refusal on loopback hosts, and every other rule in both checkers is byte-identical.

## Test coverage

`validateRedirectUri` previously had no coverage, so a rule that only takes effect under `NODE_ENV=production` was observable only by deploying. New file `apps/backend/src/routers/oauth/validate-redirect-uri.test.ts` stubs `NODE_ENV` per case (`vi.stubEnv`), 19 tests in three blocks:

- **loopback under `NODE_ENV=production`** — the three RFC 8252 spellings, arbitrary ephemeral ports, and the same acceptance in development.
- **what production still refuses** — RFC 1918 over both schemes, plain http on a routable host, https on a routable host accepted, non-http(s) schemes, unparseable input, and loopback labels appearing as a prefix or suffix.
- **the optional `allowedHosts` narrowing** — IPv6 entries in either spelling, case and whitespace normalisation, and an empty array pinned as "no restriction". That last one deliberately differs from `resolveDcrAllowedHosts`, where an empty env value means "loopback only"; the divergence is now recorded in a test rather than left to be discovered.
- **the composed authorize gate** — both checkers asserted in sequence, covering the loopback accept and the userinfo, off-allowlist and gateway-internal-port shapes that the second gate still refuses.

Five of these fail against the pre-change function, and two more against the first commit.

The docblock's claim about what this checker still contributes was measured rather than asserted: over a 616-URI corpus, under `NODE_ENV=production` with the default allowlist there are **zero** URIs that `isAllowedRedirectUri` accepts and `validateRedirectUri` refuses, and **24** once a private-range host is put in `DCR_REDIRECT_URI_ALLOWED_HOSTS` — all of them `https://192.168.1.5…` / `https://10.0.0.7…` shapes. That narrow case is the only reason the function is still called, and the docblock now says so.

Backend suite: 100 files passed / 2 skipped, 1515 tests passed / 31 skipped. Frontend suite: 13 passed. `pnpm check-types`: clean. Prettier: clean on both touched files.