### PR TITLE
fix(oauth): audit token rejections that destroy a credential

### DIFF
--- a/apps/backend/src/routers/oauth/token-audit.test.ts
+++ b/apps/backend/src/routers/oauth/token-audit.test.ts
@@ -16,6 +16,14 @@
  *
  * Same harness as `token.test.ts`: the router driven as express middleware
  * against fake req/res, repositories mocked so `db/index.ts` never loads.
+ *
+ * `GET /oauth/userinfo` is exercised here too, even though it lives in its own
+ * router and has its own suite. The property under test is the one this file
+ * exists for — a rejection that DESTROYS a credential must leave a row, and
+ * that row must hold a fingerprint rather than the credential — and the audit
+ * sink seam plus the `serialized()` negative that enforce it live here.
+ * Duplicating the seam into `userinfo.test.ts` would fork the discipline
+ * across two files instead of pinning it in one.
  */
 
 import { createHash, randomBytes } from "crypto";
@@ -60,6 +68,7 @@ vi.mock("./introspection-auth", () => ({
 }));
 
 const { default: tokenRouter } = await import("./token");
+const { default: userinfoRouter } = await import("./userinfo");
 const { setAuditSinkForTesting } = await import("@/lib/audit/audit-emitter");
 
 const CLIENT_ID = "mcp_client_test";
@@ -162,6 +171,35 @@ async function post(
   return res;
 }
 
