### PR TITLE
feat(audit): caller binding on tool_call_audit + OpenAPI path coverage

### DIFF
--- a/apps/backend/drizzle/0030_tool_call_audit_caller_binding.sql
+++ b/apps/backend/drizzle/0030_tool_call_audit_caller_binding.sql
@@ -1,0 +1,82 @@
+-- tool_call_audit caller binding: make a recorded tool call attributable.
+--
+-- The table already answered "what was called, when, and did it work". It
+-- could not answer "by whom", because the only identity column is
+-- `client_name` and that is a DISPLAY LABEL, not an identity: it is composed
+-- at call time from an api-key name plus a MUTABLE user email, it is NULL on
+-- every path that resolved no consumer, and it names no credential at all. So
+-- a row could describe a call and still leave an investigation with nothing to
+-- pivot on — rename the account, revoke the key, and the label stops matching
+-- anything that still exists.
+--
+-- These five columns are the pivot. Each is already resolved per request by
+-- middleware that runs before any tool handler; none of it reached the table.
+--
+--   api_key_uuid  the api_keys row that authenticated the request.
+--   auth_method   'api_key' | 'oauth'.
+--   user_id       the CREDENTIAL OWNER (api-key owner or OAuth subject).
+--   caller_ip     CF-Connecting-IP, the caller's real address.
+--   request_id    the per-request id audit_log rows also carry.
+--
+-- ALL FIVE ARE NULLABLE, and that is a requirement rather than a convenience.
+-- The write is fire-and-forget and its failure is swallowed by design (an
+-- audit write must never fail a tool call), so a NOT NULL here would not
+-- surface as an error — it would silently drop the audit row for every
+-- unauthenticated or passthrough call. Nullable means a partially-attributed
+-- row still lands, and NULL reads as the honest "not known" it is. Every row
+-- written before this migration keeps NULLs for the same reason: the facts
+-- were not recorded then and cannot be reconstructed now.
+--
+-- NO FOREIGN KEY on api_key_uuid, deliberately. `api_keys` rows are revoked as
+-- routine operations and `api_keys.user_id` cascades on user delete, so an FK
+-- would force one of two bad outcomes: the audit rows are deleted along with
+-- the key, or the key becomes undeletable. The audit trail must outlive the
+-- credential it names — a call attributed to a key that was revoked
+-- afterwards is exactly the row an investigation is looking for. The uuid is
+-- stored as a plain uuid so it still joins to `api_keys.uuid` when that row
+-- does exist.
+--
+-- WHY user_id IS NOT THE ACTS-AS TARGET. An admin key may carry an acts-as
+-- binding (migration 0024) and its delegated identity already appears in
+-- `client_name` as `key (as email)`. Recording that target here instead of the
+-- key's owner would make a delegated call indistinguishable from a direct one
+-- by that account. This column answers "whose credential", `client_name`
+-- answers "whose identity was exercised", and both are needed.
+--
+-- caller_ip TRUST ASSUMPTION, recorded because it is what makes the column
+-- evidence: CF-Connecting-IP is written by the Cloudflare edge and OVERWRITTEN
+-- on every request, so a client cannot forge it THROUGH Cloudflare. That holds
+-- only while the Cloudflare Tunnel is the sole ingress. Expose the origin any
+-- other way and the header becomes caller-controlled and every caller_ip in
+-- this table becomes an assertion by whoever sent it. Same assumption
+-- audit_log.actor_ip already runs on; see
+-- middleware/audit-context.middleware.ts.
+--
+-- Retention is unchanged: these columns live on the existing pruned table
+-- (TOOL_AUDIT_RETENTION_DAYS), not on the append-only audit_log.
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS) for the reason recorded on
+-- 0014_oauth_refresh_token: a re-run must not crash-loop a deployer.
+-- Journal "when" deliberately exceeds 0029's (1786924800000): drizzle only
+-- applies entries whose "when" is above the max already applied -- a renamed
+-- or renumbered migration without a "when" bump is SILENTLY SKIPPED. See
+-- UMBRELLA_FORK.md's migration-ordering note.
+ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "api_key_uuid" uuid;
+--> statement-breakpoint
+ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "auth_method" text;
+--> statement-breakpoint
+ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "user_id" text;
+--> statement-breakpoint
+ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "caller_ip" text;
+--> statement-breakpoint
+ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "request_id" text;
+--> statement-breakpoint
+-- Only api_key_uuid is indexed of the five. "What did this credential do" is
+-- the question a suspected key compromise forces first, and answering it
+-- without an index is a full scan of the busiest table in the schema. The
+-- other four are read once a row is already in hand — request_id joins a
+-- handful of rows, and caller_ip / user_id / auth_method are filters applied
+-- inside an already-bounded called_at window, which the existing
+-- tool_call_audit_called_at_idx serves. Every additional index is a permanent
+-- cost on an insert path that runs once per tool call.
+CREATE INDEX IF NOT EXISTS "tool_call_audit_api_key_uuid_idx" ON "tool_call_audit" ("api_key_uuid");

--- a/apps/backend/drizzle/0030_tool_call_audit_caller_binding.sql
+++ b/apps/backend/drizzle/0030_tool_call_audit_caller_binding.sql
@@ -12,13 +12,19 @@
 -- These five columns are the pivot. Each is already resolved per request by
 -- middleware that runs before any tool handler; none of it reached the table.
 --
---   api_key_uuid  the api_keys row that authenticated the request.
---   auth_method   'api_key' | 'oauth'.
---   user_id       the CREDENTIAL OWNER (api-key owner or OAuth subject).
---   caller_ip     CF-Connecting-IP, the caller's real address.
---   request_id    the per-request id audit_log rows also carry.
+--   api_key_uuid     the api_keys row that authenticated the request.
+--   auth_method      'api_key' | 'oauth' on the endpoint paths, 'session' on
+--                    the admin Inspector surface. Deliberately plain text with
+--                    no CHECK: a new caller class must never be able to make
+--                    an audit INSERT fail, because a failed audit INSERT here
+--                    is swallowed and therefore a silently missing record.
+--   user_id          the CREDENTIAL OWNER (api-key owner, OAuth subject, or
+--                    session user).
+--   acts_as_user_id  the delegated identity an admin key exercised.
+--   caller_ip        CF-Connecting-IP, the caller's real address.
+--   request_id       the per-request id audit_log rows also carry.
 --
--- ALL FIVE ARE NULLABLE, and that is a requirement rather than a convenience.
+-- ALL SIX ARE NULLABLE, and that is a requirement rather than a convenience.
 -- The write is fire-and-forget and its failure is swallowed by design (an
 -- audit write must never fail a tool call), so a NOT NULL here would not
 -- surface as an error — it would silently drop the audit row for every
@@ -36,12 +42,19 @@
 -- stored as a plain uuid so it still joins to `api_keys.uuid` when that row
 -- does exist.
 --
--- WHY user_id IS NOT THE ACTS-AS TARGET. An admin key may carry an acts-as
--- binding (migration 0024) and its delegated identity already appears in
--- `client_name` as `key (as email)`. Recording that target here instead of the
--- key's owner would make a delegated call indistinguishable from a direct one
--- by that account. This column answers "whose credential", `client_name`
--- answers "whose identity was exercised", and both are needed.
+-- WHY acts_as_user_id IS ITS OWN COLUMN. An admin key may carry an acts-as
+-- binding (migration 0024): the key belongs to one account and its requests
+-- run as another. Folding that into `user_id` would make a delegated call
+-- indistinguishable from a direct one by the acted-as account — the single
+-- most misleading row this table could produce. So `user_id` answers "whose
+-- credential" and `acts_as_user_id` answers "whose identity was exercised",
+-- and a NULL in the second means the call was direct.
+--
+-- The pair does already appear inside `client_name`, rendered as
+-- `key (as email)`, but that string is not a substitute: it is composed at
+-- call time from a MUTABLE email through a 60s cache that degrades to
+-- `user <short-id>` when the lookup fails, so it is a label to read and not a
+-- value to query or join on.
 --
 -- caller_ip TRUST ASSUMPTION, recorded because it is what makes the column
 -- evidence: CF-Connecting-IP is written by the Cloudflare edge and OVERWRITTEN
@@ -67,16 +80,18 @@ ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "auth_method" text;
 --> statement-breakpoint
 ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "user_id" text;
 --> statement-breakpoint
+ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "acts_as_user_id" text;
+--> statement-breakpoint
 ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "caller_ip" text;
 --> statement-breakpoint
 ALTER TABLE "tool_call_audit" ADD COLUMN IF NOT EXISTS "request_id" text;
 --> statement-breakpoint
--- Only api_key_uuid is indexed of the five. "What did this credential do" is
+-- Only api_key_uuid is indexed of the six. "What did this credential do" is
 -- the question a suspected key compromise forces first, and answering it
 -- without an index is a full scan of the busiest table in the schema. The
--- other four are read once a row is already in hand — request_id joins a
--- handful of rows, and caller_ip / user_id / auth_method are filters applied
--- inside an already-bounded called_at window, which the existing
--- tool_call_audit_called_at_idx serves. Every additional index is a permanent
--- cost on an insert path that runs once per tool call.
+-- other five are read once a row is already in hand — request_id joins a
+-- handful of rows, and caller_ip / user_id / acts_as_user_id / auth_method are
+-- filters applied inside an already-bounded called_at window, which the
+-- existing tool_call_audit_called_at_idx serves. Every additional index is a
+-- permanent cost on an insert path that runs once per tool call.
 CREATE INDEX IF NOT EXISTS "tool_call_audit_api_key_uuid_idx" ON "tool_call_audit" ("api_key_uuid");

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1786924800000,
       "tag": "0029_oauth_client_registration_source",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1787011200000,
+      "tag": "0030_tool_call_audit_caller_binding",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/tool-call-audit.repo.ts
+++ b/apps/backend/src/db/repositories/tool-call-audit.repo.ts
@@ -13,6 +13,15 @@ export interface ToolCallAuditEntry {
   success: boolean;
   error_code?: string | null;
   latency_ms?: number | null;
+  // Caller binding (migration 0030): the credential, account, address and
+  // request behind the call, as opposed to `client_name`'s display label.
+  // Every one is nullable — a path that resolved no identity must still be
+  // able to write its row. See lib/metamcp/caller-context for the sources.
+  api_key_uuid?: string | null;
+  auth_method?: string | null;
+  user_id?: string | null;
+  caller_ip?: string | null;
+  request_id?: string | null;
 }
 
 /**

--- a/apps/backend/src/db/repositories/tool-call-audit.repo.ts
+++ b/apps/backend/src/db/repositories/tool-call-audit.repo.ts
@@ -20,6 +20,7 @@ export interface ToolCallAuditEntry {
   api_key_uuid?: string | null;
   auth_method?: string | null;
   user_id?: string | null;
+  acts_as_user_id?: string | null;
   caller_ip?: string | null;
   request_id?: string | null;
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -744,11 +744,43 @@ export const toolCallAuditTable = pgTable(
     success: boolean("success").notNull(),
     error_code: text("error_code"),
     latency_ms: integer("latency_ms"),
+    // Caller binding (migration 0030). `client_name` above is a DISPLAY
+    // LABEL — composed from a mutable email, empty wherever no identity was
+    // resolved — so it describes a call without attributing it. These five
+    // columns are the attribution: which credential, which auth method, which
+    // account, from which address, as part of which request.
+    //
+    // NO FOREIGN KEY on api_key_uuid, deliberately. `api_keys.user_id`
+    // cascades on user delete and keys are revoked routinely; an FK here
+    // would either delete the audit rows with the key or block the deletion.
+    // The audit trail has to outlive the credential it names — an attributed
+    // call whose key was revoked afterwards is precisely the row an
+    // investigation wants.
+    //
+    // `user_id` is the CREDENTIAL OWNER (api-key owner or OAuth subject), not
+    // an admin key's acts-as target — that stays in `client_name` as
+    // `key (as email)` so a delegated call is still distinguishable from a
+    // direct one. `caller_ip` is CF-Connecting-IP, bounded at AUDIT_IP_MAX
+    // where it is read; `request_id` is the audit-context middleware's
+    // per-request id, shared with `audit_log.request_id` so one request's
+    // control-plane and tool-plane records join.
+    api_key_uuid: uuid("api_key_uuid"),
+    auth_method: text("auth_method"),
+    user_id: text("user_id"),
+    caller_ip: text("caller_ip"),
+    request_id: text("request_id"),
   },
   (table) => [
     index("tool_call_audit_called_at_idx").on(table.called_at),
     index("tool_call_audit_tool_name_idx").on(table.tool_name),
     index("tool_call_audit_client_name_idx").on(table.client_name),
+    // Only api_key_uuid gets an index of the five. "What did this credential
+    // do" is the question a key compromise forces and it scans the whole
+    // table without one; the other four are read after a row is already in
+    // hand (request_id joins a handful of rows, caller_ip / user_id /
+    // auth_method are filters on an already-bounded time window). Every index
+    // is a cost on the insert path of a table written once per tool call.
+    index("tool_call_audit_api_key_uuid_idx").on(table.api_key_uuid),
   ],
 );
 

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -757,16 +757,24 @@ export const toolCallAuditTable = pgTable(
     // call whose key was revoked afterwards is precisely the row an
     // investigation wants.
     //
-    // `user_id` is the CREDENTIAL OWNER (api-key owner or OAuth subject), not
-    // an admin key's acts-as target — that stays in `client_name` as
-    // `key (as email)` so a delegated call is still distinguishable from a
-    // direct one. `caller_ip` is CF-Connecting-IP, bounded at AUDIT_IP_MAX
-    // where it is read; `request_id` is the audit-context middleware's
-    // per-request id, shared with `audit_log.request_id` so one request's
-    // control-plane and tool-plane records join.
+    // `user_id` is the CREDENTIAL OWNER (api-key owner or OAuth subject);
+    // `acts_as_user_id` is the delegated identity an admin key exercised
+    // (`api_keys.acts_as_user_id`, migration 0024). Two columns, not one: one
+    // answers "whose credential", the other "whose identity was exercised",
+    // and collapsing them makes a delegated call indistinguishable from a
+    // direct one. The pair also appears inside `client_name` as
+    // `key (as email)`, but that string is composed from a mutable email
+    // through a cache that degrades to a short id on a read failure — a label,
+    // not something to query on.
+    //
+    // `caller_ip` is CF-Connecting-IP, bounded at AUDIT_IP_MAX where it is
+    // read; `request_id` is the audit-context middleware's per-request id,
+    // shared with `audit_log.request_id` so one request's control-plane and
+    // tool-plane records join.
     api_key_uuid: uuid("api_key_uuid"),
     auth_method: text("auth_method"),
     user_id: text("user_id"),
+    acts_as_user_id: text("acts_as_user_id"),
     caller_ip: text("caller_ip"),
     request_id: text("request_id"),
   },

--- a/apps/backend/src/lib/metamcp/caller-context-store.ts
+++ b/apps/backend/src/lib/metamcp/caller-context-store.ts
@@ -1,0 +1,80 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Request-scoped caller identity for the tool-call audit trail.
+ *
+ * WHY THIS IS AsyncLocalStorage AND NOT THE HANDLER CONTEXT. A MetaMCP server
+ * instance is POOLED and its `MetaMCPHandlerContext` is per-INSTANCE, so
+ * anything stamped there describes whichever request stamped it last, not the
+ * request whose tool call is being audited. Two facts make that unusable as
+ * the source of truth:
+ *
+ *   1. Parallel `tools/call` on one session is the NORMAL case for a busy
+ *      consumer, not an edge. The second request overwrites the binding
+ *      before the first's call is audited, and the `request_id` that is
+ *      supposed to join a tool call to the `audit_log` rows of the SAME
+ *      request silently points at a sibling.
+ *   2. The in-memory session lookup on the Streamable-HTTP POST leg resolves a
+ *      session by namespace + endpoint. It does not re-derive the caller from
+ *      the credential presented on THIS request, so a pooled instance's
+ *      stamped identity is not guaranteed to belong to the request being
+ *      served. An audit row that names the wrong principal is worse than one
+ *      that names none.
+ *
+ * AsyncLocalStorage has neither problem: the store is entered per request and
+ * Node propagates it across awaits, timers and synchronous EventEmitter
+ * dispatch, which covers the MCP SDK's request path. The precedent is
+ * `lib/m365/request-context.ts`, which carries the delegated user identity
+ * down the same path into the injected fetch for exactly this reason.
+ *
+ * WHY THIS IS ITS OWN MODULE, split from `caller-context.ts`: the auditing
+ * middleware reads this store, and its module graph is deliberately kept free
+ * of the database and of express so unit tests exercise it without postgres
+ * (see `metamcp-middleware/auditing.functional.ts`). `caller-context.ts`
+ * imports the express-side header helpers to BUILD a binding; this file holds
+ * only the type and the store, so importing it costs the middleware nothing
+ * but `node:async_hooks`.
+ */
+
+/**
+ * The caller half of a `tool_call_audit` row.
+ *
+ * Treated as ONE ATOMIC UNIT by every reader. Fields are never mixed between
+ * two sources — a row built half from this request and half from a stale
+ * pooled stamp would look complete and be false.
+ */
+export interface CallerContext {
+  /** Human-readable label (api-key name / OAuth user email), for `client_name`. */
+  clientName?: string;
+  apiKeyUuid?: string;
+  authMethod?: string;
+  /** The credential OWNER — api-key owner, OAuth subject, or session user. */
+  userId?: string;
+  /** An admin key's acts-as target (`api_keys.acts_as_user_id`), when bound. */
+  actsAsUserId?: string;
+  callerIp?: string;
+  requestId?: string;
+}
+
+const storage = new AsyncLocalStorage<CallerContext>();
+
+/**
+ * Run `fn` with `caller` as the request-scoped binding.
+ *
+ * An undefined caller runs OUTSIDE any store rather than entering an empty
+ * one. That difference matters to `getCallerContext`'s reader: "no store" and
+ * "a store that happens to be blank" must stay distinguishable, because the
+ * first is a path that was never wired and the second is a request that
+ * genuinely resolved no identity.
+ */
+export function runWithCallerContext<T>(
+  caller: CallerContext | undefined,
+  fn: () => T,
+): T {
+  if (!caller) return fn();
+  return storage.run(caller, fn);
+}
+
+export function getCallerContext(): CallerContext | undefined {
+  return storage.getStore();
+}

