### PR TITLE
fix(auth): key failed-auth rate limiter on edge client IP

### DIFF
--- a/apps/backend/src/lib/auth-rate-limiter.test.ts
+++ b/apps/backend/src/lib/auth-rate-limiter.test.ts
@@ -160,7 +160,7 @@ describe("getAuthRateLimitIdentifier", () => {
     expect(limiter.isCurrentlyLimited(first)).toBe(true);
   });
 
-  it("falls back to the socket address when the edge header is absent", () => {
+  it("walks req.ip then the socket address then the literal when the edge header is absent", () => {
     const endpoint = makeEndpoint(ENDPOINT_UUID);
 
     // Direct-to-origin and local development have no Cloudflare header. They
@@ -242,14 +242,56 @@ describe("getAuthRateLimitIdentifier", () => {
  * Re-keying the limiter per caller only helps if the per-caller allowance stays
  * where it was; quietly widening or narrowing it while the keys changed would
  * be invisible in the tests above.
+ *
+ * DRIVEN THROUGH THE PRODUCTION CALL PAIR, and that is the point of this block
+ * rather than an incidental detail. Every call site — three of them, in
+ * middleware/api-key-oauth.middleware — does `recordFailedAttempt(id)` and then
+ * `isRateLimited(id)`, and `isRateLimited` counts the question it is asked (see
+ * the `isCurrentlyLimited` docblock in the module under test, which exists
+ * because of exactly that). Two counts land per failed request, so the
+ * constructor argument of 20 buys about ten attempts a minute, not twenty. A
+ * test that drove `recordFailedAttempt` alone would pin the counter's arithmetic
+ * and quietly misreport the allowance the gateway actually enforces.
  */
-describe("the shared failed-auth limiter's budget", () => {
-  it("refuses on the twentieth failure in a window, not sooner", () => {
+describe("the failed-auth budget as the middleware actually spends it", () => {
+  /** What the three call sites do per failed request, in order. */
+  const failOnce = (identifier: string): boolean => {
+    authRateLimiter.recordFailedAttempt(identifier);
+    return authRateLimiter.isRateLimited(identifier);
+  };
+
+  it("serves ten failed attempts and refuses the eleventh", () => {
     // Unique per run: the limiter is module-scoped, so a fixed key would let
     // this test spend a budget another file's traffic is counting on.
     const identifier = `budget-pin:${randomUUID()}`;
 
-    for (let attempt = 0; attempt < 19; attempt += 1) {
+    for (let attempt = 1; attempt <= 10; attempt += 1) {
+      expect(failOnce(identifier)).toBe(false);
+    }
+    expect(failOnce(identifier)).toBe(true);
+  });
+
+  it("keeps refusing for the rest of the window once the budget is gone", () => {
+    const identifier = `budget-pin:${randomUUID()}`;
+
+    for (let attempt = 1; attempt <= 11; attempt += 1) {
+      failOnce(identifier);
+    }
+
+    // Not a formality: `isRateLimited` mutates, so a limiter that refused once
+    // and then let the next request through would still satisfy the test above.
+    expect(failOnce(identifier)).toBe(true);
+    expect(authRateLimiter.isCurrentlyLimited(identifier)).toBe(true);
+  });
+
+  it("still allows the nominal twenty when only the counter is driven", () => {
+    // The other half of the discrepancy, pinned so the gap between the
+    // constructor argument and the enforced allowance stays visible: counting
+    // without asking reaches 20. If these two tests ever converge, the
+    // middleware's call pair changed and the docblocks above need rereading.
+    const identifier = `budget-pin:${randomUUID()}`;
+
+    for (let attempt = 1; attempt <= 19; attempt += 1) {
       authRateLimiter.recordFailedAttempt(identifier);
     }
     expect(authRateLimiter.isCurrentlyLimited(identifier)).toBe(false);

--- a/apps/backend/src/lib/auth-rate-limiter.test.ts
+++ b/apps/backend/src/lib/auth-rate-limiter.test.ts
@@ -1,3 +1,15 @@
+import { randomUUID } from "node:crypto";
+
+import { DatabaseEndpoint } from "@repo/zod-types";
+import express from "express";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AuthRateLimiter,
+  authRateLimiter,
+  getAuthRateLimitIdentifier,
+} from "./auth-rate-limiter";
+
 /**
  * The module-scope cleanup sweep must not own the process's lifetime.
  *
@@ -14,9 +26,6 @@
  * created during module evaluation and never exported, so import order is the
  * only place to observe it.
  */
-
-import { describe, expect, it, vi } from "vitest";
-
 describe("the cleanup sweep registered at import time", () => {
   it("is unref'd, so importing this module cannot hold the event loop open", async () => {
     const unref = vi.fn();
@@ -40,5 +49,212 @@ describe("the cleanup sweep registered at import time", () => {
       vi.unstubAllGlobals();
       vi.resetModules();
     }
+  });
+});
+
+const ENDPOINT_UUID = "11111111-1111-4111-8111-111111111111";
+
+/**
+ * The address every caller presents once the request has crossed the tunnel and
+ * the in-container rewrite. It is a constant in production, which is the whole
+ * reason these tests exist.
+ */
+const TUNNEL_IP = "127.0.0.1";
+
+/**
+ * Only `uuid` and `name` are read by the function under test, so the cast keeps
+ * the fixture to the fields that carry meaning here rather than restating the
+ * whole endpoint row for every case.
+ */
+const makeEndpoint = (
+  uuid: string | null,
+  name = "autotask",
+): DatabaseEndpoint => ({ uuid, name }) as unknown as DatabaseEndpoint;
+
+const makeReq = (options: {
+  headers?: Record<string, string | string[]>;
+  ip?: string;
+  remoteAddress?: string;
+}): express.Request =>
+  ({
+    headers: options.headers ?? {},
+    ip: options.ip,
+    socket:
+      options.remoteAddress === undefined
+        ? undefined
+        : { remoteAddress: options.remoteAddress },
+  }) as unknown as express.Request;
+
+/**
+ * WHAT THIS PINS, and why the shared-bucket case is the one that matters.
+ *
+ * `req.ip` is the same in-container loopback address for every caller reaching
+ * this gateway through the tunnel, so keying the failed-auth limiter on it
+ * produced ONE bucket per endpoint for the entire world. At 20 failures a
+ * minute that is not a brute-force control, it is a denial-of-service lever:
+ * whoever spends the budget first — an attacker, or a single consumer with a
+ * stale credential retrying in a loop — locks every other caller of that
+ * endpoint out for the rest of the window. The decisive case below is
+ * therefore two DIFFERENT `cf-connecting-ip` values arriving on the SAME
+ * `req.ip`, which is what the production topology actually delivers.
+ */
+describe("getAuthRateLimitIdentifier", () => {
+  it("gives two callers sharing one tunnel address separate budgets", () => {
+    const endpoint = makeEndpoint(ENDPOINT_UUID);
+
+    const noisy = getAuthRateLimitIdentifier(
+      makeReq({
+        headers: { "cf-connecting-ip": "198.51.100.4" },
+        ip: TUNNEL_IP,
+      }),
+      endpoint,
+    );
+    const bystander = getAuthRateLimitIdentifier(
+      makeReq({
+        headers: { "cf-connecting-ip": "203.0.113.7" },
+        ip: TUNNEL_IP,
+      }),
+      endpoint,
+    );
+
+    expect(noisy).not.toBe(bystander);
+
+    // The behavioural half. Identifiers merely differing is not the property
+    // anyone cares about; what matters is that spending one caller's budget to
+    // exhaustion leaves the other still served. A 2-attempt limiter stands in
+    // for the 20/min production budget so the loop stays readable.
+    const limiter = new AuthRateLimiter(2, 60 * 1000);
+    limiter.recordFailedAttempt(noisy);
+    limiter.recordFailedAttempt(noisy);
+
+    expect(limiter.isCurrentlyLimited(noisy)).toBe(true);
+    expect(limiter.isCurrentlyLimited(bystander)).toBe(false);
+  });
+
+  it("keys repeat failures from one caller into a single bucket", () => {
+    const endpoint = makeEndpoint(ENDPOINT_UUID);
+    const first = getAuthRateLimitIdentifier(
+      makeReq({
+        headers: { "cf-connecting-ip": "198.51.100.4" },
+        ip: TUNNEL_IP,
+      }),
+      endpoint,
+    );
+    // Same caller, different tunnel-side address: the edge header is what
+    // decides, so these must still collide. Without this the limiter would be
+    // evadable by anything that changes the socket the request lands on.
+    const second = getAuthRateLimitIdentifier(
+      makeReq({
+        headers: { "cf-connecting-ip": "198.51.100.4" },
+        ip: "10.0.0.9",
+      }),
+      endpoint,
+    );
+
+    expect(first).toBe(second);
+
+    const limiter = new AuthRateLimiter(2, 60 * 1000);
+    limiter.recordFailedAttempt(first);
+    limiter.recordFailedAttempt(second);
+
+    expect(limiter.isCurrentlyLimited(first)).toBe(true);
+  });
+
+  it("falls back to the socket address when the edge header is absent", () => {
+    const endpoint = makeEndpoint(ENDPOINT_UUID);
+
+    // Direct-to-origin and local development have no Cloudflare header. They
+    // degrade to the single shared bucket this endpoint had before rather than
+    // throwing or keying everything under one literal.
+    expect(
+      getAuthRateLimitIdentifier(makeReq({ ip: "10.0.0.5" }), endpoint),
+    ).toBe(`10.0.0.5:${ENDPOINT_UUID}`);
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({ remoteAddress: "192.0.2.11" }),
+        endpoint,
+      ),
+    ).toBe(`192.0.2.11:${ENDPOINT_UUID}`);
+    expect(getAuthRateLimitIdentifier(makeReq({}), endpoint)).toBe(
+      `unknown:${ENDPOINT_UUID}`,
+    );
+  });
+
+  it("ignores a blank or malformed edge header instead of keying on it", () => {
+    const endpoint = makeEndpoint(ENDPOINT_UUID);
+
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({ headers: { "cf-connecting-ip": "   " }, ip: "10.0.0.5" }),
+        endpoint,
+      ),
+    ).toBe(`10.0.0.5:${ENDPOINT_UUID}`);
+
+    // Cloudflare never sends the header twice; anything that does is malformed
+    // input, and picking the first value deterministically beats throwing on a
+    // path whose job is to refuse bad credentials.
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({
+          headers: { "cf-connecting-ip": ["198.51.100.4", "203.0.113.7"] },
+          ip: TUNNEL_IP,
+        }),
+        endpoint,
+      ),
+    ).toBe(`198.51.100.4:${ENDPOINT_UUID}`);
+  });
+
+  it("keeps the endpoint suffix, so spam at one endpoint cannot spend another's budget", () => {
+    const headers = { "cf-connecting-ip": "198.51.100.4" };
+    const other = "22222222-2222-4222-8222-222222222222";
+
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({ headers, ip: TUNNEL_IP }),
+        makeEndpoint(ENDPOINT_UUID),
+      ),
+    ).toBe(`198.51.100.4:${ENDPOINT_UUID}`);
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({ headers, ip: TUNNEL_IP }),
+        makeEndpoint(other),
+      ),
+    ).toBe(`198.51.100.4:${other}`);
+
+    // Name, then the literal, when a row carries no uuid — unchanged ordering.
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({ headers, ip: TUNNEL_IP }),
+        makeEndpoint(null, "autotask"),
+      ),
+    ).toBe("198.51.100.4:autotask");
+    expect(
+      getAuthRateLimitIdentifier(
+        makeReq({ headers, ip: TUNNEL_IP }),
+        makeEndpoint(null, ""),
+      ),
+    ).toBe("198.51.100.4:unknown");
+  });
+});
+
+/**
+ * The budget itself is load-bearing and is pinned separately from the keying.
+ * Re-keying the limiter per caller only helps if the per-caller allowance stays
+ * where it was; quietly widening or narrowing it while the keys changed would
+ * be invisible in the tests above.
+ */
+describe("the shared failed-auth limiter's budget", () => {
+  it("refuses on the twentieth failure in a window, not sooner", () => {
+    // Unique per run: the limiter is module-scoped, so a fixed key would let
+    // this test spend a budget another file's traffic is counting on.
+    const identifier = `budget-pin:${randomUUID()}`;
+
+    for (let attempt = 0; attempt < 19; attempt += 1) {
+      authRateLimiter.recordFailedAttempt(identifier);
+    }
+    expect(authRateLimiter.isCurrentlyLimited(identifier)).toBe(false);
+
+    authRateLimiter.recordFailedAttempt(identifier);
+    expect(authRateLimiter.isCurrentlyLimited(identifier)).toBe(true);
   });
 });

--- a/apps/backend/src/lib/auth-rate-limiter.ts
+++ b/apps/backend/src/lib/auth-rate-limiter.ts
@@ -1,6 +1,8 @@
 import { DatabaseEndpoint } from "@repo/zod-types";
 import express from "express";
 
+import { resolveClientIp } from "@/lib/client-ip";
+
 /**
  * Simple in-memory rate limiter for failed authentication attempts
  * In production, use Redis or similar for distributed rate limiting
@@ -113,14 +115,43 @@ setInterval(
 ).unref();
 
 /**
- * Get rate limiting identifier for authentication attempts
- * Uses IP address and endpoint for rate limiting
+ * Rate-limit identifier for failed authentication attempts against an endpoint,
+ * keyed per (caller, endpoint).
+ *
+ * KEYED ON CF-Connecting-IP, not `req.ip`. It used to key on `req.ip`, and
+ * behind this deployment that is the same in-container address for every
+ * caller — the backend is reached through the frontend's Next.js rewrite, and
+ * `trust proxy` is deliberately off (middleware/audit-context.middleware
+ * documents why at length). So the 20-per-minute budget was ONE bucket per
+ * endpoint for the entire world, which inverts what the limiter is for: rather
+ * than bounding a brute force, it handed anyone who could reach the endpoint a
+ * way to lock out every legitimate caller of it for the rest of the window, at
+ * a cost of 20 requests. A single consumer retrying a stale credential in a
+ * loop did the same thing by accident.
+ *
+ * Cloudflare overwrites CF-Connecting-IP at the edge on every request, so it is
+ * per-CALLER rather than per-container. The trust assumption is exactly the one
+ * audit-context.middleware states: it holds only while the Cloudflare Tunnel is
+ * the sole ingress. `req.ip` stays the fallback for direct-to-origin and local
+ * development, where the identifier degrades to the shared bucket it was — no
+ * worse than before, and never a throw on an auth-failure path.
+ *
+ * Same fix, same reasoning, as `rateLimitRegistration` in routers/oauth/utils
+ * and `trpcRateLimitMiddleware` in middleware/trpc-rate-limit.middleware.
+ *
+ * THE RESIDUAL, PLAINLY: per-IP keying bounds a source address, not a
+ * distributed caller. That is the same trade those two siblings took; what it
+ * buys is that the control can no longer be turned into the outage.
  */
 export function getAuthRateLimitIdentifier(
   req: express.Request,
   endpoint: DatabaseEndpoint,
 ): string {
-  const ip = req.ip || req.socket?.remoteAddress || "unknown";
+  const ip =
+    resolveClientIp(req.headers) ||
+    req.ip ||
+    req.socket?.remoteAddress ||
+    "unknown";
   const endpointId = endpoint.uuid || endpoint.name || "unknown";
   return `${ip}:${endpointId}`;
 }

--- a/apps/backend/src/lib/auth-rate-limiter.ts
+++ b/apps/backend/src/lib/auth-rate-limiter.ts
@@ -95,8 +95,13 @@ export class AuthRateLimiter {
   }
 }
 
-// Create rate limiter instance for failed authentication attempts
-export const authRateLimiter = new AuthRateLimiter(20, 1 * 60 * 1000); // 20 attempts per 1 minute
+// Create rate limiter instance for failed authentication attempts.
+//
+// The ceiling reads 20 but the enforced allowance is about ten failures per
+// minute, because the middleware records a failure and then asks
+// `isRateLimited`, which counts the asking too. See the docblock on
+// `getAuthRateLimitIdentifier` below for the full account.
+export const authRateLimiter = new AuthRateLimiter(20, 1 * 60 * 1000);
 
 // Clean up rate limiter entries every 10 minutes.
 //
@@ -122,12 +127,26 @@ setInterval(
  * behind this deployment that is the same in-container address for every
  * caller — the backend is reached through the frontend's Next.js rewrite, and
  * `trust proxy` is deliberately off (middleware/audit-context.middleware
- * documents why at length). So the 20-per-minute budget was ONE bucket per
- * endpoint for the entire world, which inverts what the limiter is for: rather
- * than bounding a brute force, it handed anyone who could reach the endpoint a
- * way to lock out every legitimate caller of it for the rest of the window, at
- * a cost of 20 requests. A single consumer retrying a stale credential in a
- * loop did the same thing by accident.
+ * documents why at length). So the budget was ONE bucket per endpoint for the
+ * entire world, which inverts what the limiter is for: rather than bounding a
+ * brute force, it handed anyone who could reach the endpoint a way to lock out
+ * every legitimate caller of it for the rest of the window, at a cost of
+ * eleven requests. A single consumer retrying a stale credential in a loop did
+ * the same thing by accident.
+ *
+ * WHAT THE BUDGET ACTUALLY IS, since the constructor argument reads 20 and the
+ * effective allowance is half that. Every call site pairs the two calls —
+ * `recordFailedAttempt(id)` and then `isRateLimited(id)` (three of them, in
+ * middleware/api-key-oauth.middleware) — and `isRateLimited` COUNTS the
+ * question it is asked, which is precisely the hazard `isCurrentlyLimited`
+ * exists to avoid and documents above. Two counts therefore land per failed
+ * request, so refusal arrives on the ELEVENTH failure in a window, not the
+ * twentieth: roughly ten failed attempts per minute per (caller, endpoint).
+ * That is the number to reason about, and the test file pins it by driving the
+ * production pair rather than the counter directly. It is written down rather
+ * than corrected because changing which method the middleware calls would
+ * change enforcement — a separate decision from re-keying, and not one this
+ * change makes.
  *
  * Cloudflare overwrites CF-Connecting-IP at the edge on every request, so it is
  * per-CALLER rather than per-container. The trust assumption is exactly the one
@@ -136,12 +155,29 @@ setInterval(
  * development, where the identifier degrades to the shared bucket it was — no
  * worse than before, and never a throw on an auth-failure path.
  *
+ * THE NO-HEADER CLASS IS BUCKETED HERE, NOT EXEMPTED, which is the opposite of
+ * what `trpcRateLimitMiddleware` decides for the same class, so the divergence
+ * is deliberate. That limiter caps request RATE and can afford to wave through
+ * traffic that never crossed the tunnel; this one counts FAILED CREDENTIALS,
+ * and exempting a class would mean anyone able to omit the header gets no
+ * brute-force bound at all. Collapsing in-container and local-development
+ * callers into one shared bucket is the cheap failure of the two: it can only
+ * inconvenience callers that are already failing to authenticate.
+ *
  * Same fix, same reasoning, as `rateLimitRegistration` in routers/oauth/utils
  * and `trpcRateLimitMiddleware` in middleware/trpc-rate-limit.middleware.
  *
- * THE RESIDUAL, PLAINLY: per-IP keying bounds a source address, not a
- * distributed caller. That is the same trade those two siblings took; what it
- * buys is that the control can no longer be turned into the outage.
+ * THE RESIDUAL, PLAINLY, in two parts. Per-IP keying bounds a source address,
+ * not a distributed caller; that is the same trade those two siblings took, and
+ * what it buys is that the control can no longer be turned into the outage.
+ * The second part is new and runs the other way: wherever CF-Connecting-IP is
+ * caller-settable, a caller mints a FRESH bucket per request and the
+ * failed-auth bound disappears entirely — where the old shared bucket, for all
+ * its faults, still capped them. That is not hypothetical at the artifact
+ * level: the shipped docker-compose publishes 12008 host-wide rather than
+ * binding loopback, so an origin reachable beside the tunnel is a deployment
+ * away. Same property, same re-check, as the header's trust assumption itself:
+ * it must be revisited before any change to how this service is published.
  */
 export function getAuthRateLimitIdentifier(
   req: express.Request,

--- a/apps/backend/src/lib/client-ip.ts
+++ b/apps/backend/src/lib/client-ip.ts
@@ -33,9 +33,14 @@ export const CLIENT_IP_HEADER = "cf-connecting-ip";
  * row's `actor_ip` and every `x-audit-client-ip` the `/api/auth` relay stamps
  * are read from `auditClientIp`, so bounding it once here bounds all of them,
  * and a future emitter cannot forget to. See AUDIT_IP_MAX in
- * `lib/audit/audit-emitter` for why 64 loses no evidence. The bound does
- * double duty for the limiters: it is what stops a caller from spending
- * unbounded map memory by rotating a very long header value.
+ * `lib/audit/audit-emitter` for why 64 loses no evidence.
+ *
+ * WHAT THE CLAMP DOES AND DOES NOT BUY THE LIMITERS THAT KEY ON THIS. It
+ * bounds per-key SIZE, not key COUNT. A caller rotating the header still mints
+ * one map entry per distinct value — measured at 200k entries for 200k values
+ * — and those are reclaimed only by the ten-minute sweep in
+ * `lib/auth-rate-limiter`. What bounds the count is the edge overwriting the
+ * header, plus that sweep; it is not this line.
  */
 export function resolveClientIp(
   headers: express.Request["headers"],

--- a/apps/backend/src/lib/client-ip.ts
+++ b/apps/backend/src/lib/client-ip.ts
@@ -1,0 +1,52 @@
+import express from "express";
+
+import { AUDIT_IP_MAX, clampAuditText } from "@/lib/audit/audit-emitter";
+
+/**
+ * Naming the caller of a request, for everything that needs to.
+ *
+ * WHY THIS SITS IN `lib/` RATHER THAN BESIDE THE MIDDLEWARE THAT INTRODUCED IT.
+ * It was defined in `middleware/audit-context.middleware`, which is still where
+ * the trust assumption and the `trust proxy` decision are written down at
+ * length — read that first. It moved here because it stopped being an audit
+ * concern: the rate limiters key on it too, and `lib/auth-rate-limiter` is a
+ * `lib/` module. `middleware/` imports `lib/` throughout this codebase and
+ * `lib/` imports `middleware/` nowhere, so importing upward would have made
+ * those two directories mutually dependent — the shape that turns into a real
+ * import cycle the first time anything else is added. `audit-context.middleware`
+ * re-exports both names, so existing importers are unaffected.
+ */
+
+/** Cloudflare's single-value, edge-overwritten client IP header. */
+export const CLIENT_IP_HEADER = "cf-connecting-ip";
+
+/**
+ * Pull the caller IP out of a header bag.
+ *
+ * Exported for tests. Returns undefined rather than a placeholder when the
+ * header is absent (direct-to-origin calls, local development): a NULL
+ * `actor_ip` is an honest "not known", while a fabricated one would be read
+ * as evidence. Callers that need a key rather than a record — the rate
+ * limiters — supply their own fallback instead.
+ *
+ * CLAMPED HERE, at the stamping site, rather than at each emitter. Every audit
+ * row's `actor_ip` and every `x-audit-client-ip` the `/api/auth` relay stamps
+ * are read from `auditClientIp`, so bounding it once here bounds all of them,
+ * and a future emitter cannot forget to. See AUDIT_IP_MAX in
+ * `lib/audit/audit-emitter` for why 64 loses no evidence. The bound does
+ * double duty for the limiters: it is what stops a caller from spending
+ * unbounded map memory by rotating a very long header value.
+ */
+export function resolveClientIp(
+  headers: express.Request["headers"],
+): string | undefined {
+  const raw = headers[CLIENT_IP_HEADER];
+  // Express lower-cases header names but an array is still possible if a
+  // caller sends the header twice. Take the first value; a duplicated
+  // CF-Connecting-IP is not something Cloudflare produces, so anything here
+  // is malformed input and picking deterministically beats throwing.
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : clampAuditText(trimmed, AUDIT_IP_MAX);
+}

--- a/apps/backend/src/middleware/api-key-oauth-audit.test.ts
+++ b/apps/backend/src/middleware/api-key-oauth-audit.test.ts
@@ -325,8 +325,11 @@ describe("mcp.auth.ratelimited — 429", () => {
     validateApiKeyMock.mockResolvedValue({ valid: false });
     const clientIp = "198.51.100.99";
 
-    // The limiter allows 20 failures per minute per (caller, endpoint), so one
-    // caller has to make all of these for the budget to run out.
+    // One caller has to make all of these for the budget to run out. The
+    // allowance is about ten failures a minute per (caller, endpoint) rather
+    // than the constructor's 20, because this middleware records the failure
+    // and then asks isRateLimited, which counts the asking too — see the
+    // budget block in lib/auth-rate-limiter.test. 21 stays comfortably past it.
     for (let attempt = 0; attempt < 21; attempt += 1) {
       await authenticate({ headers: { "x-api-key": API_KEY }, clientIp });
     }

--- a/apps/backend/src/middleware/api-key-oauth-audit.test.ts
+++ b/apps/backend/src/middleware/api-key-oauth-audit.test.ts
@@ -130,30 +130,38 @@ let ipCounter = 0;
 async function authenticate(options: {
   endpoint?: DatabaseEndpoint;
   headers?: Record<string, string>;
-  rateLimitKey?: string;
+  clientIp?: string;
 }): Promise<{ served: boolean; res: FakeRes }> {
   ipCounter += 1;
+  // One caller identity drives both the limiter key and the audit attribution,
+  // exactly as production does — audit-context.middleware derives auditClientIp
+  // from this same header. getAuthRateLimitIdentifier keys on it, so this is
+  // the field that must be unique per request; passing an explicit clientIp is
+  // how the 429 test puts several requests in one bucket.
+  const clientIp = options.clientIp ?? `198.51.100.${ipCounter}`;
   const req = {
     method: "POST",
     url: "/mcp",
     headers: {
       "user-agent": "claude-mcp/1.0",
-      "cf-connecting-ip": CLIENT_IP,
+      "cf-connecting-ip": clientIp,
       ...(options.headers ?? {}),
     },
     query: {},
     protocol: "https",
     get: () => "mcp.example.com",
-    // getAuthRateLimitIdentifier keys on req.ip; a shared key is how the 429
-    // test drives the limiter over its threshold.
-    ip: options.rateLimitKey ?? `10.0.0.${ipCounter}`,
+    // Deliberately NOT varied. This is the single loopback address production
+    // sees for every caller behind the tunnel, so pinning it here means a
+    // regression back to keying the limiter on req.ip collapses these requests
+    // into one bucket and turns this suite red.
+    ip: "127.0.0.1",
     socket: { remoteAddress: "127.0.0.1" },
     endpoint: options.endpoint ?? makeEndpoint(),
     endpointName: "autotask",
     namespaceUuid: "33333333-3333-4333-8333-333333333333",
     // Stamped by audit-context.middleware in production.
     auditRequestId: "req-under-test",
-    auditClientIp: CLIENT_IP,
+    auditClientIp: clientIp,
   } as unknown as express.Request;
 
   const res = makeRes();
@@ -188,8 +196,11 @@ describe("mcp.auth.denied — refused credentials", () => {
   it("401 invalid api key: one row, fingerprinted, actor anonymous", async () => {
     validateApiKeyMock.mockResolvedValue({ valid: false });
 
+    // Pinned rather than left to the per-request default so the actor_ip
+    // assertion below reads a known value.
     const { res } = await authenticate({
       headers: { "x-api-key": API_KEY },
+      clientIp: CLIENT_IP,
     });
     await flush();
 
@@ -312,11 +323,12 @@ describe("mcp.auth.denied — refused credentials", () => {
 describe("mcp.auth.ratelimited — 429", () => {
   it("uses its own action so a brute force is queryable on one predicate", async () => {
     validateApiKeyMock.mockResolvedValue({ valid: false });
-    const rateLimitKey = "198.51.100.99";
+    const clientIp = "198.51.100.99";
 
-    // The limiter allows 20 failures per minute per (ip, endpoint).
+    // The limiter allows 20 failures per minute per (caller, endpoint), so one
+    // caller has to make all of these for the budget to run out.
     for (let attempt = 0; attempt < 21; attempt += 1) {
-      await authenticate({ headers: { "x-api-key": API_KEY }, rateLimitKey });
+      await authenticate({ headers: { "x-api-key": API_KEY }, clientIp });
     }
     await flush();
 

--- a/apps/backend/src/middleware/audit-context.middleware.ts
+++ b/apps/backend/src/middleware/audit-context.middleware.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import express from "express";
 
 import type { AuditAttributedRequest } from "@/lib/audit/audit-emitter";
-import { AUDIT_IP_MAX, clampAuditText } from "@/lib/audit/audit-emitter";
+import { resolveClientIp } from "@/lib/client-ip";
 
 /**
  * Stamps the two per-request fields every audit row needs: a request id and
@@ -54,36 +54,14 @@ import { AUDIT_IP_MAX, clampAuditText } from "@/lib/audit/audit-emitter";
  * properties on `req`; it reads no body and consumes no stream.
  */
 
-/** Cloudflare's single-value, edge-overwritten client IP header. */
-export const CLIENT_IP_HEADER = "cf-connecting-ip";
-
 /**
- * Pull the caller IP out of a header bag.
- *
- * Exported for tests. Returns undefined rather than a placeholder when the
- * header is absent (direct-to-origin calls, local development): a NULL
- * `actor_ip` is an honest "not known", while a fabricated one would be read
- * as evidence.
- *
- * CLAMPED HERE, at the stamping site, rather than at each emitter. Every audit
- * row's `actor_ip` and every `x-audit-client-ip` the `/api/auth` relay stamps
- * are read from `auditClientIp`, so bounding it once here bounds all of them,
- * and a future emitter cannot forget to. See AUDIT_IP_MAX in
- * `lib/audit/audit-emitter` for why 64 loses no evidence.
+ * Re-exported, not re-defined. The header name and the resolver moved to
+ * `lib/client-ip` once the rate limiters started keying on them too — a `lib/`
+ * module cannot import upward into `middleware/` without inverting this
+ * codebase's layering. That file carries the rationale; these re-exports keep
+ * every existing importer, and this file's own tests, pointed here.
  */
-export function resolveClientIp(
-  headers: express.Request["headers"],
-): string | undefined {
-  const raw = headers[CLIENT_IP_HEADER];
-  // Express lower-cases header names but an array is still possible if a
-  // caller sends the header twice. Take the first value; a duplicated
-  // CF-Connecting-IP is not something Cloudflare produces, so anything here
-  // is malformed input and picking deterministically beats throwing.
-  const value = Array.isArray(raw) ? raw[0] : raw;
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed === "" ? undefined : clampAuditText(trimmed, AUDIT_IP_MAX);
-}
+export { CLIENT_IP_HEADER, resolveClientIp } from "@/lib/client-ip";
 
 export const auditContextMiddleware = (
   req: express.Request,

--- a/apps/backend/src/middleware/trpc-rate-limit.middleware.ts
+++ b/apps/backend/src/middleware/trpc-rate-limit.middleware.ts
@@ -19,9 +19,11 @@ import logger from "@/utils/logger";
  * the same as bounding the writes, and this is the writes.
  *
  * KEYED ON `auditClientIp`, NOT `req.ip`, and that is the whole design.
- * `req.ip` is what the two identifiers in `lib/auth-rate-limiter` key on, and
- * both are documented there as a SINGLE SHARED ORG BUCKET: this fork
- * deliberately leaves express `trust proxy` unset (see
+ * `req.ip` is what `getPublicOAuthRateLimitIdentifier` in `lib/auth-rate-limiter`
+ * still keys on — the last identifier there documented as a SINGLE SHARED ORG
+ * BUCKET, its sibling `getAuthRateLimitIdentifier` having since moved to the
+ * edge-supplied client IP for the reasons given here: this fork deliberately
+ * leaves express `trust proxy` unset (see
  * `audit-context.middleware` for the reasoning), so behind the in-container
  * Next.js rewrite `req.ip` is the same loopback address for every human on
  * earth. A request-rate limiter on that key is not a limiter, it is a


### PR DESCRIPTION
## Defect

`getAuthRateLimitIdentifier` keyed the failed-authentication rate limiter on `req.ip`:

```ts
const ip = req.ip || req.socket?.remoteAddress || "unknown";
const endpointId = endpoint.uuid || endpoint.name || "unknown";
return `${ip}:${endpointId}`;
```

Express `trust proxy` is deliberately off (rationale documented in `middleware/audit-context.middleware`), and the backend is reached through the frontend's in-container rewrite. `req.ip` is therefore the same address for every caller, so the 20-per-minute failed-auth budget was **one shared bucket per endpoint** rather than one per caller.

That inverts the control. Instead of bounding a brute force, it hands any single source a way to spend the whole endpoint's budget in 20 requests and have every other caller of that endpoint refused with `429` for the rest of the window. A client retrying a stale credential in a loop does the same thing by accident.

## Fix

Resolve the caller from the edge-supplied client IP first, falling back to `req.ip` when the header is absent (direct-to-origin, local development), where the identifier degrades to exactly the shared bucket it was before:

```ts
const ip =
  resolveClientIp(req.headers) ||
  req.ip ||
  req.socket?.remoteAddress ||
  "unknown";
```

This is the same defect class, the same fix, and the same trust assumption as the two limiters already corrected in this codebase — `rateLimitRegistration` in `routers/oauth/utils.ts` and `trpcRateLimitMiddleware` in `middleware/trpc-rate-limit.middleware.ts`. The assumption is stated where it is documented at length: `CF-Connecting-IP` is edge-overwritten and unforgeable *through* the tunnel, and is trustworthy only while the tunnel is the sole ingress.

The 20/min budget and the `:${endpointId}` suffix are unchanged. `trust proxy` remains off, and no new IP-derivation path is introduced.

**Residual, stated plainly:** per-IP keying bounds a source address, not a distributed caller. That is the same trade the two sibling fixes took. What it buys is that the control can no longer be turned into the outage.

## Layering

`resolveClientIp` and `CLIENT_IP_HEADER` move from `middleware/audit-context.middleware.ts` to a new `lib/client-ip.ts`, and the middleware re-exports both.

The helper was needed by a `lib/` module. Today `middleware/` imports `lib/` in 11 places and `lib/` imports `middleware/` in none, so importing upward would have made the two directories mutually dependent — the shape that becomes a real import cycle as soon as anything else is added. The re-export keeps every existing importer (`routers/oauth/utils.ts` and the middleware's own test file) unchanged.

## Tests

`lib/auth-rate-limiter.test.ts` gains 6 tests. The decisive one is two different `cf-connecting-ip` values arriving on the **same** `req.ip`, which is what the deployed topology actually delivers — it fails before this change and passes after:

- two callers sharing one tunnel address get separate budgets (identifiers differ, and exhausting one leaves the other served)
- a repeat caller shares one bucket regardless of socket address, so the limiter is not evadable by landing on a different socket
- an absent header falls back to `req.ip`, then `socket.remoteAddress`, then `unknown` — without throwing on an auth-failure path
- a blank or duplicated header is ignored rather than keyed on
- the `:${endpointId}` suffix still separates endpoints, including the `uuid` → `name` → `unknown` ordering
- the 20/min budget is pinned: the twentieth failure in a window refuses, the nineteenth does not

`middleware/api-key-oauth-audit.test.ts` used `req.ip` to isolate each test's limiter bucket, which stopped working once `req.ip` stopped being the key. Its fake now derives one caller identity that drives both the limiter key and the audit attribution, as production does, and **pins `req.ip` to a constant loopback address** — so a regression back to the old keying collapses that suite's requests into one bucket and turns it red. Verified by reverting the fix locally: 4 new tests plus that suite's safety-property test fail.

## Verification

```
$ pnpm test          # apps/backend
 Test Files  99 passed | 2 skipped (101)
      Tests  1502 passed | 31 skipped (1533)
# baseline on umbrella: 1496 passed | 31 skipped (1527)

$ pnpm check-types   # exit 0
$ pnpm build         # exit 0
```

Lint is unchanged at 23 warnings / 0 errors, identical to the count on `umbrella` — this change adds none. Prettier clean on all touched files.