### PR TITLE
fix: scope tool catalog + whole-config reads, validate post-auth redirects

### DIFF
--- a/apps/backend/src/trpc/config-admin-gate.test.ts
+++ b/apps/backend/src/trpc/config-admin-gate.test.ts
@@ -4,7 +4,9 @@
  * lifetime, MCP timeouts/attempts, raw setConfig) was on `protectedProcedure`
  * — any authenticated member could flip auth-posture toggles for the whole
  * gateway. Moved to `adminProcedure`; reads keep their existing access level
- * (mostly public, `getAllConfigs` stays protected).
+ * (mostly public). `getAllConfigs` is the exception: it returns the entire
+ * config table in one unfiltered read and no frontend page consumes it, so it
+ * is now `adminProcedure` too rather than staying member-readable.
  *
  * One representative setter (`setSignupDisabled`) is exercised through the
  * real `createConfigRouter` wiring via a real tRPC caller — the same
@@ -75,6 +77,18 @@ describe("config write surface — admin gate", () => {
       router
         .createCaller(memberCtx)
         .setConfig({ key: "DISABLE_SIGNUP", value: "true" }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("getAllConfigs (whole-table read): admin allowed, member FORBIDDEN", async () => {
+    const router = buildRouter();
+
+    await expect(
+      router.createCaller(adminCtx).getAllConfigs(),
+    ).resolves.toEqual([]);
+
+    await expect(
+      router.createCaller(memberCtx).getAllConfigs(),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 

--- a/apps/backend/src/trpc/member-disclosure-gates.test.ts
+++ b/apps/backend/src/trpc/member-disclosure-gates.test.ts
@@ -31,6 +31,7 @@ import {
   createLogsRouter,
   createMcpServersRouter,
   createNamespacesRouter,
+  createToolsRouter,
 } from "@repo/trpc";
 import { describe, expect, it, vi } from "vitest";
 
@@ -81,6 +82,15 @@ const buildMcpServersRouter = () => {
     reconnect: okImpl({ success: true } as never),
   };
   return { router: createMcpServersRouter(impls), impls };
+};
+
+const buildToolsRouter = () => {
+  const impls = {
+    getByMcpServerUuid: okImpl({ success: true, data: [] } as never),
+    create: okImpl({ success: true, count: 0 } as never),
+    sync: okImpl({ success: true, count: 0 } as never),
+  };
+  return { router: createToolsRouter(impls), impls };
 };
 
 const buildNamespacesRouter = () => {
@@ -198,6 +208,35 @@ describe("mcpServers.reconnect — isAdmin reaches the implementation", () => {
 
     await expect(
       router.createCaller(memberCtx).reconnect({ uuid: SERVER_UUID }),
+    ).resolves.toMatchObject({ success: true });
+  });
+});
+
+describe("tools.getByMcpServerUuid — the caller id reaches the implementation", () => {
+  // The ownership decision lives in the impl (tools.impl.get.test.ts); this
+  // pins the wiring that feeds it. Drop `ctx.user.id` at the router and the
+  // impl scopes against `undefined`, which never equals any owner — every
+  // private catalog would refuse and the check would silently stop meaning
+  // anything. A positional argument no type error would catch.
+  it("passes the caller id, not the whole context", async () => {
+    const { router, impls } = buildToolsRouter();
+
+    await router
+      .createCaller(memberCtx)
+      .getByMcpServerUuid({ mcpServerUuid: SERVER_UUID });
+    expect(impls.getByMcpServerUuid).toHaveBeenCalledWith(
+      { mcpServerUuid: SERVER_UUID },
+      "member-1",
+    );
+  });
+
+  it("stays reachable by members — this is per-user scoping, not an admin gate", async () => {
+    const { router } = buildToolsRouter();
+
+    await expect(
+      router
+        .createCaller(memberCtx)
+        .getByMcpServerUuid({ mcpServerUuid: SERVER_UUID }),
     ).resolves.toMatchObject({ success: true });
   });
 });

--- a/apps/backend/src/trpc/tools.impl.get.test.ts
+++ b/apps/backend/src/trpc/tools.impl.get.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Ownership scoping for the `tools.getByMcpServerUuid` implementation.
+ *
+ * The tool catalog (names, descriptions, input schemas) is a per-user
+ * disclosure surface, the same class as the server row itself. `mcpServers.get`
+ * already gates that row to own-plus-public; this reader used to return any
+ * server's catalog to any authenticated caller who knew the UUID, with no
+ * ownership check at all. The suite pins the three outcomes that matter: a
+ * member is refused another user's PRIVATE server, allowed on a PUBLIC
+ * (unowned) server, and allowed on their OWN server. The refusal path must
+ * also never reach the catalog query.
+ *
+ * Same isolation approach as `mcp-servers.reconnect.impl.test.ts`: the
+ * `../db/repositories` barrel reaches `db/index`, which needs a live
+ * DATABASE_URL, so it is stubbed and the unit needs no postgres.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../db/repositories", () => ({
+  mcpServersRepository: { findByUuid: vi.fn() },
+  toolsRepository: { findByMcpServerUuid: vi.fn() },
+}));
+
+// Passthrough serializer: the ownership decision is the unit under test, not
+// the shape mapping, and mocking the barrel keeps db out of the import graph.
+vi.mock("../db/serializers", () => ({
+  ToolsSerializer: { serializeToolList: vi.fn((tools) => tools) },
+}));
+
+import { mcpServersRepository, toolsRepository } from "../db/repositories";
+import { toolsImplementations } from "./tools.impl";
+
+const SERVER_UUID = "11111111-1111-4111-8111-111111111111";
+const OWNER_ID = "owner-1";
+const OTHER_ID = "member-2";
+
+const fakeServer = (overrides: Record<string, unknown> = {}) =>
+  ({
+    uuid: SERVER_UUID,
+    name: "autotask",
+    user_id: null,
+    ...overrides,
+  }) as any;
+
+const CATALOG = [
+  { uuid: "tool-1", name: "create_ticket", description: "", toolSchema: {} },
+];
+
+describe("tools.getByMcpServerUuid — ownership scoping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(toolsRepository.findByMcpServerUuid).mockResolvedValue(
+      CATALOG as never,
+    );
+  });
+
+  it("refuses a member reading another user's PRIVATE server catalog", async () => {
+    vi.mocked(mcpServersRepository.findByUuid).mockResolvedValue(
+      fakeServer({ user_id: OWNER_ID }),
+    );
+
+    const result = await toolsImplementations.getByMcpServerUuid(
+      { mcpServerUuid: SERVER_UUID },
+      OTHER_ID,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.data).toEqual([]);
+    // The catalog query must never run once ownership is refused.
+    expect(toolsRepository.findByMcpServerUuid).not.toHaveBeenCalled();
+  });
+
+  it("allows any member on a PUBLIC (unowned) server", async () => {
+    vi.mocked(mcpServersRepository.findByUuid).mockResolvedValue(
+      fakeServer({ user_id: null }),
+    );
+
+    const result = await toolsImplementations.getByMcpServerUuid(
+      { mcpServerUuid: SERVER_UUID },
+      OTHER_ID,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(CATALOG);
+    expect(toolsRepository.findByMcpServerUuid).toHaveBeenCalledWith(
+      SERVER_UUID,
+    );
+  });
+
+  it("allows the OWNER on their own private server", async () => {
+    vi.mocked(mcpServersRepository.findByUuid).mockResolvedValue(
+      fakeServer({ user_id: OWNER_ID }),
+    );
+
+    const result = await toolsImplementations.getByMcpServerUuid(
+      { mcpServerUuid: SERVER_UUID },
+      OWNER_ID,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(CATALOG);
+    expect(toolsRepository.findByMcpServerUuid).toHaveBeenCalledWith(
+      SERVER_UUID,
+    );
+  });
+});