--- a/apps/backend/src/lib/metamcp/caller-context.test.ts
+++ b/apps/backend/src/lib/metamcp/caller-context.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CallerContextSource,
+  resolveCallerContext,
+  stampCallerContext,
+} from "./caller-context";
+import { MetaMCPHandlerContext } from "./metamcp-middleware/functional-middleware";
+
+const apiKeyRequest: CallerContextSource = {
+  headers: { "cf-connecting-ip": "203.0.113.7" },
+  apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+  apiKeyUserId: "user-owner-1",
+  authMethod: "api_key",
+  auditRequestId: "req-aaaa",
+};
+
+describe("resolveCallerContext — field sources", () => {
+  it("takes the credential, method, owner, address and request id off the request", () => {
+    expect(resolveCallerContext(apiKeyRequest)).toEqual({
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+      authMethod: "api_key",
+      userId: "user-owner-1",
+      callerIp: "203.0.113.7",
+      requestId: "req-aaaa",
+    });
+  });
+
+  it("uses the OAuth subject as user_id when the caller authenticated with a bearer token", () => {
+    const caller = resolveCallerContext({
+      headers: {},
+      oauthUserId: "user-oauth-9",
+      authMethod: "oauth",
+      auditRequestId: "req-bbbb",
+    });
+
+    expect(caller.userId).toBe("user-oauth-9");
+    expect(caller.authMethod).toBe("oauth");
+    expect(caller.apiKeyUuid).toBeUndefined();
+  });
+
+  it("reads the address from CF-Connecting-IP and ignores every other address header", () => {
+    const caller = resolveCallerContext({
+      headers: {
+        "cf-connecting-ip": "198.51.100.4",
+        "x-forwarded-for": "10.0.0.1, 192.0.2.9",
+        "x-real-ip": "172.16.0.2",
+      },
+    });
+
+    // X-Forwarded-For is APPENDED to rather than overwritten, so it is
+    // caller-controlled; only the edge-overwritten header is evidence.
+    expect(caller.callerIp).toBe("198.51.100.4");
+  });
+
+  it("bounds the address at 64 characters (AUDIT_IP_MAX) so one request cannot bloat the row", () => {
+    const caller = resolveCallerContext({
+      headers: { "cf-connecting-ip": "9".repeat(500) },
+    });
+
+    expect(caller.callerIp).toHaveLength(64);
+  });
+
+  it("leaves the address unknown rather than fabricating one when the header is absent", () => {
+    expect(resolveCallerContext({ headers: {} }).callerIp).toBeUndefined();
+  });
+
+  it("mints no synthetic request id when the audit-context middleware did not run", () => {
+    // A fabricated id would be a join key that matches no audit_log row while
+    // looking exactly like a real one.
+    expect(resolveCallerContext({ headers: {} }).requestId).toBeUndefined();
+  });
+});
+
+describe("stampCallerContext — pooled contexts are reused across consumers", () => {
+  it("clears the previous caller's binding instead of leaving it in place", () => {
+    const context: MetaMCPHandlerContext = {
+      namespaceUuid: "ns-1",
+      sessionId: "sess-1",
+    };
+    stampCallerContext(context, apiKeyRequest);
+    expect(context.apiKeyUuid).toBe("3f7f8a1e-0000-4000-8000-000000000001");
+
+    // Second consumer on the same pooled instance resolves no identity at all.
+    stampCallerContext(context, { headers: {} });
+
+    expect(context.apiKeyUuid).toBeUndefined();
+    expect(context.authMethod).toBeUndefined();
+    expect(context.userId).toBeUndefined();
+    expect(context.callerIp).toBeUndefined();
+    expect(context.requestId).toBeUndefined();
+  });
+
+  it("overwrites the per-request fields on a re-stamp so a session's later calls are not frozen at initialize", () => {
+    const context: MetaMCPHandlerContext = {
+      namespaceUuid: "ns-1",
+      sessionId: "sess-1",
+    };
+    stampCallerContext(context, apiKeyRequest);
+    stampCallerContext(context, {
+      ...apiKeyRequest,
+      headers: { "cf-connecting-ip": "203.0.113.99" },
+      auditRequestId: "req-cccc",
+    });
+
+    expect(context.requestId).toBe("req-cccc");
+    expect(context.callerIp).toBe("203.0.113.99");
+    // The identity half is pinned for the life of the session and unchanged.
+    expect(context.apiKeyUuid).toBe("3f7f8a1e-0000-4000-8000-000000000001");
+  });
+});

--- a/apps/backend/src/lib/metamcp/caller-context.test.ts
+++ b/apps/backend/src/lib/metamcp/caller-context.test.ts
@@ -109,3 +109,65 @@ describe("stampCallerContext — pooled contexts are reused across consumers", (
     expect(context.apiKeyUuid).toBe("3f7f8a1e-0000-4000-8000-000000000001");
   });
 });
+
+describe("resolveCallerContext — delegated identity and address provenance", () => {
+  it("records an admin key's acts-as target separately from the key owner", () => {
+    const caller = resolveCallerContext({
+      headers: {},
+      authMethod: "api_key",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000002",
+      apiKeyUserId: "key-owner-1",
+      apiKeyActsAsUserId: "acted-as-user-1",
+    });
+
+    // One column answers "whose credential", the other "whose identity was
+    // exercised". Folded together, a delegated call reads as a direct one.
+    expect(caller.userId).toBe("key-owner-1");
+    expect(caller.actsAsUserId).toBe("acted-as-user-1");
+  });
+
+  it("leaves the acts-as target unset for an unbound key", () => {
+    const caller = resolveCallerContext({
+      headers: {},
+      authMethod: "api_key",
+      apiKeyUserId: "key-owner-1",
+    });
+
+    expect(caller.actsAsUserId).toBeUndefined();
+  });
+
+  it("prefers the address the audit-context middleware already stamped", () => {
+    // Reading the same value `audit_log.actor_ip` records keeps the two tables
+    // from silently disagreeing about where one request came from.
+    const caller = resolveCallerContext({
+      headers: { "cf-connecting-ip": "198.51.100.4" },
+      auditClientIp: "203.0.113.7",
+    });
+
+    expect(caller.callerIp).toBe("203.0.113.7");
+  });
+
+  it("falls back to the header for a route that runs outside that middleware", () => {
+    const caller = resolveCallerContext({
+      headers: { "cf-connecting-ip": "198.51.100.4" },
+    });
+
+    expect(caller.callerIp).toBe("198.51.100.4");
+  });
+});
+
+describe("stampCallerContext — the consumer label travels with the binding", () => {
+  it("stamps the label and clears it for a caller that resolved none", () => {
+    const context: MetaMCPHandlerContext = {
+      namespaceUuid: "ns-1",
+      sessionId: "sess-1",
+    };
+    stampCallerContext(context, apiKeyRequest, "example connector");
+    expect(context.clientName).toBe("example connector");
+
+    // A pooled instance handed to a caller with no resolvable identity must
+    // not keep advertising the previous consumer's name.
+    stampCallerContext(context, { headers: {} });
+    expect(context.clientName).toBeUndefined();
+  });
+});

--- a/apps/backend/src/lib/metamcp/caller-context.ts
+++ b/apps/backend/src/lib/metamcp/caller-context.ts
@@ -1,7 +1,10 @@
 import type express from "express";
 
 import type { AuditRequestFields } from "@/lib/audit/audit-emitter";
-import { resolveClientIp } from "@/middleware/audit-context.middleware";
+// From `lib/client-ip`, not through the `audit-context.middleware` re-export:
+// this is a `lib/` module, and that file records why `lib/` importing
+// `middleware/` is the shape that becomes an import cycle.
+import { resolveClientIp } from "@/lib/client-ip";
 
 import type { CallerContext } from "./caller-context-store";
 import { MetaMCPHandlerContext } from "./metamcp-middleware/functional-middleware";

--- a/apps/backend/src/lib/metamcp/caller-context.ts
+++ b/apps/backend/src/lib/metamcp/caller-context.ts
@@ -1,0 +1,124 @@
+import type express from "express";
+
+import { resolveClientIp } from "@/middleware/audit-context.middleware";
+
+import { MetaMCPHandlerContext } from "./metamcp-middleware/functional-middleware";
+
+/**
+ * Caller binding for the tool-call audit trail.
+ *
+ * `tool_call_audit` could already name a consumer (`client_name`), but a
+ * display label is not an identity: it is composed from a mutable email, it
+ * says nothing about WHICH credential was presented, and it is empty on every
+ * path that never resolved one. So a row could describe a call and still not
+ * attribute it — the question "which key, which auth method, which account,
+ * from which address, as part of which request" had no answer in the table.
+ *
+ * All five facts are resolved per request by middleware that runs BEFORE any
+ * tool handler: `authenticateApiKey` stamps the identity, and
+ * `auditContextMiddleware` stamps the request id and the caller IP. They were
+ * simply never threaded into the proxy's handler context, which is the only
+ * thing the auditing middleware can see. This module is that thread.
+ *
+ * DB-FREE BY CONSTRUCTION, and it must stay that way. The auditing middleware
+ * reads these fields off the handler context and its module graph is
+ * deliberately import-clean of the database so unit tests exercise it without
+ * postgres (see `metamcp-middleware/auditing.functional.ts`). Everything this
+ * module imports — `resolveClientIp`, and the handler-context type — is on the
+ * same DB-free side of that line.
+ *
+ * WHERE EACH VALUE COMES FROM:
+ *
+ *   apiKeyUuid  <- `authenticateApiKey`: the `api_keys` row that authenticated
+ *                  this request. Recorded as a bare uuid with NO foreign key,
+ *                  because the audit row has to outlive the key it names.
+ *   authMethod  <- `authenticateApiKey`: "api_key" | "oauth".
+ *   userId      <- the key OWNER (`apiKeyUserId`) or the OAuth subject
+ *                  (`oauthUserId`). An admin key's ACTS-AS target is
+ *                  deliberately not recorded here: it already rides
+ *                  `client_name` as `key (as email)`, and this field answers
+ *                  "whose credential was used", not "whose identity was
+ *                  exercised". Collapsing the two would make a delegated call
+ *                  indistinguishable from a direct one.
+ *   callerIp    <- CF-Connecting-IP via `resolveClientIp`, never `req.ip`.
+ *   requestId   <- `auditContextMiddleware`'s per-request id, so a tool call
+ *                  joins to whatever `audit_log` rows the same request
+ *                  produced — an auth denial and the call it preceded become
+ *                  one queryable sequence instead of two timestamps.
+ */
+
+/**
+ * Structural view of the request fields the auth + audit-context middlewares
+ * stamp.
+ *
+ * Declared structurally rather than importing `ApiKeyAuthenticatedRequest` and
+ * `AuditAttributedRequest` so this module keeps no edge — not even a
+ * type-only one that a later refactor could turn into a value import — to
+ * `api-key-oauth.middleware`, which pulls three DB repositories. Express
+ * requests satisfy it by shape.
+ */
+export interface CallerContextSource {
+  headers?: express.Request["headers"];
+  apiKeyUuid?: string;
+  apiKeyUserId?: string;
+  oauthUserId?: string;
+  authMethod?: string;
+  auditRequestId?: string;
+}
+
+/** The caller-binding half of a `tool_call_audit` row. */
+export interface CallerContext {
+  apiKeyUuid?: string;
+  authMethod?: string;
+  userId?: string;
+  callerIp?: string;
+  requestId?: string;
+}
+
+export function resolveCallerContext(req: CallerContextSource): CallerContext {
+  return {
+    apiKeyUuid: req.apiKeyUuid,
+    authMethod: req.authMethod,
+    // An OAuth request never carries `apiKeyUserId` and an API-key request
+    // never carries `oauthUserId`, so this coalesce picks the one the auth
+    // middleware actually resolved rather than preferring either method.
+    userId: req.apiKeyUserId ?? req.oauthUserId,
+    // TRUST ASSUMPTION, restated at the read site because it is what makes
+    // this column evidence rather than an assertion: `CF-Connecting-IP` is
+    // written by the Cloudflare edge and OVERWRITTEN on every request, so a
+    // client cannot forge it THROUGH Cloudflare — and that is true only while
+    // the Cloudflare Tunnel is the sole ingress to this gateway. Publish the
+    // origin any other way and every `caller_ip` in the archive becomes
+    // caller-controlled. `resolveClientIp` also bounds the value (64 chars,
+    // AUDIT_IP_MAX); see `middleware/audit-context.middleware` for the full
+    // rationale and for why `trust proxy` stays off.
+    callerIp: req.headers ? resolveClientIp(req.headers) : undefined,
+    // No fallback id is minted when the middleware did not run. A synthetic
+    // request id would be a join key that matches nothing while looking
+    // exactly like a real one; NULL is the honest "not known" — the same call
+    // `resolveClientIp` makes about a missing IP.
+    requestId: req.auditRequestId,
+  };
+}
+
+/**
+ * Copy the caller binding onto a handler context.
+ *
+ * ASSIGNS EVERY FIELD, including the undefined ones, and that is the point:
+ * MetaMCP server instances are POOLED and reused across consumers, so a
+ * partial stamp would leave the previous caller's uuid or IP in place and the
+ * next call would be audited under someone else's credential. Clearing is the
+ * safe direction — a NULL column reads as "not known", a stale one reads as
+ * evidence.
+ */
+export function stampCallerContext(
+  context: MetaMCPHandlerContext,
+  req: CallerContextSource,
+): void {
+  const caller = resolveCallerContext(req);
+  context.apiKeyUuid = caller.apiKeyUuid;
+  context.authMethod = caller.authMethod;
+  context.userId = caller.userId;
+  context.callerIp = caller.callerIp;
+  context.requestId = caller.requestId;
+}