+async function getUserinfo(token: string): Promise<FakeRes> {
+  ipCounter += 1;
+  const req = {
+    method: "GET",
+    url: "/oauth/userinfo",
+    originalUrl: "/oauth/userinfo",
+    baseUrl: "",
+    // Same hand-stamped attribution as makeReq: the audit-context middleware
+    // is mounted on the app, not on this router.
+    auditRequestId: REQUEST_ID,
+    auditClientIp: CLIENT_IP,
+    headers: { authorization: `Bearer ${token}`, "user-agent": "Claude/1.0" },
+    ip: `10.3.0.${ipCounter}`,
+    socket: { remoteAddress: `10.3.0.${ipCounter}` },
+  } as unknown as express.Request;
+  const res = makeRes();
+
+  await new Promise<void>((resolve, reject) => {
+    (userinfoRouter as unknown as express.RequestHandler)(
+      req,
+      res as unknown as express.Response,
+      (err?: unknown) => (err ? reject(err) : resolve()),
+    );
+    res.settled.then(resolve);
+  });
+
+  return res;
+}
+
 function grantBody(res: FakeRes): Record<string, string> {
   if (!res.body) throw new Error("token endpoint settled without a JSON body");
   return res.body;
@@ -251,10 +289,17 @@ describe("oauth.token.issue — the authorization_code grant", () => {
     expect(serialized()).not.toContain(codeVerifier);
   });
 
-  it("writes NOTHING when the grant is refused", async () => {
+  it("claims NO issuance when a disabled account's code is refused", async () => {
     // A disabled account's code stays redeemable for its full TTL, so the
     // refusal is the outcome here. Lane A's detectors own denial rows; this
     // emitter must not claim a token was issued.
+    //
+    // Scoped to THIS refusal on purpose. It is not the general claim "a
+    // refused grant is never audited" — the expired-code and expired-refresh
+    // refusals below do emit, because they destroy the row they read and are
+    // therefore self-limiting. This one leaves the code intact so that Enable
+    // restores a working flow, which is exactly why it stays silent: an
+    // invented code could otherwise be replayed into the table forever.
     usersRepositoryMock.isDisabled.mockResolvedValue(true);
 
     const res = await exchange();
@@ -263,6 +308,57 @@ describe("oauth.token.issue — the authorization_code grant", () => {
     expect(res.statusCode).toBe(400);
     expect(oauthRepositoryMock.setAccessToken).not.toHaveBeenCalled();
     expect(rows).toEqual([]);
+  });
+
+  it("records an EXPIRED code as a failed issue, before consuming it", async () => {
+    // Same defect class as the expired-refresh branch: the handler deletes a
+    // real, currently-stored credential and used to answer 400 with nothing
+    // written anywhere. Bounded for the same reason revoke is — it needs a
+    // real code and it consumes it.
+    const issuedAt = new Date(Date.now() - 11 * 60 * 1000);
+    const expiredAt = new Date(Date.now() - 60 * 1000);
+    oauthRepositoryMock.getAuthCode.mockResolvedValue({
+      code: authCode,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      scope: SCOPE,
+      user_id: USER_ID,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+      created_at: issuedAt,
+      expires_at: expiredAt,
+    });
+
+    const res = await exchange();
+    await flush();
+
+    expect(res.statusCode).toBe(400);
+    // The code is still consumed — auditing must not change the outcome.
+    expect(oauthRepositoryMock.deleteAuthCode).toHaveBeenCalledWith(authCode);
+    expect(oauthRepositoryMock.setAccessToken).not.toHaveBeenCalled();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.issue",
+      outcome: "failure",
+      actor_type: "user",
+      actor_id: USER_ID,
+      actor_ip: CLIENT_IP,
+      request_id: REQUEST_ID,
+      target_type: "oauth_client",
+      target_id: CLIENT_ID,
+      http_status: 400,
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "authorization_code_expired",
+      token_type: "authorization_code",
+      token_sha256: sha256(authCode),
+      created_at: issuedAt.toISOString(),
+      expires_at: expiredAt.toISOString(),
+    });
+    // The code is a credential too — fingerprint only, same as every token.
+    expect(serialized()).not.toContain(authCode);
+    expect(serialized()).not.toContain(codeVerifier);
   });
 });
 
@@ -305,6 +401,114 @@ describe("oauth.token.refresh — rotation", () => {
     expect(serialized()).not.toContain(refreshToken);
     expect(serialized()).not.toContain(body.access_token);
     expect(serialized()).not.toContain(body.refresh_token);
+  });
+});
+
+describe("oauth.token.refresh — an EXPIRED refresh token is destroyed, loudly", () => {
+  // The branch this file was extended for. It reads a real token row, DELETES
+  // it, and answered 400 with nothing written anywhere — not even a logger
+  // line — so the credential and the record of when its chain was minted
+  // disappeared in the same request.
+  const refreshToken = "mcp_refresh_long_since_expired";
+  const priorAccessToken = "mcp_token_previous_value";
+  const issuedAt = new Date(Date.now() - 400 * 86400000);
+  const accessExpiredAt = new Date(Date.now() - 399 * 86400000);
+  const refreshExpiredAt = new Date(Date.now() - 86400000);
+
+  beforeEach(() => {
+    oauthRepositoryMock.getByRefreshToken.mockResolvedValue({
+      access_token: priorAccessToken,
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+      user_id: USER_ID,
+      scope: SCOPE,
+      created_at: issuedAt,
+      expires_at: accessExpiredAt,
+      refresh_token_expires_at: refreshExpiredAt,
+    });
+  });
+
+  const redeem = () =>
+    post({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: CLIENT_ID,
+    });
+
+  it("writes exactly one failure row and still destroys the row", async () => {
+    const res = await redeem();
+    await flush();
+
+    expect(res.statusCode).toBe(400);
+    // The delete is the behaviour the audit row exists to describe; it must
+    // still happen, and it must still target the row's ACCESS token, which is
+    // the primary key.
+    expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
+      priorAccessToken,
+    );
+    expect(oauthRepositoryMock.setAccessToken).not.toHaveBeenCalled();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.refresh",
+      outcome: "failure",
+      actor_type: "user",
+      actor_id: USER_ID,
+      actor_ip: CLIENT_IP,
+      request_id: REQUEST_ID,
+      target_type: "oauth_client",
+      target_id: CLIENT_ID,
+      http_status: 400,
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "refresh_token_expired",
+      token_type: "refresh_token",
+    });
+  });
+
+  it("dates the destroyed chain and joins it to the row that minted it", async () => {
+    // The forensic content. Once the row is deleted nothing else records when
+    // the chain began, and `access_token_sha256` is the join key back to the
+    // `oauth.token.issue` row under the key that emitter already writes.
+    await redeem();
+    await flush();
+
+    expect(rows[0].detail).toMatchObject({
+      token_sha256: sha256(refreshToken),
+      token_last4: refreshToken.slice(-4),
+      access_token_sha256: sha256(priorAccessToken),
+      access_token_last4: priorAccessToken.slice(-4),
+      created_at: issuedAt.toISOString(),
+      expires_at: accessExpiredAt.toISOString(),
+      refresh_token_expires_at: refreshExpiredAt.toISOString(),
+    });
+  });
+
+  it("records both credentials as fingerprints and neither as itself", async () => {
+    await redeem();
+    await flush();
+
+    expect(serialized()).not.toContain(refreshToken);
+    expect(serialized()).not.toContain(priorAccessToken);
+  });
+
+  it("still refuses and still deletes when the audit sink REJECTS", async () => {
+    // Mirror of "a broken audit sink cannot break a grant" for the rejection
+    // path. An audit write that fails must degrade the record, never the
+    // request — and it must not leave a destroyed-credential branch half
+    // executed.
+    setAuditSinkForTesting(async () => {
+      throw new Error("connection pool exhausted");
+    });
+
+    const res = await redeem();
+    await flush();
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toMatchObject({ error: "invalid_grant" });
+    expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
+      priorAccessToken,
+    );
   });
 });
 
@@ -525,6 +729,181 @@ describe("oauth.token.revoke / introspect — only for tokens that exist", () =>
       token_sha256: sha256(liveToken),
     });
     expect(serialized()).not.toContain(liveToken);
