### PR TITLE
feat(mcp-proxy): pass X-MCP-Actor through to backends

### DIFF
--- a/apps/backend/src/routers/mcp-proxy/server.remote-url.test.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.remote-url.test.ts
@@ -247,6 +247,8 @@ async function drive(
   query: Record<string, string>,
   /** `null` means the request arrives with NO session user at all. */
   user: { id?: string; role?: string } | null = CALLER,
+  /** Request headers, lowercase-keyed as Express delivers them. */
+  headers: Record<string, string> = {},
 ): Promise<number> {
   const search = new URLSearchParams(query).toString();
   const req = {
@@ -255,7 +257,7 @@ async function drive(
     originalUrl: `/mcp-proxy/server${path}?${search}`,
     baseUrl: "",
     query: Object.fromEntries(new URLSearchParams(search)),
-    headers: {},
+    headers,
     user: user ?? undefined,
   } as unknown as express.Request;
 
@@ -278,11 +280,13 @@ async function drive(
 const getSse = (
   query: Record<string, string>,
   user: { id?: string; role?: string } | null = CALLER,
-) => drive("GET", "/sse", query, user);
+  headers: Record<string, string> = {},
+) => drive("GET", "/sse", query, user, headers);
 const postMcp = (
   query: Record<string, string>,
   user: { id?: string; role?: string } | null = CALLER,
-) => drive("POST", "/mcp", query, user);
+  headers: Record<string, string> = {},
+) => drive("POST", "/mcp", query, user, headers);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -571,5 +575,57 @@ describe("the SSE connect log", () => {
     expect(line).toBeDefined();
     // The escape sequence survives as TEXT rather than as a real break.
     expect(line).not.toMatch(/\n\n/);
+  });
+});
+
+/**
+ * X-MCP-Actor passthrough: best-effort, client-asserted attribution that lets
+ * a backend MCP stamp WHO an action is on behalf of onto its audit rows and the
+ * shell-broker approval page. It is NOT an auth control — that stays the
+ * endpoint API-key — so the only questions here are whether a caller-set value
+ * reaches the backend transport and whether the whitelist stays narrow enough
+ * that nothing else rides along with it.
+ */
+describe("X-MCP-Actor passthrough — best-effort audit attribution", () => {
+  const ACTOR = "operator@umbrellaitgroup.com";
+
+  it("forwards x-mcp-actor to an SSE backend when the caller sets it", async () => {
+    await getSse(
+      { transportType: "SSE", url: "https://mcp.example.com/sse" },
+      CALLER,
+      { "x-mcp-actor": ACTOR },
+    );
+
+    expect(sseHeaders()["x-mcp-actor"]).toBe(ACTOR);
+  });
+
+  it("forwards x-mcp-actor to a STREAMABLE_HTTP backend when the caller sets it", async () => {
+    await postMcp(
+      { transportType: "STREAMABLE_HTTP", url: "https://mcp.example.com/mcp" },
+      CALLER,
+      { "x-mcp-actor": ACTOR },
+    );
+
+    expect(
+      streamableClientConstructions[0].opts.requestInit.headers["x-mcp-actor"],
+    ).toBe(ACTOR);
+  });
+
+  it("omits x-mcp-actor when the caller does not send it", async () => {
+    await getSse({ transportType: "SSE", url: "https://mcp.example.com/sse" });
+
+    expect(sseHeaders()["x-mcp-actor"]).toBeUndefined();
+  });
+
+  it("does NOT forward a header outside the whitelist", async () => {
+    // Guard against over-widening: adding x-mcp-actor must not turn the
+    // passthrough into a general-purpose header conduit.
+    await getSse(
+      { transportType: "SSE", url: "https://mcp.example.com/sse" },
+      CALLER,
+      { "x-not-whitelisted": "must-not-travel" },
+    );
+
+    expect(sseHeaders()["x-not-whitelisted"]).toBeUndefined();
   });
 });

--- a/apps/backend/src/routers/mcp-proxy/server.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.ts
@@ -28,11 +28,19 @@ import { resolveEnvVariables } from "../../lib/metamcp/utils";
 import { ProcessManagedStdioTransport } from "../../lib/stdio-transport/process-managed-transport";
 import { assertPublicMcpUrl, createGuardedFetch } from "./url-guard";
 
-const SSE_HEADERS_PASSTHROUGH = ["authorization"];
+// `x-mcp-actor` is best-effort, client-asserted attribution: it names who an
+// action is on behalf of so backend MCPs (shell-broker, ninja, inventory) can
+// stamp the operator on their audit rows and the shell-broker approval page
+// instead of a generic default. It is NOT an authentication control — the
+// security identity stays the endpoint API-key auth, and for shell-broker the
+// CF-Access-verified approver — so forwarding a caller-set value is safe.
+// Lowercase because Node lowercases incoming header names.
+const SSE_HEADERS_PASSTHROUGH = ["authorization", "x-mcp-actor"];
 const STREAMABLE_HTTP_HEADERS_PASSTHROUGH = [
   "authorization",
   "mcp-session-id",
   "last-event-id",
+  "x-mcp-actor",
 ];
 
 const defaultEnvironment = {


### PR DESCRIPTION
## What

Forward the `X-MCP-Actor` request header from the gateway to backend MCP servers over both SSE and Streamable-HTTP transports.

## Why

Backend MCPs (shell-broker, ninja, inventory) resolve their audit `actor`/driver from an `X-MCP-Actor` request header, falling back to a generic default when it is absent. The gateway's header passthrough whitelist did **not** include it, so a client-set `X-MCP-Actor` never reached the backend — every audit row, and the shell-broker approval page, showed the generic default instead of the operator.

The actor is **best-effort, client-asserted attribution — NOT an authentication control.** The security identity stays the endpoint API-key auth and, for shell-broker, the CF-Access-verified approver. Forwarding a caller-set value is therefore safe; a code comment on the constant says so to prevent it being mistaken for an auth header.

## Change

`apps/backend/src/routers/mcp-proxy/server.ts` — add `"x-mcp-actor"` (lowercase; Node lowercases incoming header names) to both `SSE_HEADERS_PASSTHROUGH` and `STREAMABLE_HTTP_HEADERS_PASSTHROUGH`. These are consumed by `getHttpHeaders`, which merges them into the outbound transport headers. Merge order at both call sites is unchanged: request passthrough still overrides a row's stored headers.

## Test

Extends the existing end-to-end harness in `server.remote-url.test.ts` (which drives the real `GET /sse` / `POST /mcp` routes and asserts on the headers handed to the transport constructor) rather than exporting the module-private `getHttpHeaders`:

- forwards `x-mcp-actor` to an SSE backend when the caller sets it
- forwards `x-mcp-actor` to a Streamable-HTTP backend when the caller sets it
- omits `x-mcp-actor` when the caller does not send it
- does **not** forward a header outside the whitelist (guard against over-widening)

## How to test

`pnpm --filter backend exec vitest run src/routers/mcp-proxy/server.remote-url.test.ts` — 38 passed (34 existing + 4 new). Backend `check-types` clean.