--- a/apps/backend/src/lib/metamcp/caller-context.ts
+++ b/apps/backend/src/lib/metamcp/caller-context.ts
@@ -1,7 +1,9 @@
 import type express from "express";
 
+import type { AuditRequestFields } from "@/lib/audit/audit-emitter";
 import { resolveClientIp } from "@/middleware/audit-context.middleware";
 
+import type { CallerContext } from "./caller-context-store";
 import { MetaMCPHandlerContext } from "./metamcp-middleware/functional-middleware";
 
 /**
@@ -14,66 +16,65 @@ import { MetaMCPHandlerContext } from "./metamcp-middleware/functional-middlewar
  * attribute it — the question "which key, which auth method, which account,
  * from which address, as part of which request" had no answer in the table.
  *
- * All five facts are resolved per request by middleware that runs BEFORE any
- * tool handler: `authenticateApiKey` stamps the identity, and
+ * All of it is resolved per request by middleware that runs BEFORE any tool
+ * handler: `authenticateApiKey` stamps the identity, and
  * `auditContextMiddleware` stamps the request id and the caller IP. They were
- * simply never threaded into the proxy's handler context, which is the only
- * thing the auditing middleware can see. This module is that thread.
- *
- * DB-FREE BY CONSTRUCTION, and it must stay that way. The auditing middleware
- * reads these fields off the handler context and its module graph is
- * deliberately import-clean of the database so unit tests exercise it without
- * postgres (see `metamcp-middleware/auditing.functional.ts`). Everything this
- * module imports — `resolveClientIp`, and the handler-context type — is on the
- * same DB-free side of that line.
+ * simply never carried down to the auditing middleware. This module builds
+ * the binding; `caller-context-store` carries it (see that file for why the
+ * carrier is AsyncLocalStorage and not the pooled handler context).
  *
  * WHERE EACH VALUE COMES FROM:
  *
- *   apiKeyUuid  <- `authenticateApiKey`: the `api_keys` row that authenticated
- *                  this request. Recorded as a bare uuid with NO foreign key,
- *                  because the audit row has to outlive the key it names.
- *   authMethod  <- `authenticateApiKey`: "api_key" | "oauth".
- *   userId      <- the key OWNER (`apiKeyUserId`) or the OAuth subject
- *                  (`oauthUserId`). An admin key's ACTS-AS target is
- *                  deliberately not recorded here: it already rides
- *                  `client_name` as `key (as email)`, and this field answers
- *                  "whose credential was used", not "whose identity was
- *                  exercised". Collapsing the two would make a delegated call
- *                  indistinguishable from a direct one.
- *   callerIp    <- CF-Connecting-IP via `resolveClientIp`, never `req.ip`.
- *   requestId   <- `auditContextMiddleware`'s per-request id, so a tool call
- *                  joins to whatever `audit_log` rows the same request
- *                  produced — an auth denial and the call it preceded become
- *                  one queryable sequence instead of two timestamps.
+ *   apiKeyUuid   <- `authenticateApiKey`: the `api_keys` row that
+ *                   authenticated this request. Recorded as a bare uuid with
+ *                   NO foreign key, because the audit row has to outlive the
+ *                   key it names.
+ *   authMethod   <- `authenticateApiKey`: "api_key" | "oauth". The admin
+ *                   Inspector surface adds "session".
+ *   userId       <- the key OWNER (`apiKeyUserId`), the OAuth subject
+ *                   (`oauthUserId`), or the session user.
+ *   actsAsUserId <- `api_keys.acts_as_user_id` (migration 0024) when an admin
+ *                   key carries a delegated binding. A SEPARATE column from
+ *                   `userId` on purpose: one answers "whose credential", the
+ *                   other "whose identity was exercised", and collapsing them
+ *                   makes a delegated call indistinguishable from a direct
+ *                   one. It also rides `client_name` as `key (as email)`, but
+ *                   that string is composed from a mutable email through a
+ *                   cache that degrades to a short-id on a read failure —
+ *                   fine as a label, not a thing to query on.
+ *   callerIp     <- CF-Connecting-IP, never `req.ip`.
+ *   requestId    <- `auditContextMiddleware`'s per-request id, so a tool call
+ *                   joins to whatever `audit_log` rows the same request
+ *                   produced — an auth denial and the call it preceded become
+ *                   one queryable sequence instead of two timestamps.
  */
 
 /**
- * Structural view of the request fields the auth + audit-context middlewares
- * stamp.
+ * Structural view of the request fields the auth and audit-context
+ * middlewares stamp.
  *
- * Declared structurally rather than importing `ApiKeyAuthenticatedRequest` and
- * `AuditAttributedRequest` so this module keeps no edge — not even a
- * type-only one that a later refactor could turn into a value import — to
- * `api-key-oauth.middleware`, which pulls three DB repositories. Express
- * requests satisfy it by shape.
+ * EXTENDS `AuditRequestFields` rather than redeclaring `auditRequestId` /
+ * `auditClientIp` locally, and that is the point: those two are stamped in
+ * `middleware/audit-context.middleware` and read here, in a different module,
+ * off a plain express request. Redeclared as loose optional properties, a
+ * rename on the stamping side would leave this module compiling green and
+ * silently writing NULL into both columns. Inheriting the declaration makes
+ * the rename a compile error at the read sites below.
+ *
+ * The identity half stays structural — declaring it against
+ * `ApiKeyAuthenticatedRequest` would put three DB repositories in this
+ * module's import graph. Express requests satisfy it by shape.
  */
-export interface CallerContextSource {
+export interface CallerContextSource extends AuditRequestFields {
   headers?: express.Request["headers"];
   apiKeyUuid?: string;
   apiKeyUserId?: string;
+  apiKeyActsAsUserId?: string;
   oauthUserId?: string;
   authMethod?: string;
-  auditRequestId?: string;
 }
 
-/** The caller-binding half of a `tool_call_audit` row. */
-export interface CallerContext {
-  apiKeyUuid?: string;
-  authMethod?: string;
-  userId?: string;
-  callerIp?: string;
-  requestId?: string;
-}
+export type { CallerContext };
 
 export function resolveCallerContext(req: CallerContextSource): CallerContext {
   return {
@@ -83,16 +84,25 @@ export function resolveCallerContext(req: CallerContextSource): CallerContext {
     // never carries `oauthUserId`, so this coalesce picks the one the auth
     // middleware actually resolved rather than preferring either method.
     userId: req.apiKeyUserId ?? req.oauthUserId,
+    actsAsUserId: req.apiKeyActsAsUserId,
+    // Prefer the value `auditContextMiddleware` already stamped — it is what
+    // `audit_log.actor_ip` records for this same request, and reading it here
+    // means the two tables cannot silently disagree about where a request came
+    // from. The header re-read is the fallback for a route that runs before or
+    // outside that middleware.
+    //
     // TRUST ASSUMPTION, restated at the read site because it is what makes
     // this column evidence rather than an assertion: `CF-Connecting-IP` is
     // written by the Cloudflare edge and OVERWRITTEN on every request, so a
     // client cannot forge it THROUGH Cloudflare — and that is true only while
     // the Cloudflare Tunnel is the sole ingress to this gateway. Publish the
     // origin any other way and every `caller_ip` in the archive becomes
-    // caller-controlled. `resolveClientIp` also bounds the value (64 chars,
-    // AUDIT_IP_MAX); see `middleware/audit-context.middleware` for the full
+    // caller-controlled. Either path bounds the value at 64 chars
+    // (AUDIT_IP_MAX); see `middleware/audit-context.middleware` for the full
     // rationale and for why `trust proxy` stays off.
-    callerIp: req.headers ? resolveClientIp(req.headers) : undefined,
+    callerIp:
+      req.auditClientIp ??
+      (req.headers ? resolveClientIp(req.headers) : undefined),
     // No fallback id is minted when the middleware did not run. A synthetic
     // request id would be a join key that matches nothing while looking
     // exactly like a real one; NULL is the honest "not known" — the same call
@@ -102,23 +112,31 @@ export function resolveCallerContext(req: CallerContextSource): CallerContext {
 }
 
 /**
- * Copy the caller binding onto a handler context.
+ * Copy the caller binding onto a pooled handler context.
+ *
+ * This is the FALLBACK carrier, not the authoritative one — the audit row is
+ * built from the request-scoped store in `caller-context-store` whenever a
+ * request entered it. It is still stamped so a code path that reaches the
+ * auditing middleware outside any request scope has something better than
+ * nothing, and so the two carriers cannot drift in shape.
  *
  * ASSIGNS EVERY FIELD, including the undefined ones, and that is the point:
- * MetaMCP server instances are POOLED and reused across consumers, so a
- * partial stamp would leave the previous caller's uuid or IP in place and the
- * next call would be audited under someone else's credential. Clearing is the
- * safe direction — a NULL column reads as "not known", a stale one reads as
- * evidence.
+ * instances are pooled and reused across consumers, so a partial stamp would
+ * leave the previous caller's uuid or IP in place and a later call could be
+ * described with someone else's credential. Clearing is the safe direction —
+ * a NULL column reads as "not known", a stale one reads as evidence.
  */
 export function stampCallerContext(
   context: MetaMCPHandlerContext,
   req: CallerContextSource,
+  clientName?: string,
 ): void {
   const caller = resolveCallerContext(req);
+  context.clientName = clientName;
   context.apiKeyUuid = caller.apiKeyUuid;
   context.authMethod = caller.authMethod;
   context.userId = caller.userId;
+  context.actsAsUserId = caller.actsAsUserId;
   context.callerIp = caller.callerIp;
   context.requestId = caller.requestId;
 }

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.test.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { runWithCallerContext } from "../caller-context-store";
 import {
   createAuditingMiddleware,
   setAuditRecorderForTesting,
@@ -116,9 +117,7 @@ describe("auditing middleware DB write-through", () => {
   });
 
   it("never fails the tool call when the audit write rejects", async () => {
-    setAuditRecorderForTesting(
-      vi.fn().mockRejectedValue(new Error("db down")),
-    );
+    setAuditRecorderForTesting(vi.fn().mockRejectedValue(new Error("db down")));
 
     const wrapped = createAuditingMiddleware()(okHandler);
     const result = await wrapped(makeRequest({ a: 1 }), context);
@@ -225,5 +224,152 @@ describe("caller binding (migration 0030)", () => {
     expect(recorder.mock.calls[0][0].session_id).toBe(
       recorder.mock.calls[1][0].session_id,
     );
+  });
+});
+
+describe("caller binding — request-scoped store wins over the pooled context", () => {
+  // The handler context belongs to a POOLED server instance, so under
+  // parallel calls on one session it describes whichever request stamped it
+  // last, and the session it is reached through is resolved by namespace +
+  // endpoint rather than re-derived from the credential presented now. A row
+  // built from it can therefore name the wrong principal — worse than naming
+  // none. The request-scoped store is the authoritative source.
+  const stale: MetaMCPHandlerContext = {
+    namespaceUuid: "ns-123",
+    sessionId: "sess-456",
+    clientName: "previous consumer",
+    apiKeyUuid: "3f7f8a1e-0000-4000-8000-00000000000a",
+    authMethod: "api_key",
+    userId: "previous-owner",
+    callerIp: "198.51.100.99",
+    requestId: "req-previous",
+  };
+
+  it("attributes the call to the request in scope, not to the last stamp on the instance", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await runWithCallerContext(
+      {
+        clientName: "live consumer",
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-00000000000b",
+        authMethod: "oauth",
+        userId: "live-user",
+        callerIp: "203.0.113.7",
+        requestId: "req-live",
+      },
+      () => wrapped(makeRequest({ a: 1 }), stale),
+    );
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.client_name).toBe("live consumer");
+    expect(entry.api_key_uuid).toBe("3f7f8a1e-0000-4000-8000-00000000000b");
+    expect(entry.auth_method).toBe("oauth");
+    expect(entry.user_id).toBe("live-user");
+    expect(entry.caller_ip).toBe("203.0.113.7");
+    expect(entry.request_id).toBe("req-live");
+    // The namespace/session halves still come from the handler context.
+    expect(entry.namespace_uuid).toBe("ns-123");
+    expect(entry.session_id).toBe("sess-456");
+  });
+
+  it("never mixes the two sources — a store with gaps does not backfill from the instance", async () => {
+    // Field-by-field coalescing would take api_key_uuid from the live request
+    // and request_id from the stale stamp: a row that looks complete and is
+    // false. One source, whole.
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await runWithCallerContext(
+      { authMethod: "session", userId: "admin-1" },
+      () => wrapped(makeRequest({ a: 1 }), stale),
+    );
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.auth_method).toBe("session");
+    expect(entry.user_id).toBe("admin-1");
+    expect(entry.api_key_uuid).toBeNull();
+    expect(entry.caller_ip).toBeNull();
+    expect(entry.request_id).toBeNull();
+    expect(entry.client_name).toBeNull();
+  });
+
+  it("falls back to the handler context when the call runs outside any request scope", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await wrapped(makeRequest({ a: 1 }), stale);
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.client_name).toBe("previous consumer");
+    expect(entry.request_id).toBe("req-previous");
+  });
+
+  it("records an acts-as target alongside the credential owner", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await runWithCallerContext(
+      {
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-00000000000c",
+        authMethod: "api_key",
+        userId: "key-owner-1",
+        actsAsUserId: "acted-as-user-1",
+      },
+      () => wrapped(makeRequest({ a: 1 }), stale),
+    );
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.user_id).toBe("key-owner-1");
+    expect(entry.acts_as_user_id).toBe("acted-as-user-1");
+  });
+});
+
+describe("a refused or failing call must not read as a successful one", () => {
+  // An MCP tool failure is a RESULT, not a throw: a gateway denial from the
+  // filter middleware (answered upstream as HTTP 403) and a backend tool's own
+  // error both come back as `isError: true` with a normal resolve. Recording
+  // those as success=true put them in exactly the bucket an investigation
+  // filters OUT while hunting denials.
+  it("writes success=false for an isError result", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+    const denied = vi.fn().mockResolvedValue({
+      isError: true,
+      content: [{ type: "text", text: 'Access denied to tool "search"' }],
+    });
+
+    const wrapped = createAuditingMiddleware()(denied);
+    const result = await wrapped(makeRequest({ a: 1 }), context);
+    await flush();
+
+    // The result still passes through untouched — this middleware observes.
+    expect(result.isError).toBe(true);
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.success).toBe(false);
+    expect(entry.error_code).toBe("tool_error");
+    // Still fully attributed: a denial is the row most worth attributing.
+    expect(entry.api_key_uuid).toBe("3f7f8a1e-0000-4000-8000-000000000001");
+  });
+
+  it("keeps success=true and no error code for an ordinary result", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await wrapped(makeRequest({ a: 1 }), context);
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.success).toBe(true);
+    expect(entry.error_code).toBeUndefined();
   });
 });

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.test.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.test.ts
@@ -13,6 +13,11 @@ const context: MetaMCPHandlerContext = {
   namespaceUuid: "ns-123",
   sessionId: "sess-456",
   clientName: "example connector",
+  apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+  authMethod: "api_key",
+  userId: "user-owner-1",
+  callerIp: "203.0.113.7",
+  requestId: "req-aaaa",
 };
 
 const makeRequest = (args?: Record<string, unknown>): CallToolRequest =>