+  });
+
+  it("DOES record an introspection that finds an EXPIRED token, which it deletes", async () => {
+    // The introspect twin of the expired-refresh branch: the handler destroys
+    // the row it just read. Bounded by that destruction, so it emits — unlike
+    // the ACTIVE branch above, which consumes nothing and is replayable.
+    const expiredToken = "mcp_token_aged_out_value";
+    const issuedAt = new Date(Date.now() - 2 * 86400000);
+    const accessExpiredAt = new Date(Date.now() - 86400000);
+    const refreshExpiresAt = new Date(Date.now() + 300 * 86400000);
+    oauthRepositoryMock.getAccessToken.mockResolvedValue({
+      access_token: expiredToken,
+      refresh_token: "mcp_refresh_still_alive",
+      client_id: CLIENT_ID,
+      user_id: USER_ID,
+      scope: SCOPE,
+      created_at: issuedAt,
+      expires_at: accessExpiredAt,
+      refresh_token_expires_at: refreshExpiresAt,
+    });
+
+    const res = await post({ token: expiredToken }, "/oauth/introspect");
+    await flush();
+
+    expect(grantBody(res).active).toBe(false);
+    expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
+      expiredToken,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.introspect",
+      outcome: "failure",
+      actor_id: USER_ID,
+      target_id: CLIENT_ID,
+      // RFC 7662 answers an inactive token with 200, so the row must say 200.
+      http_status: 200,
+    });
+    expect(rows[0].detail).toMatchObject({
+      active: false,
+      reason: "access_token_expired",
+      token_type: "access_token",
+      token_sha256: sha256(expiredToken),
+      created_at: issuedAt.toISOString(),
+      expires_at: accessExpiredAt.toISOString(),
+      // The delete takes the whole row, so a refresh token that had NOT
+      // expired dies with it. The record has to show that.
+      refresh_token_expires_at: refreshExpiresAt.toISOString(),
+    });
+    expect(serialized()).not.toContain(expiredToken);
+    expect(serialized()).not.toContain("mcp_refresh_still_alive");
+  });
+
+  it("still answers and still deletes on introspect when the sink REJECTS", async () => {
+    setAuditSinkForTesting(async () => {
+      throw new Error("connection pool exhausted");
+    });
+    const expiredToken = "mcp_token_aged_out_value";
+    oauthRepositoryMock.getAccessToken.mockResolvedValue({
+      access_token: expiredToken,
+      client_id: CLIENT_ID,
+      user_id: USER_ID,
+      scope: SCOPE,
+      created_at: new Date(Date.now() - 2 * 86400000),
+      expires_at: new Date(Date.now() - 86400000),
+      refresh_token_expires_at: null,
+    });
+
+    const res = await post({ token: expiredToken }, "/oauth/introspect");
+    await flush();
+
+    expect(grantBody(res).active).toBe(false);
+    expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
+      expiredToken,
+    );
+  });
+});
+
+describe("oauth.token.userinfo — the third destroy-on-expiry branch", () => {
+  const expiredToken = "mcp_token_userinfo_aged_out";
+  const issuedAt = new Date(Date.now() - 2 * 86400000);
+  const accessExpiredAt = new Date(Date.now() - 86400000);
+  const refreshExpiresAt = new Date(Date.now() + 300 * 86400000);
+
+  beforeEach(() => {
+    oauthRepositoryMock.getAccessToken.mockResolvedValue({
+      access_token: expiredToken,
+      refresh_token: "mcp_refresh_still_alive",
+      client_id: CLIENT_ID,
+      user_id: USER_ID,
+      scope: SCOPE,
+      created_at: issuedAt,
+      expires_at: accessExpiredAt,
+      refresh_token_expires_at: refreshExpiresAt,
+    });
+  });
+
+  it("records the destruction and still answers 401", async () => {
+    const res = await getUserinfo(expiredToken);
+    await flush();
+
+    expect(res.statusCode).toBe(401);
+    expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
+      expiredToken,
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.userinfo",
+      outcome: "failure",
+      actor_type: "user",
+      actor_id: USER_ID,
+      actor_ip: CLIENT_IP,
+      request_id: REQUEST_ID,
+      target_type: "oauth_client",
+      target_id: CLIENT_ID,
+      http_status: 401,
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "access_token_expired",
+      token_type: "access_token",
+      token_sha256: sha256(expiredToken),
+      token_last4: expiredToken.slice(-4),
+      created_at: issuedAt.toISOString(),
+      expires_at: accessExpiredAt.toISOString(),
+      refresh_token_expires_at: refreshExpiresAt.toISOString(),
+    });
+    expect(serialized()).not.toContain(expiredToken);
+    expect(serialized()).not.toContain("mcp_refresh_still_alive");
+  });
+
+  it("writes NOTHING when the token is simply unknown", async () => {
+    // The unbounded case: an invented bearer value costs an anonymous caller
+    // one request and would cost the append-only table one permanent row.
+    oauthRepositoryMock.getAccessToken.mockResolvedValue(null);
+
+    const res = await getUserinfo("mcp_token_invented_by_the_caller");
+    await flush();
+
+    expect(res.statusCode).toBe(401);
+    expect(rows).toEqual([]);
+  });
+
+  it("writes NOTHING when the account is disabled — the row survives", async () => {
+    // Disable is a reversible lockout, so this branch destroys nothing and is
+    // therefore not self-limiting. It keeps its logger.warn and no row.
+    oauthRepositoryMock.getAccessToken.mockResolvedValue({
+      access_token: expiredToken,
+      client_id: CLIENT_ID,
+      user_id: USER_ID,
+      scope: SCOPE,
+      created_at: issuedAt,
+      expires_at: new Date(Date.now() + 3600000),
+      refresh_token_expires_at: refreshExpiresAt,
+    });
+    usersRepositoryMock.isDisabled.mockResolvedValue(true);
+
+    const res = await getUserinfo(expiredToken);
+    await flush();
+
+    expect(res.statusCode).toBe(401);
+    expect(oauthRepositoryMock.deleteAccessToken).not.toHaveBeenCalled();
+    expect(rows).toEqual([]);
+  });
+
+  it("still answers and still deletes when the sink REJECTS", async () => {
+    setAuditSinkForTesting(async () => {
+      throw new Error("connection pool exhausted");
+    });
+
+    const res = await getUserinfo(expiredToken);
+    await flush();
+
+    expect(res.statusCode).toBe(401);
+    expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
+      expiredToken,
+    );
   });
 });
 