--- a/apps/backend/src/trpc/tools.impl.ts
+++ b/apps/backend/src/trpc/tools.impl.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
-import { toolsRepository } from "../db/repositories";
+import { mcpServersRepository, toolsRepository } from "../db/repositories";
 import { ToolsSerializer } from "../db/serializers";
 import { emitAdminEvent } from "../lib/audit/admin-event";
 import { toolsSyncCache } from "../lib/metamcp/tools-sync-cache";
@@ -27,8 +27,27 @@ import { toolsSyncCache } from "../lib/metamcp/tools-sync-cache";
 export const toolsImplementations = {
   getByMcpServerUuid: async (
     input: z.infer<typeof GetToolsByMcpServerUuidRequestSchema>,
+    userId: string,
   ): Promise<z.infer<typeof GetToolsByMcpServerUuidResponseSchema>> => {
     try {
+      // Scope the catalog the same way `mcpServers.get` scopes the server
+      // itself: a private server (user_id set) is readable only by its owner,
+      // public servers (no user_id) stay readable to any member. The tool
+      // catalog (names, descriptions, input schemas) is the same per-user
+      // disclosure surface, so it must gate on ownership before returning —
+      // otherwise a member who obtains a private server's UUID can read
+      // another user's tools. Admins are not exempted here, matching
+      // mcpServers.get.
+      const server = await mcpServersRepository.findByUuid(input.mcpServerUuid);
+      if (server && server.user_id && server.user_id !== userId) {
+        return {
+          success: false as const,
+          data: [],
+          message:
+            "Access denied: You can only view tools for servers you own or public servers",
+        };
+      }
+
       const tools = await toolsRepository.findByMcpServerUuid(
         input.mcpServerUuid,
       );

--- a/apps/frontend/app/[locale]/cors-error/page.tsx
+++ b/apps/frontend/app/[locale]/cors-error/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useTranslations } from "@/hooks/useTranslations";
 import { getAppUrl } from "@/lib/env";
+import { toSafeInternalPath } from "@/lib/safe-redirect";
 
 function CorsErrorContent() {
   const { t } = useTranslations();
@@ -31,12 +32,23 @@ function CorsErrorContent() {
     }
   }, []);
 
-  const attemptedPath = searchParams.get("callbackUrl") || "/";
+  // callbackUrl is attacker-controlled; reduce it to a safe same-origin path
+  // before it is ever concatenated onto an origin and navigated to.
+  const attemptedPath = toSafeInternalPath(searchParams.get("callbackUrl"));
 
   const handleRedirectToCorrectDomain = () => {
-    if (correctDomain) {
-      const redirectUrl = `${correctDomain}${attemptedPath}`;
-      window.location.href = redirectUrl;
+    if (!correctDomain) return;
+    try {
+      // Belt to the sanitized path above: resolve against the authorized
+      // origin and navigate only when the result is still that same origin,
+      // so a value that slipped past the path check cannot send the user off
+      // to another host.
+      const target = new URL(attemptedPath, correctDomain);
+      if (target.origin === new URL(correctDomain).origin) {
+        window.location.href = target.href;
+      }
+    } catch (error) {
+      console.error("Invalid redirect target:", error);
     }
   };
 

--- a/apps/frontend/app/[locale]/login/page.tsx
+++ b/apps/frontend/app/[locale]/login/page.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/ui/input";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useTranslations } from "@/hooks/useTranslations";
 import { authClient } from "@/lib/auth-client";
+import { toSafeInternalPath } from "@/lib/safe-redirect";
 import { vanillaTrpcClient } from "@/lib/trpc";
 
 function LoginForm() {
@@ -27,7 +28,10 @@ function LoginForm() {
 
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
+  // Sanitize once at the source: callbackUrl is attacker-controlled and flows
+  // into both router.push and better-auth's callbackURL below. Reduced to a
+  // safe same-origin path so neither leg can redirect off-site.
+  const callbackUrl = toSafeInternalPath(searchParams.get("callbackUrl"));
 
   // Check if signup is disabled
   useEffect(() => {

--- a/apps/frontend/lib/oauth-provider.ts
+++ b/apps/frontend/lib/oauth-provider.ts
@@ -3,7 +3,6 @@ import {
   OAuthClientInformation,
   OAuthClientInformationSchema,
   OAuthClientMetadata,
-  OAuthMetadata,
   OAuthTokens,
   OAuthTokensSchema,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
@@ -227,52 +226,10 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   }
 }
 
-// Debug version that overrides redirect URL and allows saving server OAuth metadata
-export class DebugDbOAuthClientProvider extends DbOAuthClientProvider {
-  get redirectUrl(): string {
-    return getAppUrl() + "/fe-oauth/callback/debug";
-  }
-
-  saveServerMetadata(metadata: OAuthMetadata) {
-    const key = getServerSpecificKey(
-      SESSION_KEYS.SERVER_METADATA,
-      this.serverUrl,
-    );
-    sessionStorage.setItem(key, JSON.stringify(metadata));
-  }
-
-  getServerMetadata(): OAuthMetadata | null {
-    const key = getServerSpecificKey(
-      SESSION_KEYS.SERVER_METADATA,
-      this.serverUrl,
-    );
-    const metadata = sessionStorage.getItem(key);
-    if (!metadata) {
-      return null;
-    }
-    return JSON.parse(metadata);
-  }
-
-  clear() {
-    super.clear();
-    sessionStorage.removeItem(
-      getServerSpecificKey(SESSION_KEYS.SERVER_METADATA, this.serverUrl),
-    );
-  }
-}
-
 // Factory function to create an OAuth provider for a specific MCP server
 export function createAuthProvider(
   mcpServerUuid: string,
   serverUrl: string,
 ): DbOAuthClientProvider {
   return new DbOAuthClientProvider(mcpServerUuid, serverUrl);
-}
-
-// Factory function to create a debug OAuth provider for a specific MCP server
-export function createDebugAuthProvider(
-  mcpServerUuid: string,
-  serverUrl: string,
-): DebugDbOAuthClientProvider {
-  return new DebugDbOAuthClientProvider(mcpServerUuid, serverUrl);
 }

--- a/apps/frontend/lib/safe-redirect.test.ts
+++ b/apps/frontend/lib/safe-redirect.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The same-origin guard for post-auth redirects.
+ *
+ * `callbackUrl` is an attacker-controlled query parameter that both the login
+ * page and the cors-error page navigate to. This proves the guard admits an
+ * ordinary internal path and rejects every off-origin shape — the scheme, the
+ * bare host, the protocol-relative and the backslash-smuggled forms — falling
+ * back to "/" instead.
+ *
+ * The frontend harness is `environment: "node"` (see vitest.config.ts), so
+ * getAppUrl() takes its server branch and reads process.env; NEXT_PUBLIC_APP_URL
+ * is set below to give it a deterministic origin to validate against.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { toSafeInternalPath } from "./safe-redirect";
+
+const APP_URL = "https://mcp.example.com";
+
+let priorAppUrl: string | undefined;
+let priorPublicAppUrl: string | undefined;
+
+beforeAll(() => {
+  priorAppUrl = process.env.APP_URL;
+  priorPublicAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  process.env.NEXT_PUBLIC_APP_URL = APP_URL;
+});
+
+afterAll(() => {
+  if (priorAppUrl === undefined) delete process.env.APP_URL;
+  else process.env.APP_URL = priorAppUrl;
+  if (priorPublicAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+  else process.env.NEXT_PUBLIC_APP_URL = priorPublicAppUrl;
+});
+
+describe("toSafeInternalPath", () => {
+  it("keeps an ordinary internal path", () => {
+    expect(toSafeInternalPath("/x")).toBe("/x");
+  });
+
+  it("preserves the query and hash on a same-origin path", () => {
+    expect(toSafeInternalPath("/mcp-servers?tab=tools#top")).toBe(
+      "/mcp-servers?tab=tools#top",
+    );
+  });
+
+  const REJECTED: Array<[string, string]> = [
+    ["//evil", "protocol-relative URL -> another host"],
+    ["/\\evil", "backslash the browser reads as a slash -> another host"],
+    ["@evil.com", "userinfo host, no leading slash"],
+    [".evil.com", "bare host, no leading slash"],
+    ["https://evil", "absolute URL to another origin"],
+    ["javascript:", "non-navigational scheme"],
+  ];
+
+  it.each(REJECTED)("rejects %s (%s) and falls back to /", (input) => {
+    expect(toSafeInternalPath(input)).toBe("/");
+  });
+
+  it("falls back to / for empty, null and undefined", () => {
+    expect(toSafeInternalPath("")).toBe("/");
+    expect(toSafeInternalPath(null)).toBe("/");
+    expect(toSafeInternalPath(undefined)).toBe("/");
+  });
+
+  it("honors an explicit fallback", () => {
+    expect(toSafeInternalPath("https://evil", "/mcp-servers")).toBe(
+      "/mcp-servers",
+    );
+  });
+});

--- a/apps/frontend/lib/safe-redirect.ts
+++ b/apps/frontend/lib/safe-redirect.ts
@@ -1,0 +1,54 @@
+import { getAppUrl } from "./env";
+
+/**
+ * Reduce a caller-supplied `callbackUrl` to a safe SAME-ORIGIN relative path,
+ * falling back to `fallback` ("/") for anything else.
+ *
+ * `callbackUrl` comes off the query string, which an attacker controls in a
+ * crafted link. The login page navigates to it after a successful sign-in
+ * (router.push, and better-auth's own callbackURL) and the cors-error page
+ * builds a redirect from it. Without this a value like "//evil.com",
+ * "@evil.com" or "https://evil" would land an already-authenticated user on an
+ * attacker origin: an open redirect / phishing aid.
+ *
+ * A value is accepted only when ALL of these hold, checked cheapest first:
+ *   - it begins with a single "/" — a relative path, not a scheme
+ *     ("javascript:", "https://evil") or a bare host ("@evil.com",
+ *     ".evil.com"), none of which start with "/";
+ *   - it does not begin with "//" — a protocol-relative URL resolves to
+ *     another host;
+ *   - it contains no backslash — browsers treat "\" as "/", so "/\evil.com"
+ *     would resolve to another host;
+ *   - parsed against the app origin it resolves back to that SAME origin, so
+ *     any authority a path still manages to smuggle is caught by the URL
+ *     parser rather than by trying to pattern-match every trick.
+ *
+ * The returned value is the resolved path plus any query and hash the caller
+ * supplied, all guaranteed same-origin by the check above.
+ */
+export function toSafeInternalPath(
+  value: string | null | undefined,
+  fallback = "/",
+): string {
+  if (!value) return fallback;
+  if (!value.startsWith("/")) return fallback;
+  if (value.startsWith("//")) return fallback;
+  if (value.includes("\\")) return fallback;
+
+  let appUrl: string;
+  try {
+    appUrl = getAppUrl();
+  } catch {
+    // No configured origin to validate against — refuse rather than guess.
+    return fallback;
+  }
+
+  try {
+    const appOrigin = new URL(appUrl).origin;
+    const target = new URL(value, appUrl);
+    if (target.origin !== appOrigin) return fallback;
+    return target.pathname + target.search + target.hash;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/trpc/src/routers/frontend/config.ts
+++ b/packages/trpc/src/routers/frontend/config.ts
@@ -235,7 +235,15 @@ export const createConfigRouter = (implementations: {
         return await implementations.setSessionLifetime(input, auditActor(ctx));
       }),
 
-    getAllConfigs: protectedProcedure.query(async () => {
+    // Admin only. Unlike the individually-gated getters above, this returns
+    // the ENTIRE config table in one unfiltered read, and every paired write
+    // in this router is `adminProcedure`. A call-site sweep of `apps/frontend`
+    // found no consumer at all — the settings page reads each value through
+    // its named getter, never this — so gating it removes a member-level
+    // whole-table read with no UI impact. Left on `protectedProcedure`, a
+    // future sensitive config key would leak to every member automatically
+    // the moment it was added.
+    getAllConfigs: adminProcedure.query(async () => {
       return await implementations.getAllConfigs();
     }),
 

--- a/packages/trpc/src/routers/frontend/tools.ts
+++ b/packages/trpc/src/routers/frontend/tools.ts
@@ -13,7 +13,12 @@ import {
 
 export const createToolsRouter = <
   TImplementations extends {
-    getByMcpServerUuid: (input: any) => Promise<any>;
+    // `userId` is threaded from `ctx.user.id` so the impl can scope the tool
+    // catalog to servers the caller owns or public servers, the same
+    // own-plus-public contract as `mcpServers.get`. Without it any member who
+    // learns a private server's UUID could read that server's full tool
+    // catalog.
+    getByMcpServerUuid: (input: any, userId: string) => Promise<any>;
     create: (input: any, actor: AuditActor) => Promise<any>;
     sync: (input: any, actor: AuditActor) => Promise<any>;
   },
@@ -21,11 +26,11 @@ export const createToolsRouter = <
   implementations: TImplementations,
 ) => {
   return router({
-    // Protected: Get tools by MCP server UUID
+    // Protected: Get tools by MCP server UUID, scoped to the caller in the impl.
     getByMcpServerUuid: protectedProcedure
       .input(GetToolsByMcpServerUuidRequestSchema)
-      .query(async ({ input }) => {
-        return implementations.getByMcpServerUuid(input);
+      .query(async ({ input, ctx }) => {
+        return implementations.getByMcpServerUuid(input, ctx.user.id);
       }),
 
     // Admin only: Save tools to database (upsert only, no cleanup). Curation


### PR DESCRIPTION
Batched hardening for the tRPC and web surface. Four changes, each with a test that fails without the fix.

## Scope tool catalog reads to the calling user
`frontend.tools.getByMcpServerUuid` was `protectedProcedure` and forwarded only its input, never the caller id; the implementation filtered on the server UUID alone. Any authenticated member who obtained a private server's UUID could read that server's full tool catalog (names, descriptions, input schemas) even when another user owned it.

Fix: thread `ctx.user.id` into the implementation and gate the read the same way `mcpServers.get` does. A private server (`user_id` set) is readable only by its owner; public servers (no `user_id`) stay readable to any member. Admins are not exempted on another user's private server, matching `mcpServers.get`.

Tests: `tools.impl.get.test.ts` (member refused another user's private catalog, allowed on public, owner allowed, and the catalog query never runs on refusal) and a router-wiring assertion in `member-disclosure-gates.test.ts` that the caller id reaches the implementation.

## Gate the whole-config read behind admin
`frontend.config.getAllConfigs` was `protectedProcedure` and returned the entire config table in one unfiltered read, while every paired write in the router is admin-only. A call-site sweep of `apps/frontend` found no consumer at all (the settings page reads each value through its named getter), so it moves to `adminProcedure`. Left member-readable, a future sensitive config key would leak to every member automatically.

Test: `config-admin-gate.test.ts` now asserts admin allowed, member `FORBIDDEN` for `getAllConfigs`.

## Keep post-auth redirects on the app origin
The cors-error page concatenated a caller-supplied `callbackUrl` onto the app origin and navigated; the login page pushed the raw `callbackUrl` after sign-in. A crafted link could land an already-authenticated user on an attacker origin (a phishing aid).

Fix: a shared `lib/safe-redirect.ts` helper accepts only same-origin relative paths (single leading slash, no protocol-relative `//` or backslash forms, and a URL parse back to the same origin), falling back to `/`. Both pages sanitize `callbackUrl` through it; the cors-error page additionally rebuilds the URL with `new URL(path, origin)` and compares origins before navigating.

Test: `safe-redirect.test.ts` covers `/x`, `//evil`, `/\evil`, `@evil.com`, `.evil.com`, `https://evil`, `javascript:`, plus empty/null and query/hash preservation.

## Remove unused debug OAuth client provider
`DebugDbOAuthClientProvider` and `createDebugAuthProvider` in `lib/oauth-provider.ts` pointed at a debug callback route that no longer exists and were referenced nowhere. Removed, along with the now-unused metadata import.

## Verification
- `pnpm --filter @repo/zod-types build` and `pnpm --filter @repo/trpc build`: pass
- `pnpm -C apps/backend test`: 2029 passed, 93 skipped (was 2023 passed before this change)
- `pnpm -C apps/frontend test`: 38 passed (was 28 before this change)
- `pnpm check-types`: pass
- eslint on every touched file: clean

https://claude.ai/code/session_01GLGuUof88SHr6kxCUqzyE7