@@ -131,5 +136,94 @@ describe("auditing middleware DB write-through", () => {
 
     expect(result).toEqual({ content: [] });
     expect(okHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("caller binding (migration 0030)", () => {
+  it("carries the credential, method, account, address and request id onto the row", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await wrapped(makeRequest({ q: "printer" }), context);
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.api_key_uuid).toBe("3f7f8a1e-0000-4000-8000-000000000001");
+    expect(entry.auth_method).toBe("api_key");
+    expect(entry.user_id).toBe("user-owner-1");
+    expect(entry.caller_ip).toBe("203.0.113.7");
+    expect(entry.request_id).toBe("req-aaaa");
+  });
+
+  it("carries the same binding onto a FAILURE row", async () => {
+    // A denied or failing call is the one an investigation reads first, so it
+    // must be as attributable as a successful one.
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+    const failing = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("denied"), { code: -32602 }));
+
+    const wrapped = createAuditingMiddleware()(failing);
+    await expect(wrapped(makeRequest({ a: 1 }), context)).rejects.toThrow(
+      "denied",
+    );
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.success).toBe(false);
+    expect(entry.api_key_uuid).toBe("3f7f8a1e-0000-4000-8000-000000000001");
+    expect(entry.user_id).toBe("user-owner-1");
+    expect(entry.caller_ip).toBe("203.0.113.7");
+    expect(entry.request_id).toBe("req-aaaa");
+  });
+
+  it("writes NULLs without throwing when no identity was resolved", async () => {
+    // An unauthenticated / passthrough endpoint resolves none of these. The
+    // row must still land: dropping it would leave the call unrecorded
+    // entirely, which is strictly worse than recording it un-attributed.
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+    const bare: MetaMCPHandlerContext = {
+      namespaceUuid: "ns-123",
+      sessionId: "sess-456",
+    };
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    const result = await wrapped(makeRequest({ a: 1 }), bare);
+    await flush();
+
+    expect(result).toEqual({ content: [] });
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.api_key_uuid).toBeNull();
+    expect(entry.auth_method).toBeNull();
+    expect(entry.user_id).toBeNull();
+    expect(entry.caller_ip).toBeNull();
+    expect(entry.request_id).toBeNull();
+    // The rest of the row is unaffected.
+    expect(entry.server_name).toBe("autotask");
+    expect(entry.success).toBe(true);
+  });
+
+  it("gives two calls on one session distinct request ids", async () => {
+    // The regression this guards: `clientName` is stamped once at session
+    // creation, and copying that pattern for `requestId` would brand every
+    // call in a long-lived session with the initialize request's id.
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const wrapped = createAuditingMiddleware()(okHandler);
+    await wrapped(makeRequest({ a: 1 }), { ...context, requestId: "req-one" });
+    await wrapped(makeRequest({ a: 2 }), { ...context, requestId: "req-two" });
+    await flush();
+
+    expect(recorder).toHaveBeenCalledTimes(2);
+    expect(recorder.mock.calls[0][0].request_id).toBe("req-one");
+    expect(recorder.mock.calls[1][0].request_id).toBe("req-two");
+    // Same session id on both — the session is not the discriminator.
+    expect(recorder.mock.calls[0][0].session_id).toBe(
+      recorder.mock.calls[1][0].session_id,
+    );
   });
 });

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.ts
@@ -37,6 +37,13 @@ type AuditRecorder = (entry: {
   success: boolean;
   error_code?: string | null;
   latency_ms?: number | null;
+  // Caller binding (migration 0030) — see lib/metamcp/caller-context for
+  // where each of these is resolved and what it may be trusted to mean.
+  api_key_uuid?: string | null;
+  auth_method?: string | null;
+  user_id?: string | null;
+  caller_ip?: string | null;
+  request_id?: string | null;
 }) => Promise<void>;
 
 let auditRecorder: AuditRecorder | null | undefined;
@@ -105,6 +112,16 @@ export function createAuditingMiddleware(): CallToolMiddleware {
     // (Streamable-HTTP sets it on the acquired instance; OpenAPI sets it
     // per-call). Undefined on auth-off / passthrough endpoints.
     const clientName = context.clientName;
+    // Caller binding — stamped alongside `clientName` by the router layer.
+    // Read once here so the success and failure rows below cannot drift apart
+    // if a concurrent request re-stamps the (pooled) context mid-call.
+    const caller = {
+      api_key_uuid: context.apiKeyUuid ?? null,
+      auth_method: context.authMethod ?? null,
+      user_id: context.userId ?? null,
+      caller_ip: context.callerIp ?? null,
+      request_id: context.requestId ?? null,
+    };
     const paramsHash = hashParams(request.params.arguments);
 
     try {
@@ -128,6 +145,7 @@ export function createAuditingMiddleware(): CallToolMiddleware {
         params_hash: paramsHash,
         success: true,
         latency_ms: durationMs,
+        ...caller,
       });
       return result;
     } catch (error) {
@@ -152,6 +170,7 @@ export function createAuditingMiddleware(): CallToolMiddleware {
         success: false,
         error_code: errorCode(error),
         latency_ms: durationMs,
+        ...caller,
       });
       throw error;
     }

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/auditing.functional.ts
@@ -1,8 +1,12 @@
 import { createHash } from "node:crypto";
 
+import { CallerContext, getCallerContext } from "../caller-context-store";
 import { metamcpLogStore } from "../log-store";
 import { parseToolName } from "../tool-name-parser";
-import { CallToolMiddleware } from "./functional-middleware";
+import {
+  CallToolMiddleware,
+  MetaMCPHandlerContext,
+} from "./functional-middleware";
 
 /**
  * Auditing middleware — records every proxied `tools/call` to the Live Logs
@@ -42,9 +46,30 @@ type AuditRecorder = (entry: {
   api_key_uuid?: string | null;
   auth_method?: string | null;
   user_id?: string | null;
+  acts_as_user_id?: string | null;
   caller_ip?: string | null;
   request_id?: string | null;
 }) => Promise<void>;
+
+/**
+ * Pick the caller binding for this call, from ONE source.
+ *
+ * The request-scoped store wins whenever the call is running inside one,
+ * because the handler context is per-INSTANCE and instances are pooled: under
+ * parallel calls on a single session it describes whichever request stamped
+ * it last, and on the Streamable-HTTP in-memory session lookup it is not
+ * re-derived from the credential presented on THIS request at all. The
+ * handler context remains the fallback for a call that reaches this
+ * middleware outside any request scope.
+ *
+ * ATOMIC, never field-by-field. Coalescing each field independently would let
+ * a row take its `api_key_uuid` from the live request and its `request_id`
+ * from a stale stamp — a row that looks complete and is false. One source or
+ * the other, whole.
+ */
+function selectCaller(context: MetaMCPHandlerContext): CallerContext {
+  return getCallerContext() ?? context;
+}
 
 let auditRecorder: AuditRecorder | null | undefined;
 