--- a/apps/backend/src/routers/oauth/token-audit.test.ts
+++ b/apps/backend/src/routers/oauth/token-audit.test.ts
@@ -360,6 +360,44 @@ describe("oauth.token.issue — the authorization_code grant", () => {
     expect(serialized()).not.toContain(authCode);
     expect(serialized()).not.toContain(codeVerifier);
   });
+
+  it("keeps the row when the code DELETE throws — emit runs FIRST", async () => {
+    // The ordering itself, pinned. Emitting before the delete is the whole
+    // reason the record survives a destruction that fails halfway, and every
+    // other case here passes with the two statements swapped. A delete that
+    // throws is exactly the state an operator is investigating: the row may or
+    // may not still be in the table, and this event is the only thing that
+    // says the credential was reached at all.
+    const issuedAt = new Date(Date.now() - 11 * 60 * 1000);
+    const expiredAt = new Date(Date.now() - 60 * 1000);
+    oauthRepositoryMock.getAuthCode.mockResolvedValue({
+      code: authCode,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      scope: SCOPE,
+      user_id: USER_ID,
+      code_challenge: codeChallenge,
+      code_challenge_method: "S256",
+      created_at: issuedAt,
+      expires_at: expiredAt,
+    });
+    oauthRepositoryMock.deleteAuthCode.mockRejectedValue(
+      new Error("connection pool exhausted"),
+    );
+
+    await expect(exchange()).rejects.toThrow("connection pool exhausted");
+    await flush();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.issue",
+      outcome: "failure",
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "authorization_code_expired",
+      token_sha256: sha256(authCode),
+    });
+  });
 });
 
 describe("oauth.token.refresh — rotation", () => {
@@ -488,6 +526,10 @@ describe("oauth.token.refresh — an EXPIRED refresh token is destroyed, loudly"
     await redeem();
     await flush();
 
+    // Asserted before the negatives on purpose: `not.toContain` over an empty
+    // table passes for the wrong reason, so without this line the case would
+    // stay green if the emit disappeared entirely.
+    expect(rows).toHaveLength(1);
     expect(serialized()).not.toContain(refreshToken);
     expect(serialized()).not.toContain(priorAccessToken);
   });
@@ -509,6 +551,27 @@ describe("oauth.token.refresh — an EXPIRED refresh token is destroyed, loudly"
     expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
       priorAccessToken,
     );
+  });
+
+  it("keeps the row when the token DELETE throws — emit runs FIRST", async () => {
+    // Same ordering assertion as the expired-code branch, on the branch the
+    // commit body argues from. See the note there.
+    oauthRepositoryMock.deleteAccessToken.mockRejectedValue(
+      new Error("connection pool exhausted"),
+    );
+
+    await expect(redeem()).rejects.toThrow("connection pool exhausted");
+    await flush();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.refresh",
+      outcome: "failure",
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "refresh_token_expired",
+      access_token_sha256: sha256(priorAccessToken),
+    });
   });
 });
 
@@ -804,6 +867,40 @@ describe("oauth.token.revoke / introspect — only for tokens that exist", () =>
       expiredToken,
     );
   });
+
+  it("keeps the row when the introspect DELETE throws — emit runs FIRST", async () => {
+    // Ordering, on the introspect branch. Here the failed delete is caught by
+    // the endpoint's own try/catch and answered 500, so the request outcome is
+    // observable — but the row is the point: it exists because the emit ran
+    // before the statement that threw.
+    const expiredToken = "mcp_token_aged_out_value";
+    oauthRepositoryMock.getAccessToken.mockResolvedValue({
+      access_token: expiredToken,
+      client_id: CLIENT_ID,
+      user_id: USER_ID,
+      scope: SCOPE,
+      created_at: new Date(Date.now() - 2 * 86400000),
+      expires_at: new Date(Date.now() - 86400000),
+      refresh_token_expires_at: null,
+    });
+    oauthRepositoryMock.deleteAccessToken.mockRejectedValue(
+      new Error("connection pool exhausted"),
+    );
+
+    const res = await post({ token: expiredToken }, "/oauth/introspect");
+    await flush();
+
+    expect(res.statusCode).toBe(500);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.introspect",
+      outcome: "failure",
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "access_token_expired",
+      token_sha256: sha256(expiredToken),
+    });
+  });
 });
 
 describe("oauth.token.userinfo — the third destroy-on-expiry branch", () => {
@@ -904,6 +1001,29 @@ describe("oauth.token.userinfo — the third destroy-on-expiry branch", () => {
     expect(oauthRepositoryMock.deleteAccessToken).toHaveBeenCalledWith(
       expiredToken,
     );
+  });
+
+  it("keeps the row when the userinfo DELETE throws — emit runs FIRST", async () => {
+    // Ordering, on the fourth branch. Same shape as the introspect case: the
+    // handler's try/catch turns the failed delete into a 500, and the row is
+    // there because the emit preceded it.
+    oauthRepositoryMock.deleteAccessToken.mockRejectedValue(
+      new Error("connection pool exhausted"),
+    );
+
+    const res = await getUserinfo(expiredToken);
+    await flush();
+
+    expect(res.statusCode).toBe(500);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      action: "oauth.token.userinfo",
+      outcome: "failure",
+    });
+    expect(rows[0].detail).toMatchObject({
+      reason: "access_token_expired",
+      token_sha256: sha256(expiredToken),
+    });
   });
 });
 