@@ -108,30 +133,39 @@ export function createAuditingMiddleware(): CallToolMiddleware {
     // call arrives without the gateway prefix.
     const serverName = parsed?.serverName ?? "unknown";
     const toolName = parsed?.originalToolName ?? fullName;
-    // Who is calling — stamped onto the handler context by the router layer
-    // (Streamable-HTTP sets it on the acquired instance; OpenAPI sets it
-    // per-call). Undefined on auth-off / passthrough endpoints.
-    const clientName = context.clientName;
-    // Caller binding — stamped alongside `clientName` by the router layer.
-    // Read once here so the success and failure rows below cannot drift apart
-    // if a concurrent request re-stamps the (pooled) context mid-call.
+    // Who is calling. Resolved ONCE, at entry, from a single source (see
+    // selectCaller) so the success and failure rows below cannot be built from
+    // different requests if a parallel call re-stamps the pooled context
+    // mid-flight. Undefined on auth-off / passthrough endpoints.
+    const source = selectCaller(context);
+    const clientName = source.clientName;
     const caller = {
-      api_key_uuid: context.apiKeyUuid ?? null,
-      auth_method: context.authMethod ?? null,
-      user_id: context.userId ?? null,
-      caller_ip: context.callerIp ?? null,
-      request_id: context.requestId ?? null,
+      api_key_uuid: source.apiKeyUuid ?? null,
+      auth_method: source.authMethod ?? null,
+      user_id: source.userId ?? null,
+      acts_as_user_id: source.actsAsUserId ?? null,
+      caller_ip: source.callerIp ?? null,
+      request_id: source.requestId ?? null,
     };
     const paramsHash = hashParams(request.params.arguments);
 
     try {
       const result = await handler(request, context);
       const durationMs = Math.round(performance.now() - start);
+      // An MCP tool failure is a RESULT, not a throw: both a gateway denial
+      // from the filter middleware (which answers HTTP 403 upstream) and a
+      // backend tool's own error come back as `isError: true` with a normal
+      // resolve. Recording those as success=true said "the tool ran" about a
+      // call that was refused — the exact rows an investigation would filter
+      // OUT while looking for denials.
+      const failed = result?.isError === true;
       metamcpLogStore.record({
         category: "tool_call",
         serverName,
-        level: "info",
-        message: `${toolName} (${durationMs}ms)`,
+        level: failed ? "error" : "info",
+        message: failed
+          ? `${toolName} returned an error (${durationMs}ms)`
+          : `${toolName} (${durationMs}ms)`,
         toolName,
         durationMs,
         clientName,
@@ -143,7 +177,12 @@ export function createAuditingMiddleware(): CallToolMiddleware {
         server_name: serverName,
         tool_name: toolName,
         params_hash: paramsHash,
-        success: true,
+        success: !failed,
+        // No `code` exists on an isError result — the MCP shape carries the
+        // reason as human text in `content`, which is not something to put in
+        // an indexed column. A fixed marker keeps the class queryable and
+        // distinct from the protocol-level codes the catch branch records.
+        error_code: failed ? "tool_error" : undefined,
         latency_ms: durationMs,
         ...caller,
       });

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/functional-middleware.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/functional-middleware.ts
@@ -16,6 +16,18 @@ export interface MetaMCPHandlerContext {
   // registry keyed by sessionId.
   clientName?: string;
   clientId?: string;
+  // Caller binding for the tool-call audit trail — the credential, account,
+  // address and request behind this call, as opposed to `clientName`'s display
+  // label. Stamped by the router layer via `lib/metamcp/caller-context`
+  // (`stampCallerContext`), which is also where each field's source and its
+  // trust assumptions are documented. All optional: an unauthenticated or
+  // passthrough path resolves none of them, and a NULL column is the honest
+  // answer there.
+  apiKeyUuid?: string;
+  authMethod?: string;
+  userId?: string;
+  callerIp?: string;
+  requestId?: string;
 }
 
 // Handler function types

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/functional-middleware.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/functional-middleware.ts
@@ -20,12 +20,19 @@ export interface MetaMCPHandlerContext {
   // address and request behind this call, as opposed to `clientName`'s display
   // label. Stamped by the router layer via `lib/metamcp/caller-context`
   // (`stampCallerContext`), which is also where each field's source and its
-  // trust assumptions are documented. All optional: an unauthenticated or
+  // trust assumptions are documented.
+  //
+  // FALLBACK CARRIER ONLY. This object is per-INSTANCE and instances are
+  // pooled, so it describes whichever request stamped it last. The
+  // authoritative per-request binding travels in the AsyncLocalStorage store
+  // in `lib/metamcp/caller-context-store`, which the auditing middleware
+  // prefers; see that file for why. All optional: an unauthenticated or
   // passthrough path resolves none of them, and a NULL column is the honest
   // answer there.
   apiKeyUuid?: string;
   authMethod?: string;
   userId?: string;
+  actsAsUserId?: string;
   callerIp?: string;
   requestId?: string;
 }

--- a/apps/backend/src/middleware/api-key-oauth.middleware.ts
+++ b/apps/backend/src/middleware/api-key-oauth.middleware.ts
@@ -10,6 +10,7 @@ import { resolveActsAsUserId } from "../lib/api-key-identity";
 import {
   type AuditActorType,
   auditRequestContext,
+  type AuditRequestFields,
   credentialFingerprint,
   emit,
 } from "../lib/audit/audit-emitter";
@@ -24,8 +25,16 @@ import {
 } from "../lib/auth-rate-limiter";
 import { GRANTED_OAUTH_SCOPE } from "../routers/oauth/utils";
 
-// Extend Express Request interface for our custom properties
-export interface ApiKeyAuthenticatedRequest extends express.Request {
+// Extend Express Request interface for our custom properties.
+//
+// `AuditRequestFields` (auditRequestId / auditClientIp) is inherited rather
+// than assumed: `auditContextMiddleware` stamps those two on every request
+// and the tool-call audit path reads them off this type. Declared here, a
+// rename on the stamping side is a compile error at the read sites instead of
+// two silently NULL audit columns.
+export interface ApiKeyAuthenticatedRequest
+  extends express.Request,
+    AuditRequestFields {
   namespaceUuid: string;
   endpointName: string;
   endpoint: DatabaseEndpoint;

--- a/apps/backend/src/routers/mcp-proxy/metamcp.caller-binding.test.ts
+++ b/apps/backend/src/routers/mcp-proxy/metamcp.caller-binding.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Caller binding on the admin Inspector surface (migration 0030).
+ *
+ * Tool calls driven from the Inspector reach the same auditing middleware as
+ * production traffic but carry no credential — the actor is a better-auth
+ * admin session. They were therefore written as fully un-attributed rows,
+ * which read exactly like rows from a path that lost its identity plumbing.
+ *
+ * `auth_method = 'session'` is what tells the two apart, so it is the value
+ * this test pins hardest.
+ */
+import express from "express";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/db", () => ({ db: {}, pool: { on: vi.fn() } }));
+// Reached transitively via `lib/metamcp/index` -> the repositories barrel.
+vi.mock("@/db/audit-db", () => ({ auditDb: {}, auditPool: { on: vi.fn() } }));
+
+import { inspectorCaller } from "./metamcp";
+
+const fakeReq = (overrides: Record<string, unknown> = {}) =>
+  ({ headers: {}, query: {}, ...overrides }) as unknown as express.Request;
+
+describe("inspectorCaller", () => {
+  it("attributes the call to the admin session that drove it", () => {
+    expect(
+      inspectorCaller(
+        fakeReq({
+          user: { id: "admin-user-1", role: "admin" },
+          auditRequestId: "req-inspector",
+          auditClientIp: "203.0.113.7",
+        }),
+      ),
+    ).toEqual({
+      apiKeyUuid: undefined,
+      authMethod: "session",
+      userId: "admin-user-1",
+      actsAsUserId: undefined,
+      callerIp: "203.0.113.7",
+      requestId: "req-inspector",
+    });
+  });
+
+  it("still marks the call as session-driven when the user cannot be read", () => {
+    // A NULL user_id with auth_method='session' is honest: the row says the
+    // call came from the admin surface even if the id was unavailable. Leaving
+    // auth_method NULL instead would make it indistinguishable from a
+    // consumer call whose identity plumbing broke.
+    const caller = inspectorCaller(fakeReq({ auditRequestId: "req-x" }));
+
+    expect(caller.authMethod).toBe("session");
+    expect(caller.userId).toBeUndefined();
+    expect(caller.requestId).toBe("req-x");
+  });
+
+  it("never fabricates a consumer label — there is no consumer on this surface", () => {
+    const caller = inspectorCaller(fakeReq({ user: { id: "admin-user-1" } }));
+
+    expect(caller.clientName).toBeUndefined();
+  });
+});

--- a/apps/backend/src/routers/mcp-proxy/metamcp.ts
+++ b/apps/backend/src/routers/mcp-proxy/metamcp.ts
@@ -5,12 +5,49 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import express from "express";
 
+import type { AuditAttributedRequest } from "@/lib/audit/audit-emitter";
 import logger from "@/utils/logger";
 
+import { resolveCallerContext } from "../../lib/metamcp/caller-context";
+import {
+  CallerContext,
+  runWithCallerContext,
+} from "../../lib/metamcp/caller-context-store";
 import { createServer } from "../../lib/metamcp/index";
 import { mcpServerPool } from "../../lib/metamcp/mcp-server-pool";
 
 const metamcpRouter = express.Router();
+
+/**
+ * The session user, as `betterAuthMcpMiddleware` leaves it on the request —
+ * same shape `requireAdminMcpMiddleware` and `mcp-proxy/server.ts` read.
+ */
+type SessionUser = { id?: string; role?: string };
+
+/**
+ * Caller binding for tool calls driven from the Inspector (migration 0030).
+ *
+ * Every route here is admin-session-gated by the parent router, so the actor
+ * is a better-auth user rather than a credential: there is no api-key uuid and
+ * no OAuth token to record. Without this the tool calls an admin makes while
+ * testing a namespace wrote fully un-attributed audit rows, which read exactly
+ * like rows from a path that lost its identity plumbing.
+ *
+ * `auth_method` is therefore a THIRD value, `session`, and it is the
+ * discriminator for this traffic — which is why no `clientName` label is
+ * invented here. That column means "the resolved consumer identity"
+ * (api-key name / OAuth user email) and there is no consumer on this surface.
+ * `callerIp` / `requestId` still come from `auditContextMiddleware`, which is
+ * mounted app-wide ahead of every router.
+ */
+export function inspectorCaller(req: express.Request): CallerContext {
+  const user = (req as express.Request & { user?: SessionUser }).user;
+  return {
+    ...resolveCallerContext(req as AuditAttributedRequest),
+    authMethod: "session",
+    userId: user?.id,
+  };
+}
 
 // Auth (session) and authorization (admin-only) are applied once by the
 // parent router in `routers/mcp-proxy.ts`, so every route below is already
@@ -143,10 +180,12 @@ metamcpRouter.post("/:uuid/mcp", async (req, res) => {
       });
       logger.info("Created MetaMCP StreamableHttp transport");
 
-      await (webAppTransport as StreamableHTTPServerTransport).handleRequest(
-        req,
-        res,
-        req.body,
+      await runWithCallerContext(inspectorCaller(req), () =>
+        (webAppTransport as StreamableHTTPServerTransport).handleRequest(
+          req,
+          res,
+          req.body,
+        ),
       );
     } catch (error) {
       logger.error("Error in MetaMCP /mcp POST route:", error);
@@ -163,9 +202,8 @@ metamcpRouter.post("/:uuid/mcp", async (req, res) => {
       if (!transport) {
         res.status(404).end("Transport not found for sessionId " + sessionId);
       } else {
-        await (transport as StreamableHTTPServerTransport).handleRequest(
-          req,
-          res,
+        await runWithCallerContext(inspectorCaller(req), () =>
+          (transport as StreamableHTTPServerTransport).handleRequest(req, res),
         );
       }
     } catch (error) {
@@ -252,7 +290,9 @@ metamcpRouter.post("/:uuid/message", async (req, res) => {
       res.status(404).end("Session not found");
       return;
     }
-    await transport.handlePostMessage(req, res);
+    await runWithCallerContext(inspectorCaller(req), () =>
+      transport.handlePostMessage(req, res),
+    );
   } catch (error) {
     logger.error("Error in MetaMCP /message route:", error);
     res.status(500).json(error);

--- a/apps/backend/src/routers/public-metamcp/openapi/handlers.audit.test.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/handlers.audit.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The OpenAPI bridge composes its OWN call-tool chain rather than reusing the
+ * Streamable-HTTP one in `metamcp-proxy`, and the auditing middleware sat
+ * commented out of it. Every tool call made through the OpenAPI endpoints
+ * therefore executed with no `tool_call_audit` row — a gap that was invisible
+ * from the table, because a missing row and a quiet consumer look identical.
+ *
+ * These tests pin the wiring: the chain invokes the auditing middleware, and
+ * the caller binding that arrives per call reaches the row. Removing
+ * `createAuditingMiddleware()` from the compose in `handlers.ts` fails them.
+ *
+ * Only the DB-touching boundary is mocked (the convention `streamable-http.
+ * test.ts` and `mcp-server-pool.test.ts` follow). The auditing middleware and
+ * `compose` run for real — they are what is under test. The two other
+ * middlewares in the chain are stubbed to pass-through so their own DB-backed
+ * tool-status lookups cannot decide the outcome of an audit test.
+ */
+import { CallToolRequest } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `db/index.ts` throws without DATABASE_URL and is reached transitively from
+// `lib/metamcp/utils` (sanitizeName -> oauth-sessions.repo). Same stub the
+// other DB-free unit tests use.
+vi.mock("../../../db/index", () => ({ db: {}, pool: {} }));
+
+// Inlined rather than shared through a top-level helper: `vi.mock` factories
+// are hoisted above every const in the file.
+vi.mock(
+  "../../../lib/metamcp/metamcp-middleware/filter-tools.functional",
+  () => ({
+    createFilterCallToolMiddleware: () => (h: unknown) => h,
+    createFilterListToolsMiddleware: () => (h: unknown) => h,
+  }),
+);
+
+vi.mock(
+  "../../../lib/metamcp/metamcp-middleware/tool-overrides.functional",
+  () => ({
+    createToolOverridesCallToolMiddleware: () => (h: unknown) => h,
+    createToolOverridesListToolsMiddleware: () => (h: unknown) => h,
+  }),
+);
+
+// `getMcpServers` returning nothing makes the original handler reach its
+// "Unknown tool" throw without any backend session — the shortest real path
+// through the chain that still produces an audited outcome.
+vi.mock("../../../lib/metamcp/fetch-metamcp", () => ({
+  getMcpServers: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../../../db/repositories/namespaces.repo", () => ({
+  namespacesRepository: {
+    // No last-known-good owner for the tool, so the reconnect-window fallback
+    // is skipped and the handler reaches its genuine "Unknown tool" throw.
+    findServersForNamespaceToolName: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock("../../../lib/config.service", () => ({
+  configService: {
+    getMcpResetTimeoutOnProgress: vi.fn().mockResolvedValue(false),
+    getMcpTimeout: vi.fn().mockResolvedValue(60000),
+    getMcpMaxTotalTimeout: vi.fn().mockResolvedValue(60000),
+    getMcpToolCallReconnectWarmupTimeout: vi.fn().mockResolvedValue(1000),
+  },
+}));
+
+vi.mock("../../../lib/metamcp/mcp-server-pool", () => ({
+  mcpServerPool: {
+    getSession: vi.fn().mockResolvedValue(undefined),
+    ensureSession: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../../../lib/metamcp/tool-call-warmup", () => ({
+  acquireSessionWithBoundedWarmup: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { setAuditRecorderForTesting } from "../../../lib/metamcp/metamcp-middleware/auditing.functional";
+import { createMiddlewareEnabledHandlers } from "./handlers";
+
+const caller = {
+  apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+  authMethod: "api_key",
+  userId: "user-owner-1",
+  callerIp: "203.0.113.7",
+  requestId: "req-openapi-1",
+};
+
+const callRequest = (): CallToolRequest =>
+  ({
+    method: "tools/call",
+    params: { name: "autotask__search", arguments: { q: "printer" } },
+  }) as CallToolRequest;
+
+// Flush the fire-and-forget persist() chain the middleware detaches.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+afterEach(() => {
+  setAuditRecorderForTesting(null);
+  vi.clearAllMocks();
+});
+
+describe("OpenAPI call-tool chain writes tool_call_audit rows", () => {
+  it("invokes the auditing middleware for a call made through the bridge", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const { callToolWithMiddleware, handlerContext } =
+      createMiddlewareEnabledHandlers(
+        "openapi_ns-123",
+        "ns-123",
+        "example connector",
+        caller,
+      );
+
+    await expect(
+      callToolWithMiddleware(callRequest(), handlerContext),
+    ).rejects.toThrow(/Unknown tool/);
+    await flush();
+
+    expect(recorder).toHaveBeenCalledTimes(1);
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.server_name).toBe("autotask");
+    expect(entry.tool_name).toBe("search");
+    expect(entry.success).toBe(false);
+  });
+
+  it("carries the per-call caller binding onto the row", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const { callToolWithMiddleware, handlerContext } =
+      createMiddlewareEnabledHandlers(
+        "openapi_ns-123",
+        "ns-123",
+        "example connector",
+        caller,
+      );
+
+    await expect(
+      callToolWithMiddleware(callRequest(), handlerContext),
+    ).rejects.toThrow();
+    await flush();
+
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.client_name).toBe("example connector");
+    expect(entry.api_key_uuid).toBe(caller.apiKeyUuid);
+    expect(entry.auth_method).toBe("api_key");
+    expect(entry.user_id).toBe("user-owner-1");
+    expect(entry.caller_ip).toBe("203.0.113.7");
+    expect(entry.request_id).toBe("req-openapi-1");
+  });
+
+  it("keeps two consumers apart on the SHARED openapi session id", async () => {
+    // Every consumer of a namespace shares `openapi_<namespace>`, so the
+    // session id identifies nobody. Attribution has to come from the per-call
+    // context, and this is the test that it does.
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const first = createMiddlewareEnabledHandlers(
+      "openapi_ns-123",
+      "ns-123",
+      "example connector",
+      caller,
+    );
+    const second = createMiddlewareEnabledHandlers(
+      "openapi_ns-123",
+      "ns-123",
+      "other consumer",
+      {
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000002",
+        authMethod: "oauth",
+        userId: "user-oauth-9",
+        callerIp: "198.51.100.4",
+        requestId: "req-openapi-2",
+      },
+    );
+
+    await expect(
+      first.callToolWithMiddleware(callRequest(), first.handlerContext),
+    ).rejects.toThrow();
+    await expect(
+      second.callToolWithMiddleware(callRequest(), second.handlerContext),
+    ).rejects.toThrow();
+    await flush();
+
+    expect(recorder).toHaveBeenCalledTimes(2);
+    const [rowA] = recorder.mock.calls[0];
+    const [rowB] = recorder.mock.calls[1];
+    expect(rowA.session_id).toBe(rowB.session_id);
+    expect(rowA.api_key_uuid).not.toBe(rowB.api_key_uuid);
+    expect(rowA.request_id).toBe("req-openapi-1");
+    expect(rowB.request_id).toBe("req-openapi-2");
+    expect(rowB.auth_method).toBe("oauth");
+  });
+
+  it("records the call un-attributed rather than not at all when no identity was resolved", async () => {
+    const recorder = vi.fn().mockResolvedValue(undefined);
+    setAuditRecorderForTesting(recorder);
+
+    const { callToolWithMiddleware, handlerContext } =
+      createMiddlewareEnabledHandlers("openapi_ns-123", "ns-123");
+
+    await expect(
+      callToolWithMiddleware(callRequest(), handlerContext),
+    ).rejects.toThrow();
+    await flush();
+
+    expect(recorder).toHaveBeenCalledTimes(1);
+    const entry = recorder.mock.calls[0][0];
+    expect(entry.api_key_uuid).toBeNull();
+    expect(entry.request_id).toBeNull();
+    expect(entry.tool_name).toBe("search");
+  });
+});

--- a/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
@@ -12,8 +12,10 @@ import logger from "@/utils/logger";
 import { namespacesRepository } from "../../../db/repositories/namespaces.repo";
 import { configService } from "../../../lib/config.service";
 import { ConnectedClient } from "../../../lib/metamcp";
+import { CallerContext } from "../../../lib/metamcp/caller-context";
 import { getMcpServers } from "../../../lib/metamcp/fetch-metamcp";
 import { mcpServerPool } from "../../../lib/metamcp/mcp-server-pool";
+import { createAuditingMiddleware } from "../../../lib/metamcp/metamcp-middleware/auditing.functional";
 import {
   createFilterCallToolMiddleware,
   createFilterListToolsMiddleware,
@@ -382,15 +384,23 @@ export const createMiddlewareEnabledHandlers = (
   sessionId: string,
   namespaceUuid: string,
   clientName?: string,
+  caller?: CallerContext,
 ) => {
   // Create the handler context. OpenAPI is stateless (one deterministic
   // sessionId per namespace shared across consumers), so the calling
   // consumer's identity rides the per-call context here rather than the
   // session registry — no cross-consumer race.
+  //
+  // That property is why the caller binding is a plain parameter here and not
+  // stamped onto a pooled instance the way the Streamable-HTTP path has to do
+  // it: this context object is built fresh for one call and discarded, so
+  // `requestId` and `callerIp` cannot be overwritten by a concurrent request
+  // on the same shared `openapi_<namespace>` session id.
   const handlerContext: MetaMCPHandlerContext = {
     namespaceUuid,
     sessionId,
     clientName,
+    ...caller,
   };
 
   // Create original handlers
@@ -407,6 +417,18 @@ export const createMiddlewareEnabledHandlers = (
   )(originalListToolsHandler);
 
   const callToolWithMiddleware = compose(
+    // Outermost, matching the Streamable-HTTP chain in metamcp-proxy: records
+    // every call — including the ones the filter middleware below denies — to
+    // the Live Logs store and to tool_call_audit.
+    //
+    // This chain ran WITHOUT it until now, so every tool call made through the
+    // OpenAPI bridge executed with no audit row at all. The gap was invisible
+    // from the table: the rows the other path writes look the same, so the
+    // absence read as "these consumers were quiet" rather than "these
+    // consumers are not recorded". Both entry points reach the same backend
+    // servers with the same credentials, so both have to be recorded the same
+    // way for retention on this table to mean anything.
+    createAuditingMiddleware(),
     createFilterCallToolMiddleware({
       cacheEnabled: true,
       customErrorMessage: (toolName, reason) =>
@@ -414,7 +436,6 @@ export const createMiddlewareEnabledHandlers = (
     }),
     createToolOverridesCallToolMiddleware({ cacheEnabled: true }),
     // Add more middleware here as needed
-    // createAuditingMiddleware(),
     // createAuthorizationMiddleware(),
   )(originalCallToolHandler);
 

--- a/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
@@ -399,8 +399,10 @@ export const createMiddlewareEnabledHandlers = (
   const handlerContext: MetaMCPHandlerContext = {
     namespaceUuid,
     sessionId,
-    clientName,
     ...caller,
+    // Last, so the explicitly-passed label always wins over anything a future
+    // `CallerContext` field of the same name could carry.
+    clientName,
   };
 
   // Create original handlers

--- a/apps/backend/src/routers/public-metamcp/openapi/tool-execution.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/tool-execution.ts
@@ -3,6 +3,7 @@ import express from "express";
 
 import logger from "@/utils/logger";
 
+import { resolveCallerContext } from "../../../lib/metamcp/caller-context";
 import { resolveClientIdentity } from "../../../lib/metamcp/consumer-identity-resolver";
 import { metaMcpServerPool } from "../../../lib/metamcp/metamcp-server-pool";
 import { createMiddlewareEnabledHandlers } from "./handlers";
@@ -32,12 +33,19 @@ export const executeToolWithMiddleware = async (
     // tool_call log shows WHO called it. Carried on the per-call context.
     const clientIdentity = await resolveClientIdentity(req);
 
+    // Caller binding for the audit row (migration 0030): which credential,
+    // account, address and request. Resolved per call, from this request,
+    // because the OpenAPI session id is shared across every consumer of the
+    // namespace and therefore identifies nobody.
+    const caller = resolveCallerContext(req);
+
     // Create middleware-enabled handlers
     const { handlerContext, callToolWithMiddleware } =
       createMiddlewareEnabledHandlers(
         sessionId,
         namespaceUuid,
         clientIdentity?.name,
+        caller,
       );
 
     // Use middleware-enabled call tool handler

--- a/apps/backend/src/routers/public-metamcp/sse.caller-binding.test.ts
+++ b/apps/backend/src/routers/public-metamcp/sse.caller-binding.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Caller binding on the SSE transport (migration 0030).
+ *
+ * The `/message` leg drives `tools/call` for every SSE consumer and reached
+ * the auditing middleware with nothing stamped at all — no consumer label and
+ * no caller binding — so those calls landed as fully un-attributed rows. That
+ * is the failure mode worth a test: an all-NULL row is indistinguishable from
+ * a path nobody uses, so the gap could not be seen from the table it damaged.
+ *
+ * Both legs are driven for real over a socket rather than unit-tested, because
+ * what is under test is the WIRING: the router entering the request-scoped
+ * store around the dispatch, and stamping the pooled instance it acquires.
+ * Only the DB-touching boundary is mocked.
+ */
+import type { Server } from "node:http";
+
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import express from "express";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("@/db", () => ({ db: {}, pool: { on: vi.fn() } }));
+
+vi.mock("@/middleware/api-key-oauth.middleware", () => ({
+  authenticateApiKey: vi.fn(),
+}));
+vi.mock("@/middleware/lookup-endpoint-middleware", () => ({
+  lookupEndpoint: vi.fn(),
+}));
+vi.mock("@/middleware/rate-limit.middleware", () => ({
+  rateLimitMiddleware: vi.fn(),
+}));
+
+vi.mock("../../lib/metamcp/consumer-identity-resolver", () => ({
+  resolveClientIdentity: vi.fn().mockResolvedValue({ name: "test-consumer" }),
+}));
+
+vi.mock("../../lib/metamcp/metamcp-server-pool", () => ({
+  metaMcpServerPool: {
+    getServer: vi.fn(),
+    cleanupSession: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { authenticateApiKey } from "@/middleware/api-key-oauth.middleware";
+import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
+import { rateLimitMiddleware } from "@/middleware/rate-limit.middleware";
+
+import type { CallerContext } from "../../lib/metamcp/caller-context-store";
+import { getCallerContext } from "../../lib/metamcp/caller-context-store";
+import { metaMcpServerPool } from "../../lib/metamcp/metamcp-server-pool";
+import sseRouter from "./sse";
+
+const CALLER = {
+  namespaceUuid: "ns-1",
+  endpointName: "ep-1",
+  authMethod: "api_key",
+  apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000005",
+  apiKeyUserId: "key-owner-1",
+  apiKeyActsAsUserId: "acted-as-user-1",
+  // Stamped app-wide by auditContextMiddleware in production.
+  auditRequestId: "req-sse",
+  auditClientIp: "203.0.113.7",
+};
+
+let server: Server;
+let baseUrl = "";
+
+/** What the auditing middleware would see, captured from inside the dispatch. */
+let seen: CallerContext | undefined;
+let instance: {
+  server: { connect: ReturnType<typeof vi.fn> };
+  cleanup: ReturnType<typeof vi.fn>;
+  handlerContext: Record<string, unknown>;
+};
+
+function makeInstance() {
+  return {
+    // `connect` receives the transport the router just built, which is the
+    // only handle a test has on it. Attaching `onmessage` here is what lets
+    // the assertion run at the exact point a tools/call would be dispatched.
+    server: {
+      connect: vi.fn(async (transport: Transport) => {
+        transport.onmessage = () => {
+          seen = getCallerContext();
+        };
+        // The real SDK `Server.connect` starts the transport, which is what
+        // writes the SSE headers and the `endpoint` frame the client waits
+        // for. Without it the stream never flushes and the request hangs.
+        await transport.start();
+      }),
+    },
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    handlerContext: {} as Record<string, unknown>,
+  };
+}
+
+beforeAll(async () => {
+  vi.mocked(lookupEndpoint).mockImplementation(((
+    req: express.Request,
+    _res: express.Response,
+    next: () => void,
+  ) => {
+    Object.assign(req, CALLER);
+    next();
+  }) as never);
+  vi.mocked(authenticateApiKey).mockImplementation(((
+    _req: express.Request,
+    _res: express.Response,
+    next: () => void,
+  ) => next()) as never);
+  vi.mocked(rateLimitMiddleware).mockImplementation(((
+    _req: express.Request,
+    _res: express.Response,
+    next: () => void,
+  ) => next()) as never);
+
+  const app = express();
+  app.use("/metamcp", sseRouter);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (typeof address === "object" && address) {
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  }
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  seen = undefined;
+  instance = makeInstance();
+  vi.mocked(metaMcpServerPool.getServer).mockResolvedValue(instance as never);
+});
+
+/**
+ * Open the SSE stream and read the `endpoint` frame the transport emits, which
+ * is where the sessionId the /message leg needs comes from. The stream is left
+ * open (aborted by the caller) — closing it tears the session down.
+ */
+async function openStream(): Promise<{
+  sessionId: string;
+  abort: AbortController;
+}> {
+  const abort = new AbortController();
+  const response = await fetch(`${baseUrl}/metamcp/ep-1/sse`, {
+    signal: abort.signal,
+  });
+  if (!response.body) throw new Error("SSE response carried no body");
+  const reader = response.body.getReader();
+  const frame = new TextDecoder().decode((await reader.read()).value);
+  const match = /sessionId=([\w-]+)/.exec(frame);
+  if (!match) throw new Error(`no sessionId in SSE frame: ${frame}`);
+  return { sessionId: match[1], abort };
+}
+
+const postMessage = (sessionId: string) =>
+  fetch(`${baseUrl}/metamcp/ep-1/message?sessionId=${sessionId}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+  });
+
+describe("SSE /message leg — tool calls are attributable", () => {
+  it("dispatches inside this request's caller binding", async () => {
+    const { sessionId, abort } = await openStream();
+
+    const response = await postMessage(sessionId);
+    expect(response.status).toBe(202);
+
+    expect(seen).toEqual({
+      clientName: "test-consumer",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000005",
+      authMethod: "api_key",
+      userId: "key-owner-1",
+      actsAsUserId: "acted-as-user-1",
+      callerIp: "203.0.113.7",
+      requestId: "req-sse",
+    });
+
+    abort.abort();
+  });
+
+  it("takes the binding from the message request, not from the one that opened the stream", async () => {
+    const { sessionId, abort } = await openStream();
+
+    // A later message arrives with a different request id and address — the
+    // stream-open values must not be what gets audited.
+    vi.mocked(lookupEndpoint).mockImplementationOnce(((
+      req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => {
+      Object.assign(req, {
+        ...CALLER,
+        auditRequestId: "req-sse-later",
+        auditClientIp: "198.51.100.4",
+      });
+      next();
+    }) as never);
+
+    await postMessage(sessionId);
+
+    expect(seen?.requestId).toBe("req-sse-later");
+    expect(seen?.callerIp).toBe("198.51.100.4");
+
+    abort.abort();
+  });
+});
+
+describe("SSE /sse leg — the acquired instance carries the fallback binding", () => {
+  it("stamps the pooled instance at stream open", async () => {
+    const { abort } = await openStream();
+
+    expect(instance.handlerContext).toMatchObject({
+      clientName: "test-consumer",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000005",
+      authMethod: "api_key",
+      userId: "key-owner-1",
+      actsAsUserId: "acted-as-user-1",
+      callerIp: "203.0.113.7",
+      requestId: "req-sse",
+    });
+
+    abort.abort();
+  });
+});

--- a/apps/backend/src/routers/public-metamcp/sse.ts
+++ b/apps/backend/src/routers/public-metamcp/sse.ts
@@ -10,6 +10,12 @@ import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
 import { rateLimitMiddleware } from "@/middleware/rate-limit.middleware";
 import logger from "@/utils/logger";
 
+import {
+  resolveCallerContext,
+  stampCallerContext,
+} from "../../lib/metamcp/caller-context";
+import { runWithCallerContext } from "../../lib/metamcp/caller-context-store";
+import { resolveClientIdentity } from "../../lib/metamcp/consumer-identity-resolver";
 import { metaMcpServerPool } from "../../lib/metamcp/metamcp-server-pool";
 import {
   bindingMatches,
@@ -121,6 +127,18 @@ sseRouter.get(
         `Using MetaMCP server instance for public endpoint session ${sessionId}`,
       );
 
+      // Stamp the caller onto the acquired instance so tool calls arriving on
+      // the /message leg are attributable (migration 0030). Fallback carrier
+      // only — the authoritative per-request binding is entered on that leg
+      // itself; this covers the window before the first message and any call
+      // that reaches the auditing middleware outside a request scope.
+      const clientIdentity = await resolveClientIdentity(authReq);
+      stampCallerContext(
+        mcpServerInstance.handlerContext,
+        authReq,
+        clientIdentity?.name,
+      );
+
       // Bind the session to the endpoint it was opened on so the message leg
       // below can reject a sessionId replayed against a different endpoint.
       sessionManager.addSession(sessionId, webAppTransport, {
@@ -171,9 +189,21 @@ sseRouter.post(
         res.status(404).end("Session not found");
         return;
       }
-      await (resolution.transport as SSEServerTransport).handlePostMessage(
-        req,
-        res,
+      // This leg drives `tools/call` for every SSE consumer, so it needs the
+      // same request-scoped caller binding the Streamable-HTTP dispatch
+      // enters — without it these calls audited as fully un-attributed rows,
+      // which is indistinguishable from a path nobody uses. `authenticateApiKey`
+      // has already run above, so the identity is on the request; the instance
+      // stamped at stream-open cannot serve because the SSE session is
+      // long-lived and `requestId` / `callerIp` are per-message facts.
+      const clientIdentity = await resolveClientIdentity(authReq);
+      await runWithCallerContext(
+        { ...resolveCallerContext(authReq), clientName: clientIdentity?.name },
+        () =>
+          (resolution.transport as SSEServerTransport).handlePostMessage(
+            req,
+            res,
+          ),
       );
     } catch (error) {
       logger.error("Error in public endpoint /message route:", error);

--- a/apps/backend/src/routers/public-metamcp/streamable-http.test.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.test.ts
@@ -106,6 +106,7 @@ vi.mock("../../lib/metamcp/consumer-identity-resolver", () => ({
 vi.mock("../../lib/metamcp/metamcp-server-pool", () => ({
   metaMcpServerPool: {
     getServer: vi.fn(),
+    getServerInstance: vi.fn(),
     cleanupSession: vi.fn().mockResolvedValue(undefined),
     getMcpServerPoolStatus: vi.fn().mockReturnValue({ idle: 0, active: 0 }),
     getPoolStatus: vi.fn().mockReturnValue({ idle: 0, active: 0 }),
@@ -128,9 +129,14 @@ vi.mock("../../lib/metamcp/transport-recovery-hydration", () => ({
 // them below is the established convention in this repo's test files).
 import { mcpSessionsRepository } from "@/db/repositories/mcp-sessions.repo";
 import type { ApiKeyAuthenticatedRequest } from "@/middleware/api-key-oauth.middleware";
+import { authenticateApiKey } from "@/middleware/api-key-oauth.middleware";
+import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
+import { rateLimitMiddleware } from "@/middleware/rate-limit.middleware";
 
 import type { M365UserContext } from "../../lib/m365/request-context";
 import { getM365UserContext } from "../../lib/m365/request-context";
+import type { CallerContext } from "../../lib/metamcp/caller-context-store";
+import { getCallerContext } from "../../lib/metamcp/caller-context-store";
 import {
   GATEWAY_BOOT_ID,
   GATEWAY_CAPABILITY_HASH,
@@ -932,5 +938,327 @@ describe("m365 identity gate (via dispatchTracked) — oauth + acts-as api keys 
       "utf8",
     );
     expect(streamableSource).toContain("runWithM365UserContext");
+  });
+});
+
+/**
+ * Caller binding for `tool_call_audit` (migration 0030).
+ *
+ * Two carriers, tested separately because they fail differently:
+ *
+ *  - the REQUEST-SCOPED store (`lib/metamcp/caller-context-store`), entered by
+ *    `dispatchTracked`, is what the auditing middleware actually reads. Delete
+ *    that wiring and every proxied tool call is audited from a pooled object
+ *    that belongs to whichever request stamped it last.
+ *  - the per-instance handler context is the fallback, stamped at session
+ *    creation, at lazy recovery, and again on each subsequent POST. Delete any
+ *    of those and the fallback goes stale or empty.
+ *
+ * Every stamp site below was deletable with the suite green before these
+ * tests existed.
+ */
+describe("caller binding — request-scoped store (the audited source)", () => {
+  function callerCapturingTransport(captured: {
+    caller: CallerContext | undefined;
+  }): StreamableHTTPServerTransport {
+    return {
+      handleRequest: vi.fn().mockImplementation(async () => {
+        captured.caller = getCallerContext();
+      }),
+    } as unknown as StreamableHTTPServerTransport;
+  }
+
+  async function dispatchAndCaptureCaller(
+    authReq: ApiKeyAuthenticatedRequest,
+    sessionId: string,
+    clientName?: string,
+  ): Promise<CallerContext | undefined> {
+    publicSessionSweeper.beginTracking(sessionId);
+    const captured: { caller: CallerContext | undefined } = {
+      caller: undefined,
+    };
+    await dispatchTracked(
+      authReq,
+      callerCapturingTransport(captured),
+      {} as express.Request,
+      {} as express.Response,
+      sessionId,
+      clientName,
+    );
+    return captured.caller;
+  }
+
+  it("carries THIS request's credential, account, address and request id into the dispatch", async () => {
+    const caller = await dispatchAndCaptureCaller(
+      fakeAuthReq({
+        authMethod: "api_key",
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+        apiKeyUserId: "key-owner-1",
+        headers: { "cf-connecting-ip": "203.0.113.7" },
+        auditRequestId: "req-aaaa",
+      }),
+      "sess-binding-1",
+      "example connector",
+    );
+
+    expect(caller).toEqual({
+      clientName: "example connector",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+      authMethod: "api_key",
+      userId: "key-owner-1",
+      actsAsUserId: undefined,
+      callerIp: "203.0.113.7",
+      requestId: "req-aaaa",
+    });
+  });
+
+  it("records an admin key's acts-as target separately from the key owner", async () => {
+    const caller = await dispatchAndCaptureCaller(
+      fakeAuthReq({
+        authMethod: "api_key",
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000002",
+        apiKeyUserId: "key-owner-1",
+        apiKeyActsAsUserId: "acted-as-user-1",
+        auditRequestId: "req-bbbb",
+      }),
+      "sess-binding-acts-as",
+    );
+
+    // Folding these into one column would make a delegated call read exactly
+    // like a direct one by the acted-as account.
+    expect(caller?.userId).toBe("key-owner-1");
+    expect(caller?.actsAsUserId).toBe("acted-as-user-1");
+  });
+
+  it("does not leak one request's binding into the next dispatch on the same session", async () => {
+    // The failure this guards is the whole reason the store exists: parallel
+    // or successive calls on one session share a pooled handler context.
+    const first = await dispatchAndCaptureCaller(
+      fakeAuthReq({
+        authMethod: "api_key",
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000001",
+        apiKeyUserId: "key-owner-1",
+        headers: { "cf-connecting-ip": "203.0.113.7" },
+        auditRequestId: "req-first",
+      }),
+      "sess-binding-shared",
+      "example connector",
+    );
+    const second = await dispatchAndCaptureCaller(
+      fakeAuthReq({
+        authMethod: "oauth",
+        oauthUserId: "oauth-user-9",
+        headers: { "cf-connecting-ip": "198.51.100.4" },
+        auditRequestId: "req-second",
+      }),
+      "sess-binding-shared",
+      "other consumer",
+    );
+
+    expect(first?.requestId).toBe("req-first");
+    expect(second?.requestId).toBe("req-second");
+    expect(second?.apiKeyUuid).toBeUndefined();
+    expect(second?.userId).toBe("oauth-user-9");
+    expect(second?.callerIp).toBe("198.51.100.4");
+  });
+
+  it("leaves the store empty outside a dispatch", async () => {
+    // "No store" must stay distinguishable from "a store that resolved
+    // nothing" — the auditing middleware falls back to the handler context on
+    // the first and not on the second.
+    await dispatchAndCaptureCaller(
+      fakeAuthReq({ authMethod: "api_key", apiKeyUuid: "u-1" }),
+      "sess-binding-scope",
+    );
+    expect(getCallerContext()).toBeUndefined();
+  });
+});
+
+describe("caller binding — per-instance fallback stamps", () => {
+  const fakeInstance = () => ({
+    server: { connect: vi.fn().mockResolvedValue(undefined) },
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    handlerContext: {} as Record<string, unknown>,
+  });
+
+  it("lazy recovery re-stamps the rebuilt instance with the re-validated caller", async () => {
+    const sessionId = "sess-stamp-recovery";
+    const rawToken = "test-api-key-value";
+    (
+      mcpSessionsRepository.findById as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      session_id: sessionId,
+      namespace_uuid: "ns-1",
+      endpoint_name: "ep-1",
+      auth_principal: hashAuthPrincipal(rawToken, "api_key"),
+      auth_method: "api_key",
+      init_params: {},
+      created_at: new Date(),
+      last_seen_at: new Date(),
+      gateway_boot_id: GATEWAY_BOOT_ID,
+      capability_hash: GATEWAY_CAPABILITY_HASH,
+    });
+    const instance = fakeInstance();
+    (
+      metaMcpServerPool.getServer as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(instance);
+
+    const result = await recoverPersistedSession(
+      sessionId,
+      fakeAuthReq({
+        namespaceUuid: "ns-1",
+        endpointName: "ep-1",
+        authMethod: "api_key",
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000003",
+        apiKeyUserId: "key-owner-1",
+        headers: { "x-api-key": rawToken, "cf-connecting-ip": "203.0.113.7" },
+        auditRequestId: "req-recovery",
+      }),
+    );
+
+    expect(result.status).toBe("recovered");
+    expect(instance.handlerContext).toMatchObject({
+      clientName: "test-consumer",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000003",
+      authMethod: "api_key",
+      userId: "key-owner-1",
+      callerIp: "203.0.113.7",
+      requestId: "req-recovery",
+    });
+  });
+});
+
+describe("caller binding — the POST route stamps the instance it serves", () => {
+  let server: Server;
+  let baseUrl = "";
+  let instance: ReturnType<typeof makeInstance>;
+
+  const makeInstance = () => ({
+    server: { connect: vi.fn().mockResolvedValue(undefined) },
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    handlerContext: {} as Record<string, unknown>,
+  });
+
+  beforeAll(async () => {
+    // The file-wide mocks for these three are bare `vi.fn()`s that never call
+    // next(), which is right for the unit tests above and would hang a real
+    // request. Give them the shape the production chain has: resolve the
+    // endpoint, stamp the identity the auth middleware would stamp, pass on.
+    vi.mocked(lookupEndpoint).mockImplementation(((
+      req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => {
+      Object.assign(req, {
+        namespaceUuid: "ns-1",
+        endpointName: "ep-1",
+        endpoint: { uuid: "ep-uuid-1", name: "ep-1" },
+        authMethod: "api_key",
+        apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000004",
+        apiKeyUserId: "key-owner-1",
+        // Stamped app-wide by auditContextMiddleware in production.
+        auditRequestId: "req-route",
+        auditClientIp: "203.0.113.7",
+      });
+      next();
+    }) as never);
+    vi.mocked(authenticateApiKey).mockImplementation(((
+      _req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => next()) as never);
+    vi.mocked(rateLimitMiddleware).mockImplementation(((
+      _req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => next()) as never);
+
+    const app = express();
+    app.use("/metamcp", streamableHttpRouter);
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (typeof address === "object" && address) {
+      baseUrl = `http://127.0.0.1:${address.port}`;
+    }
+  });
+
+  afterAll(async () => {
+    // Restore the file-wide defaults — clearAllMocks does not reset
+    // implementations, so these would otherwise follow into any later block.
+    vi.mocked(lookupEndpoint).mockImplementation((() => undefined) as never);
+    vi.mocked(authenticateApiKey).mockImplementation(
+      (() => undefined) as never,
+    );
+    vi.mocked(rateLimitMiddleware).mockImplementation(
+      (() => undefined) as never,
+    );
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    instance = makeInstance();
+  });
+
+  /**
+   * Drive one POST through the real router. The transport's own answer is
+   * irrelevant here (no MCP handshake is performed, so it refuses the body) —
+   * what is under test is the stamp the route applies before dispatching.
+   */
+  const post = (headers: Record<string, string> = {}) =>
+    fetch(`${baseUrl}/metamcp/ep-1/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...headers,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+
+  it("stamps the instance it acquires for a NEW session", async () => {
+    (
+      metaMcpServerPool.getServer as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(instance);
+
+    await post();
+
+    expect(instance.handlerContext).toMatchObject({
+      clientName: "test-consumer",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000004",
+      authMethod: "api_key",
+      userId: "key-owner-1",
+      callerIp: "203.0.113.7",
+      requestId: "req-route",
+    });
+  });
+
+  it("re-stamps the pooled instance on a subsequent POST rather than leaving the initialize request's values", async () => {
+    // Seed a live in-memory session so the request takes the existing-session
+    // branch rather than falling into lazy recovery (which has its own stamp).
+    const sessionId = "sess-route-existing";
+    await seedBoundSession(sessionId, "ns-1", "ep-1");
+
+    // The state the bug produces: values frozen at session creation.
+    instance.handlerContext = {
+      clientName: "stale consumer",
+      requestId: "req-from-initialize",
+      callerIp: "198.51.100.99",
+      apiKeyUuid: "stale-uuid",
+    } as Record<string, unknown>;
+    (
+      metaMcpServerPool.getServerInstance as ReturnType<typeof vi.fn>
+    ).mockReturnValueOnce(instance);
+
+    await post({ "mcp-session-id": sessionId });
+
+    expect(instance.handlerContext).toMatchObject({
+      clientName: "test-consumer",
+      apiKeyUuid: "3f7f8a1e-0000-4000-8000-000000000004",
+      callerIp: "203.0.113.7",
+      requestId: "req-route",
+    });
+    await cleanupSession(sessionId);
   });
 });

--- a/apps/backend/src/routers/public-metamcp/streamable-http.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.ts
@@ -14,7 +14,11 @@ import logger from "@/utils/logger";
 
 import { isAdminHealthRequest } from "../../lib/health-upstream";
 import { runWithM365UserContext } from "../../lib/m365/request-context";
-import { stampCallerContext } from "../../lib/metamcp/caller-context";
+import {
+  resolveCallerContext,
+  stampCallerContext,
+} from "../../lib/metamcp/caller-context";
+import { runWithCallerContext } from "../../lib/metamcp/caller-context-store";
 import { resolveClientIdentity } from "../../lib/metamcp/consumer-identity-resolver";
 import {
   GATEWAY_BOOT_ID,
@@ -216,10 +220,20 @@ export async function dispatchTracked(
   req: express.Request,
   res: express.Response,
   sessionId: string,
+  clientName?: string,
 ): Promise<void> {
   publicSessionSweeper.markInFlight(sessionId);
   try {
-    await handleRequestWithUserContext(authReq, transport, req, res);
+    // Enter the request-scoped caller binding for the whole dispatch, so the
+    // auditing middleware attributes this call to THIS request rather than to
+    // whichever request last stamped the pooled handler context. Every
+    // Streamable-HTTP tool call reaches the transport through here, which is
+    // what makes the store the authoritative source rather than a best-effort
+    // one. See `lib/metamcp/caller-context-store`.
+    await runWithCallerContext(
+      { ...resolveCallerContext(authReq), clientName },
+      () => handleRequestWithUserContext(authReq, transport, req, res),
+    );
   } finally {
     publicSessionSweeper.markSettled(sessionId);
   }
@@ -458,8 +472,11 @@ export async function recoverPersistedSession(
   // post-restart tool calls stay attributed (the registry/in-memory state is
   // gone after a restart; authReq is the re-validated current caller).
   const recoveredIdentity = await resolveClientIdentity(authReq);
-  mcpServerInstance.handlerContext.clientName = recoveredIdentity?.name;
-  stampCallerContext(mcpServerInstance.handlerContext, authReq);
+  stampCallerContext(
+    mcpServerInstance.handlerContext,
+    authReq,
+    recoveredIdentity?.name,
+  );
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => sessionId,
     onsessioninitialized: async (sid) => {
@@ -846,6 +863,10 @@ streamableHttpRouter.get(
         }
       }
       logger.info(`Handling GET for session ${sessionId}`);
+      // No clientName resolved for the standalone GET stream: it carries only
+      // server-initiated notifications, never a tools/call, so nothing on this
+      // leg reaches the auditing middleware. The identity half of the binding
+      // still rides the store via dispatchTracked, which costs no lookup.
       await dispatchTracked(authReq, transport, req, res, sessionId);
     } catch (error) {
       logger.error("Error in public endpoint /mcp route:", error);
@@ -896,17 +917,20 @@ streamableHttpRouter.post(
           throw new Error("Failed to get MetaMCP server instance from pool");
         }
 
-        // Stamp the calling consumer onto the (possibly idle-warmed) instance's
-        // handler context so the audit middleware attributes tool calls to it.
-        // Idle servers carry a placeholder sessionId, so we can't key by
-        // sessionId — we set it directly on the instance we just acquired.
-        mcpServerInstance.handlerContext.clientName = clientIdentity?.name;
-        // Caller binding for the tool_call_audit row (migration 0030). Set
-        // here AND re-set per request in the existing-session branch below:
-        // `requestId` and `callerIp` describe one request, so freezing them at
-        // session creation the way `clientName` is frozen would stamp every
-        // later call in the session with the initialize request's id.
-        stampCallerContext(mcpServerInstance.handlerContext, authReq);
+        // Stamp the calling consumer + caller binding onto the (possibly
+        // idle-warmed) instance's handler context. Idle servers carry a
+        // placeholder sessionId, so we can't key by sessionId — we set it
+        // directly on the instance we just acquired.
+        //
+        // This is the FALLBACK carrier (migration 0030). The row an audit
+        // write actually uses comes from the request-scoped store entered in
+        // dispatchTracked; see `lib/metamcp/caller-context-store` for why a
+        // per-instance object cannot be the source of truth.
+        stampCallerContext(
+          mcpServerInstance.handlerContext,
+          authReq,
+          clientIdentity?.name,
+        );
 
         logger.info(
           `Using MetaMCP server instance for public endpoint session ${newSessionId} (endpoint: ${endpointName})`,
@@ -1002,7 +1026,14 @@ streamableHttpRouter.post(
         }
 
         // Now handle the request - server is guaranteed to be ready
-        await dispatchTracked(authReq, transport, req, res, newSessionId);
+        await dispatchTracked(
+          authReq,
+          transport,
+          req,
+          res,
+          newSessionId,
+          clientIdentity?.name,
+        );
       } catch (error) {
         logger.error("Error in public endpoint /mcp POST route:", error);
 
@@ -1085,13 +1116,18 @@ streamableHttpRouter.post(
             return;
           }
         }
-        // Re-stamp the caller binding for THIS request before dispatching it.
-        // The session was authenticated once, at initialize, and the identity
-        // half of the binding cannot change afterwards — a session is pinned
-        // to one auth principal (see `principalMatches`) — but `requestId` and
-        // `callerIp` are per-request facts, and without this every tool call
-        // for the life of the session would be audited under the initialize
-        // request's id and address.
+        // Refresh the pooled instance's fallback binding to THIS request.
+        //
+        // The authoritative binding for the audit row is the request-scoped
+        // store `dispatchTracked` enters below; this keeps the fallback from
+        // describing an older request. It matters because the handler context
+        // is per-INSTANCE while the facts on it are per-REQUEST: `requestId`
+        // and `callerIp` change on every call, and the instance is reached by
+        // an in-memory session lookup that resolves on namespace + endpoint
+        // rather than by re-deriving the caller from the credential presented
+        // now. Neither property makes the pooled object safe to audit from,
+        // which is exactly why the store exists — see
+        // `lib/metamcp/caller-context-store`.
         //
         // A pure map read, never a create: an instance the pool no longer
         // holds means the transport is being served from lazy recovery, which
@@ -1099,22 +1135,24 @@ streamableHttpRouter.post(
         // own sessionId here — that is a placeholder on an idle-converted
         // instance — only on the transport session id the pool itself
         // assigned.
-        //
-        // KNOWN WINDOW, stated rather than papered over: the handler context
-        // is per-INSTANCE, not per-request, so two requests interleaving on
-        // one session can have the second overwrite the binding before the
-        // first's tool call is audited. Both requests carry the same
-        // credential and account (the principal is pinned), so the
-        // attribution stays correct; only `request_id` / `caller_ip` can be
-        // taken from the sibling request. Closing it properly needs a
-        // per-request context the MCP SDK's handler signature does not carry.
         const activeInstance = metaMcpServerPool.getServerInstance(sessionId);
         if (activeInstance) {
-          stampCallerContext(activeInstance.handlerContext, authReq);
+          stampCallerContext(
+            activeInstance.handlerContext,
+            authReq,
+            clientIdentity?.name,
+          );
         }
 
         logger.info(`Handling POST for session ${sessionId}`);
-        await dispatchTracked(authReq, transport, req, res, sessionId);
+        await dispatchTracked(
+          authReq,
+          transport,
+          req,
+          res,
+          sessionId,
+          clientIdentity?.name,
+        );
       } catch (error) {
         logger.error("Error in public endpoint /mcp route:", error);
 

--- a/apps/backend/src/routers/public-metamcp/streamable-http.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.ts
@@ -14,6 +14,7 @@ import logger from "@/utils/logger";
 
 import { isAdminHealthRequest } from "../../lib/health-upstream";
 import { runWithM365UserContext } from "../../lib/m365/request-context";
+import { stampCallerContext } from "../../lib/metamcp/caller-context";
 import { resolveClientIdentity } from "../../lib/metamcp/consumer-identity-resolver";
 import {
   GATEWAY_BOOT_ID,
@@ -458,6 +459,7 @@ export async function recoverPersistedSession(
   // gone after a restart; authReq is the re-validated current caller).
   const recoveredIdentity = await resolveClientIdentity(authReq);
   mcpServerInstance.handlerContext.clientName = recoveredIdentity?.name;
+  stampCallerContext(mcpServerInstance.handlerContext, authReq);
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => sessionId,
     onsessioninitialized: async (sid) => {
@@ -899,6 +901,12 @@ streamableHttpRouter.post(
         // Idle servers carry a placeholder sessionId, so we can't key by
         // sessionId — we set it directly on the instance we just acquired.
         mcpServerInstance.handlerContext.clientName = clientIdentity?.name;
+        // Caller binding for the tool_call_audit row (migration 0030). Set
+        // here AND re-set per request in the existing-session branch below:
+        // `requestId` and `callerIp` describe one request, so freezing them at
+        // session creation the way `clientName` is frozen would stamp every
+        // later call in the session with the initialize request's id.
+        stampCallerContext(mcpServerInstance.handlerContext, authReq);
 
         logger.info(
           `Using MetaMCP server instance for public endpoint session ${newSessionId} (endpoint: ${endpointName})`,
@@ -1077,6 +1085,34 @@ streamableHttpRouter.post(
             return;
           }
         }
+        // Re-stamp the caller binding for THIS request before dispatching it.
+        // The session was authenticated once, at initialize, and the identity
+        // half of the binding cannot change afterwards — a session is pinned
+        // to one auth principal (see `principalMatches`) — but `requestId` and
+        // `callerIp` are per-request facts, and without this every tool call
+        // for the life of the session would be audited under the initialize
+        // request's id and address.
+        //
+        // A pure map read, never a create: an instance the pool no longer
+        // holds means the transport is being served from lazy recovery, which
+        // stamps its own binding. Nothing is keyed on the handler context's
+        // own sessionId here — that is a placeholder on an idle-converted
+        // instance — only on the transport session id the pool itself
+        // assigned.
+        //
+        // KNOWN WINDOW, stated rather than papered over: the handler context
+        // is per-INSTANCE, not per-request, so two requests interleaving on
+        // one session can have the second overwrite the binding before the
+        // first's tool call is audited. Both requests carry the same
+        // credential and account (the principal is pinned), so the
+        // attribution stays correct; only `request_id` / `caller_ip` can be
+        // taken from the sibling request. Closing it properly needs a
+        // per-request context the MCP SDK's handler signature does not carry.
+        const activeInstance = metaMcpServerPool.getServerInstance(sessionId);
+        if (activeInstance) {
+          stampCallerContext(activeInstance.handlerContext, authReq);
+        }
+
         logger.info(`Handling POST for session ${sessionId}`);
         await dispatchTracked(authReq, transport, req, res, sessionId);
       } catch (error) {


### PR DESCRIPTION
Two coupled gaps in the tool-call audit trail: rows that could not be attributed, and consumer paths that wrote no rows at all.

## 1. Caller binding on `tool_call_audit` (migration 0030)

The table recorded what was called and whether it worked. Its only identity column was `client_name`, which is a **display label**, not an identity — composed at call time from an api-key name plus a mutable user email, through a cache that degrades to a short id on a read failure, NULL wherever no consumer resolved, and naming no credential. A row could describe a call and still leave an investigation with nothing to pivot on.

Six nullable columns added:

| column | source |
| --- | --- |
| `api_key_uuid` (uuid) | `authenticateApiKey` — the `api_keys` row that authenticated the request |
| `auth_method` (text) | `api_key` / `oauth`, plus `session` on the admin Inspector surface |
| `user_id` (text) | the credential OWNER (api-key owner, OAuth subject, or session user) |
| `acts_as_user_id` (text) | the delegated identity an admin key exercised (`api_keys.acts_as_user_id`) |
| `caller_ip` (text) | `CF-Connecting-IP` via the shared `resolveClientIp` helper |
| `request_id` (text) | the audit-context middleware's per-request id |

Every value was already resolved per request by middleware that runs before any tool handler; none of it reached the auditing middleware.

Decisions worth naming, each also recorded next to the code:

- **All six nullable.** The audit write is fire-and-forget and its failure is swallowed by design (an audit write must never fail a tool call), so a `NOT NULL` would not surface as an error — it would silently drop the row for every unauthenticated or passthrough call. A partially-attributed row is worth more than no row.
- **No foreign key on `api_key_uuid`.** Keys are revoked routinely and `api_keys.user_id` cascades on user delete, so an FK would either delete audit rows with the key or block the deletion. The trail has to outlive the credential it names.
- **`user_id` and `acts_as_user_id` are separate columns.** One answers "whose credential", the other "whose identity was exercised". Folded together, a delegated call reads exactly like a direct one by the acted-as account.
- **`caller_ip` comes from `CF-Connecting-IP`, not `req.ip`,** and `trust proxy` stays off. It prefers the value the audit-context middleware already stamped, so `tool_call_audit` and `audit_log` cannot disagree about one request's origin. The trust assumption (edge-overwritten header, valid only while the tunnel is the sole ingress) is restated at the read site.
- **No synthetic `request_id`.** When the audit-context middleware did not run the column stays NULL rather than carrying a minted id that would look real and join to nothing.
- **Only `api_key_uuid` is indexed** of the six — "what did this credential do" is the query that would otherwise scan the table; the rest are read once a row is in hand.

### The binding travels per request, not on the pooled instance

A MetaMCP server instance is pooled and its handler context is per-INSTANCE, while every fact above is per-REQUEST. Two consequences ruled it out as the source of truth: parallel `tools/call` on one session is the normal case for a busy consumer, so a second request can overwrite the first's binding before it is audited (and the `request_id` that is meant to join a tool call to the same request's `audit_log` rows then points at a sibling); and the in-memory session lookup resolves a session on namespace + endpoint without re-deriving the caller from the credential presented on the current request, so the stamped identity is not guaranteed to belong to the request being served. A row naming the wrong principal is worse than one naming none.

The binding therefore travels in an `AsyncLocalStorage` store entered once per request (`lib/metamcp/caller-context-store`) — the same mechanism the delegated-identity context already uses through this path. The auditing middleware reads that store and falls back to the handler context only for a call that reaches it outside any request scope, and it takes **one source whole** rather than coalescing field by field: a row built half from the live request and half from a stale stamp looks complete and is false.

## 2. Transport coverage

- **OpenAPI bridge** composes its own call-tool chain and had `createAuditingMiddleware()` commented out of it, so every tool call through those endpoints wrote **no audit row at all** — invisible from the table, because a missing row and a quiet consumer look identical. Wired in outermost, matching the Streamable-HTTP chain, so denied calls are recorded too. Its context is built fresh per call and discarded, so it has none of the pooling problem above.
- **SSE** never stamped anything: its `/message` leg drives `tools/call` for every SSE consumer and produced fully un-attributed rows. Both legs are wired now.
- **Admin Inspector surface** likewise wrote un-attributed rows. It records the better-auth session actor under `auth_method = 'session'`, which is the discriminator for that traffic; no consumer label is invented, because there is no consumer there.

## 3. A denied call no longer reads as a successful one

An MCP tool failure is a RESULT, not a throw: a gateway denial from the filter middleware (answered upstream as HTTP 403) and a backend tool's own error both come back as `isError: true` with a normal resolve. Those were recorded as `success = true` — landing in exactly the bucket an investigation filters out while hunting denials. `success` is now derived from the result, with `error_code = 'tool_error'` to keep the class distinct from the protocol-level codes a throw records.

## Tests

`vitest run` — **104 files passed, 2 skipped; 1567 tests passed, 31 skipped.** `tsc --noEmit` clean. `eslint` warning count 22 against a base-branch baseline of 23.

Every wiring site is mutation-checked — deleting any one of them fails a named test, verified by actually deleting it:

| removed | tests that go red |
| --- | --- |
| the request-scoped store in the Streamable-HTTP dispatch | 3 |
| the lazy-recovery stamp | 1 |
| the new-session stamp | 1 |
| the per-request re-stamp | 1 |
| the SSE `/message` store | 2 |
| the SSE stream-open stamp | 1 |
| the auditing middleware reading the store | 3 |
| atomic source selection (replaced with field-by-field coalescing) | 1 |
| the honest `success` flag | 1 |
| `createAuditingMiddleware()` in the OpenAPI chain | 4 |

New coverage lives in `caller-context.test.ts`, `caller-context-store` usage in `auditing.functional.test.ts`, `streamable-http.test.ts`, `sse.caller-binding.test.ts`, `openapi/handlers.audit.test.ts`, and `mcp-proxy/metamcp.caller-binding.test.ts`.

`ApiKeyAuthenticatedRequest` now inherits `AuditRequestFields`, so renaming `auditRequestId` on the stamping side is a compile error at the read sites rather than two silently NULL columns — verified by performing the rename and observing `tsc` fail.

Migration 0030 was applied against a throwaway postgres: applies clean, re-applies clean (idempotent), leaves pre-existing rows with NULLs across all six columns, and accepts the full range of rows the code writes (delegated, session-actor, denied, un-attributed). Journal `when` is set strictly above 0029's, since drizzle only applies entries above the max already applied.