--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -661,6 +661,23 @@ function isoOrNull(value: Date | null | undefined): string | null {
  *    leave the row deliberately intact, because disable must stay reversible,
  *    and they already carry a `logger.warn`.
  *
+ * THE RESIDUAL ON THAT BOUND, STATED PLAINLY RATHER THAN IMPLIED AWAY: it is
+ * one row per destroy ATTEMPT, not per credential. Read-then-delete is not
+ * atomic and neither delete reports whether it removed anything —
+ * `deleteAccessToken` and `deleteAuthCode` both return void — so N concurrent
+ * presentations of the SAME expired credential each read the row before the
+ * first delete commits, and each writes a row. /oauth/token is per-IP limited
+ * by `rateLimitToken` and /oauth/introspect sits behind the failure limiter
+ * plus the RFC 7662 credential gate; GET /oauth/userinfo carries no limiter at
+ * all, so it is the one a burst actually reaches. Emit-first is the half of
+ * that trade being kept ON PURPOSE: the record has to survive a delete that
+ * throws, which is the case an operator is investigating, and buying
+ * exactly-once instead would mean gating the emit on a delete that returns a
+ * row count — trading the forensic guarantee for a counting one. So the bound
+ * is one BURST per real credential, once, where the same burst wrote zero rows
+ * before these emitters existed. Bounding it further needs the prune path on
+ * `audit_log`, same as the introspect-active case above.
+ *
  * GET /oauth/userinfo has the same destroy-on-expiry branch and emits the same
  * shape, but from ./userinfo.ts — this emitter is private to the token router.
  *

--- a/apps/backend/src/routers/oauth/token.ts
+++ b/apps/backend/src/routers/oauth/token.ts
@@ -258,6 +258,27 @@ async function handleAuthorizationCodeGrant(
 
   // Check if code has expired (10 minutes)
   if (Date.now() > codeData.expires_at.getTime()) {
+    // Emitted before the delete for the reason given on the refresh-expiry
+    // branch below: this is a rejection that destroys the row it just read, so
+    // the row here is the only surviving evidence the code ever existed. The
+    // client is UNAUTHENTICATED at this point — auth-method validation happens
+    // further down — but the branch is still bounded, because reaching it
+    // requires a real, currently-stored authorization code and consumes it.
+    emitTokenLifecycle(req, {
+      action: "oauth.token.issue",
+      clientId: codeData.client_id,
+      userId: codeData.user_id,
+      token: code,
+      outcome: "failure",
+      httpStatus: 400,
+      detail: {
+        reason: "authorization_code_expired",
+        token_type: "authorization_code",
+        grant_type: "authorization_code",
+        created_at: isoOrNull(codeData.created_at),
+        expires_at: isoOrNull(codeData.expires_at),
+      },
+    });
     await oauthRepository.deleteAuthCode(code);
     return res.status(400).json({
       error: "invalid_grant",
@@ -453,6 +474,37 @@ async function handleRefreshTokenGrant(
     tokenData.refresh_token_expires_at &&
     Date.now() > tokenData.refresh_token_expires_at.getTime()
   ) {
+    // Emitted BEFORE the delete, and never awaited — `emit` is fire-and-forget
+    // by contract (see lib/audit/audit-emitter). Ordering it first is what
+    // makes the record survive a delete that throws: the whole point of the
+    // row is that the credential it describes no longer exists to be looked
+    // up, so writing it after the destruction would lose it in exactly the
+    // case an operator is investigating.
+    const destroyed = credentialFingerprint(tokenData.access_token);
+    emitTokenLifecycle(req, {
+      action: "oauth.token.refresh",
+      clientId: tokenData.client_id,
+      userId: tokenData.user_id,
+      // The refresh token as PRESENTED — `token_sha256` in the row. It is a
+      // different string from the access token in the same row, which is
+      // fingerprinted separately below.
+      token: refresh_token,
+      outcome: "failure",
+      httpStatus: 400,
+      detail: {
+        reason: "refresh_token_expired",
+        token_type: "refresh_token",
+        // The destroyed row's ACCESS token, under the same keys
+        // `emitTokenIssued` writes — this is the join back to the
+        // `oauth.token.issue` / `oauth.token.refresh` row that minted the
+        // chain, which is the only place its age is now recorded.
+        access_token_sha256: destroyed.sha256,
+        access_token_last4: destroyed.last4,
+        created_at: isoOrNull(tokenData.created_at),
+        expires_at: isoOrNull(tokenData.expires_at),
+        refresh_token_expires_at: isoOrNull(tokenData.refresh_token_expires_at),
+      },
+    });
     await oauthRepository.deleteAccessToken(tokenData.access_token);
     return res.status(400).json({
       error: "invalid_grant",
@@ -536,13 +588,29 @@ async function handleRefreshTokenGrant(
 }
 
 /**
- * Record an introspection or revocation of a token that ACTUALLY EXISTS.
+ * Render a row timestamp for `detail`, tolerating a missing or null value.
  *
- * WHAT IS AND IS NOT EMITTED HERE, because both endpoints are unauthenticated
- * and `audit_log` has no prune path. Both now carry a FAILURE-only limiter
- * (see isPublicOAuthEndpointLimited below), which bounds unresolvable-token
- * spam but deliberately does NOT bound the success paths — so every "is this
- * branch replayable?" judgement below still stands unchanged:
+ * `refresh_token_expires_at` is genuinely nullable in the schema, and the
+ * remaining columns are only NOT NULL as far as the type system is concerned —
+ * an emitter that called `.toISOString()` straight would turn one unexpected
+ * null into a throw on a rejection path, i.e. a 500 on a request that was
+ * already being refused. A null in the column is also honest output: it says
+ * the row carried no such instant.
+ */
+function isoOrNull(value: Date | null | undefined): string | null {
+  return value instanceof Date ? value.toISOString() : null;
+}
+
+/**
+ * Record a lifecycle event for a credential that ACTUALLY EXISTS — issued,
+ * refreshed, introspected, revoked, or REJECTED AND DESTROYED.
+ *
+ * WHAT IS AND IS NOT EMITTED HERE, because /oauth/revoke is unauthenticated
+ * and `audit_log` has no prune path. The two public endpoints carry a
+ * FAILURE-only limiter (see isPublicOAuthEndpointLimited below), which bounds
+ * unresolvable-token spam but deliberately does NOT bound the success paths —
+ * so every "is this branch replayable?" judgement below still stands
+ * unchanged:
  *
  *  - UNKNOWN token, either endpoint: NOTHING. One anonymous request would
  *    equal one permanent INSERT recording a string the caller invented, and
@@ -571,14 +639,49 @@ async function handleRefreshTokenGrant(
  *    token, and it is rate-limited on top, so it is not replay amplification.
  *    A caller naming a different client than the token was issued to is not a
  *    confused client.
+ *  - A REJECTION THAT DESTROYS THE ROW IT JUST READ: emitted. Three branches
+ *    qualify — an EXPIRED AUTHORIZATION CODE and an EXPIRED REFRESH TOKEN on
+ *    /oauth/token, and an EXPIRED ACCESS TOKEN on /oauth/introspect. Each is
+ *    bounded by exactly the argument that admits revoke above: it cannot be
+ *    reached without presenting a REAL, currently-stored credential, and
+ *    reaching it DELETES that credential, so a replay of the same string finds
+ *    nothing and writes nothing. One row per credential destroyed. These were
+ *    the only deletes in this file that left no trace anywhere — not even a
+ *    `logger` line — so a stale credential simply vanished, and with it the
+ *    only evidence of when the chain behind it was minted. That is what the
+ *    `created_at` / `expires_at` / `refresh_token_expires_at` values in
+ *    `detail` are for: they date the chain that just ended, and the destroyed
+ *    row's `access_token_sha256` joins this row to the `oauth.token.issue` row
+ *    that minted it.
+ *  - Every OTHER refusal on the grant half of /oauth/token — missing or
+ *    mismatched client, bad client secret, PKCE failure, unknown code, unknown
+ *    refresh token, disabled account: still NOTHING here. None of them
+ *    destroys a row, so none is self-limiting; an invented code or refresh
+ *    token can be replayed forever. The two disabled-account refusals also
+ *    leave the row deliberately intact, because disable must stay reversible,
+ *    and they already carry a `logger.warn`.
  *
- * The token is recorded as a fingerprint only, matching `emitTokenIssued`, so
- * an operator can follow one credential from mint to revocation by hash.
+ * GET /oauth/userinfo has the same destroy-on-expiry branch and emits the same
+ * shape, but from ./userinfo.ts — this emitter is private to the token router.
+ *
+ * A FAILURE ROW REUSES THE VERB OF THE OPERATION IT REFUSED (`oauth.token.issue`
+ * for a dead authorization code, `oauth.token.refresh` for a dead refresh
+ * token) rather than inventing a `*.expired` verb, matching the revoke
+ * client-mismatch row above. `outcome` is what separates them, so any query
+ * counting successful grants must filter on `outcome = 'success'` and not on
+ * `action` alone.
+ *
+ * The credential is recorded as a fingerprint only, matching `emitTokenIssued`,
+ * so an operator can follow one credential from mint to destruction by hash.
  */
 function emitTokenLifecycle(
   req: express.Request,
   fields: {
-    action: "oauth.token.introspect" | "oauth.token.revoke";
+    action:
+      | "oauth.token.issue"
+      | "oauth.token.refresh"
+      | "oauth.token.introspect"
+      | "oauth.token.revoke";
     clientId: string;
     userId: string;
     token: string;
@@ -760,6 +863,31 @@ tokenRouter.post("/oauth/introspect", async (req, res) => {
       // and a caller replaying one indefinitely is the shape being bounded. A
       // real client hits this at most once, when its own token ages out.
       recordPublicOAuthEndpointFailure(req, "introspect");
+      // Emitted before the delete, same reasoning as the grant-half branches.
+      // No `httpStatus`: RFC 7662 answers an inactive token with 200 and
+      // `{active:false}`, which is the emitter's default.
+      //
+      // `refresh_token_expires_at` is in the row deliberately. This delete
+      // takes the WHOLE row, so a refresh token that had not itself expired
+      // dies with the access token — the record has to show what was
+      // destroyed, not just what was asked about.
+      emitTokenLifecycle(req, {
+        action: "oauth.token.introspect",
+        clientId: tokenData.client_id,
+        userId: tokenData.user_id,
+        token,
+        outcome: "failure",
+        detail: {
+          active: false,
+          reason: "access_token_expired",
+          token_type: "access_token",
+          created_at: isoOrNull(tokenData.created_at),
+          expires_at: isoOrNull(tokenData.expires_at),
+          refresh_token_expires_at: isoOrNull(
+            tokenData.refresh_token_expires_at,
+          ),
+        },
+      });
       await oauthRepository.deleteAccessToken(token);
       return res.json({
         active: false,

--- a/apps/backend/src/routers/oauth/userinfo.ts
+++ b/apps/backend/src/routers/oauth/userinfo.ts
@@ -1,10 +1,95 @@
 import express from "express";
 
+import {
+  auditRequestContext,
+  credentialFingerprint,
+  emit,
+} from "@/lib/audit/audit-emitter";
 import logger from "@/utils/logger";
 
 import { oauthRepository, usersRepository } from "../../db/repositories";
 
 const userinfoRouter = express.Router();
+
+/**
+ * Render a row timestamp for `detail`, tolerating a missing or null value.
+ *
+ * Local twin of the helper in ./token.ts, deliberately not shared: hoisting a
+ * one-line formatter into `lib/audit` would put a router detail in the audit
+ * library's API for no gain. `refresh_token_expires_at` is genuinely nullable,
+ * and an emitter that called `.toISOString()` straight would turn one
+ * unexpected null into a 500 on a request that was already being refused.
+ */
+function isoOrNull(value: Date | null | undefined): string | null {
+  return value instanceof Date ? value.toISOString() : null;
+}
+
+/**
+ * Record the destruction of an expired access token, before it is destroyed.
+ *
+ * The branch below DELETES a real, currently-stored token row and answers 401.
+ * Until this emitter existed it wrote nothing anywhere — no audit row, no log
+ * line — so the credential and every trace of when it had been minted vanished
+ * in the same request. This is the same defect, and the same fix, as the
+ * expired-code / expired-refresh / expired-introspect branches in ./token.ts,
+ * whose `emitTokenLifecycle` header carries the full emit/no-emit doctrine.
+ *
+ * IT IS EMITTED FOR THE SAME REASON THEY ARE, which is not severity but replay
+ * amplification: `audit_log` has no prune path, so a branch an anonymous caller
+ * can reach with an invented string must never write to it. This branch cannot
+ * be reached with an invented string — it requires a token this server issued
+ * and still holds — and reaching it deletes that token, so a replay finds
+ * nothing and writes nothing. One row per credential destroyed.
+ *
+ * `oauth.token.userinfo` rather than `oauth.userinfo`: the subject of the event
+ * is the token, and this endpoint is the second half of the same token-metadata
+ * plane as `oauth.token.introspect`. Keeping the prefix keeps one credential's
+ * whole life queryable with `action LIKE 'oauth.token.%'`.
+ *
+ * The token is recorded ONLY as a sha256 + last-4 fingerprint, matching every
+ * other emitter on this plane, so it stays joinable to the `oauth.token.issue`
+ * row that minted it without the append-only table ever holding the credential.
+ */
+function emitExpiredTokenDestroyed(
+  req: express.Request,
+  tokenData: {
+    client_id: string;
+    user_id: string;
+    created_at?: Date | null;
+    expires_at?: Date | null;
+    refresh_token_expires_at?: Date | null;
+  },
+  token: string,
+): void {
+  const audit = auditRequestContext(req);
+  const fingerprint = credentialFingerprint(token);
+  emit({
+    actor_type: "user",
+    actor_id: tokenData.user_id,
+    actor_label: null,
+    actor_ip: audit.actor_ip,
+    actor_user_agent: audit.actor_user_agent,
+    action: "oauth.token.userinfo",
+    target_type: "oauth_client",
+    target_id: tokenData.client_id,
+    outcome: "failure",
+    request_id: audit.request_id,
+    http_status: 401,
+    detail: {
+      token_sha256: fingerprint.sha256,
+      token_last4: fingerprint.last4,
+      reason: "access_token_expired",
+      token_type: "access_token",
+      // The chain's age is the forensic content — it is what the deleted row
+      // was carrying and what nothing else records once the row is gone.
+      created_at: isoOrNull(tokenData.created_at),
+      expires_at: isoOrNull(tokenData.expires_at),
+      // In the row because this delete takes the WHOLE row: a refresh token
+      // that had not itself expired dies with the access token.
+      refresh_token_expires_at: isoOrNull(tokenData.refresh_token_expires_at),
+    },
+  });
+}
 
 /**
  * OAuth 2.0 UserInfo Endpoint
@@ -42,6 +127,12 @@ userinfoRouter.get("/oauth/userinfo", async (req, res) => {
 
     // Check if token has expired
     if (Date.now() > tokenData.expires_at.getTime()) {
+      // Before the delete, and never awaited: `emit` is fire-and-forget by
+      // contract, and ordering it first is what makes the record survive a
+      // delete that throws. The row describes a credential that will not
+      // exist to be looked up afterwards, so writing it second would lose it
+      // in exactly the case an operator is investigating.
+      emitExpiredTokenDestroyed(req, tokenData, token);
       await oauthRepository.deleteAccessToken(token);
       return res.status(401).json({
         error: "invalid_token",

--- a/apps/backend/src/routers/oauth/userinfo.ts
+++ b/apps/backend/src/routers/oauth/userinfo.ts
@@ -41,6 +41,21 @@ function isoOrNull(value: Date | null | undefined): string | null {
  * and still holds — and reaching it deletes that token, so a replay finds
  * nothing and writes nothing. One row per credential destroyed.
  *
+ * THE RESIDUAL, STATED HERE BECAUSE THIS ENDPOINT CARRIES THE MOST OF IT: that
+ * is one row per destroy ATTEMPT. Read-then-delete is not atomic and
+ * `deleteAccessToken` returns void rather than a row count, so N concurrent
+ * presentations of the SAME expired token each read the row before the first
+ * delete commits and each write a row. /oauth/userinfo also has NO rate
+ * limiter — ./index.ts mounts it behind CORS, security headers and the body
+ * parsers only, while `rateLimitToken` guards /oauth/token and the failure
+ * limiter plus the RFC 7662 credential gate guard /oauth/introspect — so it is
+ * the branch a burst actually reaches. Kept anyway, because the alternative is
+ * to emit AFTER a delete that reports what it removed, which loses the record
+ * in precisely the failed-delete case this ordering exists for. One burst per
+ * real credential, once, against zero rows before this emitter existed.
+ * ./token.ts's `emitTokenLifecycle` header states the same trade for the other
+ * three branches.
+ *
  * `oauth.token.userinfo` rather than `oauth.userinfo`: the subject of the event
  * is the token, and this endpoint is the second half of the same token-metadata
  * plane as `oauth.token.introspect`. Keeping the prefix keeps one credential's


### PR DESCRIPTION
## The defect

Four OAuth rejection branches DELETE a real, currently-stored credential row and write nothing anywhere — no `audit_log` row, no log line:

| endpoint | branch | destroyed |
|---|---|---|
| `POST /oauth/token` | authorization code expired | the auth-code row |
| `POST /oauth/token` | refresh token expired | the whole token row |
| `POST /oauth/introspect` | access token expired | the whole token row |
| `GET /oauth/userinfo` | access token expired | the whole token row |

These were the only deletes in the OAuth router that left no trace at all. The credential vanished together with the only record of when the chain behind it had been minted — which is exactly what an operator needs afterwards, and the one moment it is no longer recoverable, because `audit_log` is append-only and the row is gone.

## The fix

Each branch emits an `audit_log` event **before** the delete. Ordering matters: a delete that throws still leaves the record, and the row describes a credential that will not exist to be looked up afterwards. The emitter stays fire-and-forget — never awaited, never wrapped in a `try`/`catch` — per the contract in `lib/audit/audit-emitter`. Each branch carries a test that makes the delete throw and asserts the row survives, so the ordering is pinned where it is argued.

**The residual, stated rather than implied away** (both doctrine blocks now say this): it is one row per destroy *attempt*, not per credential. Read-then-delete is not atomic and neither delete reports a row count, so concurrent presentations of the same expired credential each write a row — and `GET /oauth/userinfo` carries no rate limiter at all, so it is the branch a burst actually reaches. Emit-first is the half of that trade kept on purpose: buying exactly-once would mean emitting after a delete that reports what it removed, which loses the record in the failed-delete case the ordering exists for. One burst per real credential, once, against zero rows before.

## Why these four and not the other refusals

The router's emit criterion is **replay amplification**, not severity: `audit_log` has no prune path, so a branch an anonymous caller can reach with an invented string must never write to it. These four cannot be reached with an invented string — each requires a credential this server issued and still holds — and reaching one destroys that credential, so a replay finds nothing and writes nothing. That is the same self-limiting bound that already admits the revoke rows.

Every other refusal on the grant half stays silent, and the doctrine comment block now says so explicitly: unknown code, unknown refresh token, client mismatch, bad secret, PKCE failure and the two disabled-account refusals all leave the row intact, so none of them is bounded.

## Shape of the rows

- Credentials appear **only** as sha256 + last-4, same as every other emitter on this plane.
- The refresh row fingerprints both the presented refresh token and the destroyed row's access token, under the key `emitTokenIssued` already writes — so the event joins back to the row that minted the chain.
- `created_at` / `expires_at` / `refresh_token_expires_at` are the forensic content: they date the chain that just ended. The introspect and userinfo rows carry `refresh_token_expires_at` because the delete takes the whole row, so a refresh token that had **not** expired dies with the access token.
- A failure row reuses the verb of the operation it refused (`oauth.token.issue`, `oauth.token.refresh`) rather than inventing a `*.expired` verb, matching the existing revoke client-mismatch row. **`outcome` is what separates them** — a query counting successful grants must filter `outcome = 'success'`, not `action` alone.
- One new verb: `oauth.token.userinfo`, keeping the `oauth.token.*` prefix so one credential's whole life stays queryable with a single `LIKE`.

## Tests

12 new cases in `token-audit.test.ts` (15 -> 27), covering all four branches: exactly one row, correct action / outcome / http_status / reason, timestamps and both fingerprints, the credential absent from `JSON.stringify(rows)`, and the delete still performed. Each branch also gets a rejecting-sink case proving a broken audit sink degrades the record and never the request — the mirror of the existing "a broken audit sink cannot break a grant" — and a **failing-delete** case proving the emit ran first.

The existing `writes NOTHING when the grant is refused` case is retitled to `claims NO issuance when a disabled account's code is refused` and its comment narrowed. It always pinned `emitTokenIssued` specifically rather than "no refusal is ever audited"; the old title would now read as contradicting these rows.

Verified by mutation, per site rather than in bulk. With the four emit calls neutralised, 5 of the new cases fail. Swapping emit and delete on each of the four branches in turn fails exactly that branch's ordering case (userinfo, auth code, refresh, introspect — one failure each). Suppressing the refresh emit fails 4 cases in its describe, including the fingerprint negative that previously passed over an empty table and now asserts a row count first. Restored and md5-verified, the suite is green.

