### PR TITLE
fix(db): dial the runtime role from the gateway-events pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Cutover order:
 
 1. Set `METAMCP_RUNTIME_DB_PASSWORD` in `.env` to a strong value.
 2. `docker compose up -d` (a recreate, not a restart — the variable has to reach the entrypoint).
-3. Confirm the boot log carries `Runtime DB role check (main pool): connected as "metamcp_runtime", rolsuper=false` and the same for the audit pool. The failure shape is the same line with `rolsuper=true` and the words `remain bypassable by this credential` — that means the split did not take. It is also written to `audit_log` as `db.runtime_split.ineffective`, so it can be alerted on rather than only watched for.
+3. Confirm the boot log carries `Runtime DB role check (main pool): connected as "metamcp_runtime", rolsuper=false` and the same for the audit pool and the gateway-events pool (all three request-path pools are checked). The failure shape is the same line with `rolsuper=true` and the words `remain bypassable by this credential`, which means the split did not take. It is also written to `audit_log` as `db.runtime_split.ineffective`, so it can be alerted on rather than only watched for.
 
 The dev stack (`docker-compose.dev.yml`) runs the same step from its own entrypoint, so it honours the switch too. Both compose files read the same `.env`.
 

--- a/apps/backend/src/db/ensure-runtime-role.integration.test.ts
+++ b/apps/backend/src/db/ensure-runtime-role.integration.test.ts
@@ -161,6 +161,11 @@ describeIfDb("ensure-runtime-role.sh against a REAL postgres", () => {
   it.each([
     ["audit_log", ["SELECT", "INSERT"], ["UPDATE", "DELETE", "TRUNCATE"]],
     ["tool_call_audit", ["SELECT", "INSERT", "DELETE"], ["UPDATE", "TRUNCATE"]],
+    // gateway_events carries the same trigger set as tool_call_audit, so its
+    // grant matrix matches: append and read, prune the aged tail, never
+    // rewrite. This is the end state the gateway-events pool depends on the
+    // moment it dials the runtime role.
+    ["gateway_events", ["SELECT", "INSERT", "DELETE"], ["UPDATE", "TRUNCATE"]],
   ])("%s: keeps %j, refuses %j", async (table, allowed, denied) => {
     for (const privilege of allowed as string[]) {
       const { rows } = await owner.query<{ ok: boolean }>(

--- a/apps/backend/src/db/gateway-events-db.test.ts
+++ b/apps/backend/src/db/gateway-events-db.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The gateway-events writer must dial the SAME runtime role the other two
+ * request-path pools dial, not the bootstrap superuser.
+ *
+ * This pool records every gateway event, including a crash-looping backend's
+ * stderr firehose, into `gateway_events`, a table migration 0031 makes
+ * append-only for 30 days. That immutability is only as real as the credential
+ * the writer holds: a superuser bypasses GRANTs and can `SET
+ * session_replication_role = 'replica'` to turn the triggers off. The main and
+ * audit pools already resolve through the runtime/migration split
+ * (`./runtime-connection`); this one used to build straight from the raw
+ * DATABASE_URL, so it was the one request-path pool still holding a
+ * trigger-bypassing credential after the other two gave theirs up. Reverting
+ * this file to `connectionString: DATABASE_URL` fails the derived-mode case
+ * below.
+ *
+ * pg constructs a Pool without connecting, so this needs no database, only a
+ * parseable DATABASE_URL, and (for the derived case) a runtime password, set
+ * before the modules are imported.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+type GatewayEventsDbModule = typeof import("./gateway-events-db");
+type AuditDbModule = typeof import("./audit-db");
+type DbModule = typeof import("./index");
+type RuntimeConnectionModule = typeof import("./runtime-connection");
+
+let gatewayEventsDbModule: GatewayEventsDbModule;
+let auditDbModule: AuditDbModule;
+let dbModule: DbModule;
+let runtimeConnectionModule: RuntimeConnectionModule;
+
+beforeAll(async () => {
+  // Never a real database: these modules read the environment at import time
+  // and construct pools, but pg does not dial until a query is issued.
+  //
+  // METAMCP_RUNTIME_DB_PASSWORD is set so the resolver returns the DERIVED
+  // form, the runtime role swapped into the URL. That is the case that tells
+  // the raw-DATABASE_URL regression apart from the fix: unconfigured, the two
+  // strings are byte-identical and no assertion could distinguish them.
+  process.env.DATABASE_URL =
+    "postgres://owner:owner-pw@127.0.0.1:1/gateway_events_pool_unit_test";
+  process.env.METAMCP_RUNTIME_DB_PASSWORD = "runtime-unit-test";
+
+  runtimeConnectionModule = await import("./runtime-connection");
+  gatewayEventsDbModule = await import("./gateway-events-db");
+  auditDbModule = await import("./audit-db");
+  dbModule = await import("./index");
+});
+
+afterAll(async () => {
+  process.env = { ...ORIGINAL_ENV };
+  await Promise.all([
+    gatewayEventsDbModule.gatewayEventsPool.end(),
+    auditDbModule.auditPool.end(),
+    dbModule.pool.end(),
+  ]);
+});
+
+describe("gateway-events pool", () => {
+  it("dials the resolved RUNTIME connection, not the raw DATABASE_URL", () => {
+    // The assertion that catches a revert. When the split is configured the
+    // resolved string names the NOSUPERUSER runtime role; the raw DATABASE_URL
+    // names the bootstrap superuser. A pool built from the latter reads as
+    // hardened and is not.
+    const resolved =
+      runtimeConnectionModule.resolveRuntimeConnection().connectionString;
+    expect(
+      gatewayEventsDbModule.gatewayEventsPool.options.connectionString,
+    ).toBe(resolved);
+    expect(
+      gatewayEventsDbModule.gatewayEventsPool.options.connectionString,
+    ).not.toBe(process.env.DATABASE_URL);
+  });
+
+  it("authenticates as the runtime role, not the owner", () => {
+    // Read the same way pg will read it: the userinfo of the connection string.
+    const url = new URL(
+      gatewayEventsDbModule.gatewayEventsPool.options
+        .connectionString as string,
+    );
+    expect(url.username).toBe(runtimeConnectionModule.DEFAULT_RUNTIME_DB_ROLE);
+    expect(url.username).not.toBe("owner");
+  });
+
+  it("resolves through the same split as the audit pool", () => {
+    // Both pools resolve independently (own call to the resolver), so the
+    // guarantee is that they resolve to the SAME string, not that one imported
+    // the other's.
+    expect(
+      gatewayEventsDbModule.gatewayEventsPool.options.connectionString,
+    ).toBe(auditDbModule.auditPool.options.connectionString);
+  });
+
+  it("is a DIFFERENT pool object from the shared and audit pools", () => {
+    expect(gatewayEventsDbModule.gatewayEventsPool).not.toBe(dbModule.pool);
+    expect(gatewayEventsDbModule.gatewayEventsPool).not.toBe(
+      auditDbModule.auditPool,
+    );
+    expect(gatewayEventsDbModule.gatewayEventsDb).not.toBe(dbModule.db);
+  });
+
+  it("keeps its own bounded budget and both timeouts", () => {
+    // The connection isolation this file has always provided: a two-connection
+    // ceiling, a 1s checkout timeout, and a server-side statement timeout so a
+    // write stuck behind an ACCESS EXCLUSIVE lock cannot hold half the budget
+    // indefinitely. Repointing the credential must not disturb any of it.
+    expect(gatewayEventsDbModule.gatewayEventsPool.options.max).toBe(2);
+    expect(
+      gatewayEventsDbModule.gatewayEventsPool.options.connectionTimeoutMillis,
+    ).toBe(1000);
+    expect(gatewayEventsDbModule.gatewayEventsPool.options.options).toContain(
+      "statement_timeout=5000",
+    );
+  });
+
+  it("survives an idle-client 'error' event instead of crashing the process", () => {
+    // pg emits 'error' on the pool when a backend dies (maintenance, a killed
+    // connection). An unhandled 'error' event on an EventEmitter throws.
+    expect(
+      gatewayEventsDbModule.gatewayEventsPool.listenerCount("error"),
+    ).toBeGreaterThan(0);
+    expect(() =>
+      gatewayEventsDbModule.gatewayEventsPool.emit(
+        "error",
+        new Error("idle client died"),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/apps/backend/src/db/gateway-events-db.ts
+++ b/apps/backend/src/db/gateway-events-db.ts
@@ -3,6 +3,7 @@ import { Pool } from "pg";
 
 import logger from "@/utils/logger";
 
+import { resolveRuntimeConnection } from "./runtime-connection";
 import * as schema from "./schema";
 
 /**
@@ -34,8 +35,16 @@ import * as schema from "./schema";
  *
  * `max: 2` rather than 1 for the same reason `./audit-db` gives: a single
  * connection would serialise every write behind the slowest one. Same
- * DATABASE_URL and same TLS material as the other two pools — this is
- * isolation of CONNECTIONS, not of credentials or of the database.
+ * connection string and same TLS material as the other two pools: this is
+ * isolation of CONNECTIONS, not of the database. It becomes isolation of
+ * PRIVILEGE too once the optional NOSUPERUSER role split is configured, which
+ * is what `./runtime-connection` resolves: all three request-path pools then
+ * dial a role that holds INSERT, SELECT and DELETE on `gateway_events` and
+ * cannot UPDATE or TRUNCATE it, so migration 0031's append-only triggers stop
+ * being bypassable by the credential the gateway holds while serving. Before
+ * this it built from the raw DATABASE_URL (the bootstrap superuser), so this
+ * one request-path pool kept a trigger-bypassing credential the other two had
+ * already given up.
  *
  * NOTE the asymmetry inside `gateway-events.repo.ts`: only `record()` uses
  * this pool. `list()`, `listServerNames()` and `pruneOlderThan()` run on the
@@ -62,14 +71,17 @@ import * as schema from "./schema";
  * the two settings.
  */
 
-const { DATABASE_URL, POSTGRES_CA_CERT } = process.env;
+const { POSTGRES_CA_CERT } = process.env;
 
-if (!DATABASE_URL) {
-  throw new Error("DATABASE_URL is not set");
-}
+// Resolved here rather than imported from `./index` for the same reason
+// `./audit-db` resolves its own: this module shares nothing with the main pool
+// it does not have to, and the resolution is a pure function of the
+// environment. `resolveRuntimeConnection` throws the same "DATABASE_URL is not
+// set" this file used to throw directly, so the missing-URL guard moves there.
+export const gatewayEventsRuntimeConnection = resolveRuntimeConnection();
 
 export const gatewayEventsPool = new Pool({
-  connectionString: DATABASE_URL,
+  connectionString: gatewayEventsRuntimeConnection.connectionString,
   max: 2,
   // Fail fast instead of queueing forever. A write that cannot get a
   // connection within a second under load is better off dropped: the caller is

--- a/apps/backend/src/db/runtime-connection.test.ts
+++ b/apps/backend/src/db/runtime-connection.test.ts
@@ -310,6 +310,35 @@ describe("scripts/ensure-runtime-role.sh — the audit-table revoke list", () =>
     );
   });
 
+  it("self-checks the end state for every audit table it revokes on", () => {
+    // The REVOKE re-runs on every boot, so drift is bounded to one restart,
+    // but only the self-check turns a wrong end state into a NON-ZERO EXIT the
+    // entrypoint treats as fatal. A table left out of the self-check can be
+    // hand-granted UPDATE on a boot where the REVOKE was edited away and
+    // nothing fails. gateway_events used to be that table; assert its block is
+    // present and mirrors the other two (rewrite refused, prune kept).
+    expect(script).toMatch(
+      /has_table_privilege\(v_role, 'public\.gateway_events', 'UPDATE'\)/,
+    );
+    expect(script).toMatch(
+      /has_table_privilege\(v_role, 'public\.gateway_events', 'TRUNCATE'\)/,
+    );
+    expect(script).toMatch(
+      /has_table_privilege\(v_role, 'public\.gateway_events', 'INSERT'\)/,
+    );
+    expect(script).toMatch(
+      /has_table_privilege\(v_role, 'public\.gateway_events', 'SELECT'\)/,
+    );
+    expect(script).toMatch(
+      /has_table_privilege\(v_role, 'public\.gateway_events', 'DELETE'\)/,
+    );
+    // Guarded so a database that has not run migration 0031 converges rather
+    // than erroring, the same way the tool_call_audit block is guarded.
+    expect(script).toMatch(
+      /to_regclass\('public\.gateway_events'\) IS NOT NULL/,
+    );
+  });
+
   it("names every table that a migration protects with an immutability trigger", () => {
     // The rule this enforces: if a migration installs a row- or
     // statement-level trigger that guards a table against mutation, that table

--- a/apps/backend/src/db/runtime-role-check.test.ts
+++ b/apps/backend/src/db/runtime-role-check.test.ts
@@ -8,8 +8,8 @@
  * assert on what the check does with the SERVER's answer — including the case
  * where the server says "yes, superuser" and the check has to say so loudly.
  *
- * Both pools are exercised. They resolve their connection independently, so a
- * regression that repointed one and not the other would otherwise pass.
+ * All three pools are exercised. They resolve their connection independently,
+ * so a regression that repointed some and not the others would otherwise pass.
  *
  * pg constructs a Pool without connecting, so this needs no database — only a
  * parseable DATABASE_URL, set before the first dynamic import below.
@@ -30,10 +30,12 @@ const ORIGINAL_ENV = { ...process.env };
 type CheckModule = typeof import("./runtime-role-check");
 type DbModule = typeof import("./index");
 type AuditDbModule = typeof import("./audit-db");
+type GatewayEventsDbModule = typeof import("./gateway-events-db");
 
 let checkModule: CheckModule;
 let dbModule: DbModule;
 let auditDbModule: AuditDbModule;
+let gatewayEventsDbModule: GatewayEventsDbModule;
 
 /**
  * Runs `body` with the audit sink redirected into an array, and returns what
@@ -67,11 +69,14 @@ interface CapturedEvent {
   detail?: Record<string, unknown>;
 }
 
-/** Replaces both pools' `query` with a canned `SELECT current_user` answer. */
+/** Replaces all three pools' `query` with a canned `SELECT current_user` answer. */
 function stubPools(answer: { current_user: string; is_superuser: boolean }) {
   const stub = vi.fn(async () => ({ rows: [answer] }));
   (dbModule.pool as unknown as { query: unknown }).query = stub;
   (auditDbModule.auditPool as unknown as { query: unknown }).query = stub;
+  (
+    gatewayEventsDbModule.gatewayEventsPool as unknown as { query: unknown }
+  ).query = stub;
   return stub;
 }
 
@@ -82,6 +87,7 @@ beforeAll(async () => {
 
   dbModule = await import("./index");
   auditDbModule = await import("./audit-db");
+  gatewayEventsDbModule = await import("./gateway-events-db");
   checkModule = await import("./runtime-role-check");
 });
 
@@ -91,11 +97,15 @@ afterEach(() => {
 
 afterAll(async () => {
   process.env = { ...ORIGINAL_ENV };
-  await Promise.all([dbModule.pool.end(), auditDbModule.auditPool.end()]);
+  await Promise.all([
+    dbModule.pool.end(),
+    auditDbModule.auditPool.end(),
+    gatewayEventsDbModule.gatewayEventsPool.end(),
+  ]);
 });
 
 describe("verifyRuntimeDatabaseRole", () => {
-  it("asks BOTH pools, not just the main one", async () => {
+  it("asks ALL THREE pools, not just the main one", async () => {
     const stub = stubPools({
       current_user: "metamcp_runtime",
       is_superuser: false,
@@ -103,10 +113,11 @@ describe("verifyRuntimeDatabaseRole", () => {
 
     await checkModule.verifyRuntimeDatabaseRole();
 
-    // Two calls: the audit pool is the one the whole feature is about, so a
-    // check that covered only the main pool would miss the regression that
-    // matters most.
-    expect(stub).toHaveBeenCalledTimes(2);
+    // Three calls: the audit and gateway-events pools each front an append-only
+    // table, so a check that covered only the main pool would miss exactly the
+    // regression that matters. The gateway-events pool was the one that used to
+    // keep the bootstrap superuser after the other two dialed the runtime role.
+    expect(stub).toHaveBeenCalledTimes(3);
   });
 
   it("reports the healthy case on stdout, where the documented cutover looks", async () => {
@@ -119,9 +130,10 @@ describe("verifyRuntimeDatabaseRole", () => {
     await checkModule.verifyRuntimeDatabaseRole();
 
     const lines = log.mock.calls.map((call) => String(call[0]));
-    expect(lines.filter((l) => l.includes("rolsuper=false"))).toHaveLength(2);
+    expect(lines.filter((l) => l.includes("rolsuper=false"))).toHaveLength(3);
     expect(lines.some((l) => l.includes("main pool"))).toBe(true);
     expect(lines.some((l) => l.includes("audit pool"))).toBe(true);
+    expect(lines.some((l) => l.includes("gateway-events pool"))).toBe(true);
   });
 
   it("WARNS when the runtime connection turns out to be a superuser", async () => {
@@ -131,7 +143,7 @@ describe("verifyRuntimeDatabaseRole", () => {
 
     await checkModule.verifyRuntimeDatabaseRole();
 
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(3);
     expect(String(warn.mock.calls[0][0])).toMatch(/rolsuper=true/);
     // The consequence is named, not just the fact — the log line has to be
     // actionable to someone who did not write this file, and the README
@@ -154,8 +166,8 @@ describe("verifyRuntimeDatabaseRole", () => {
       await checkModule.verifyRuntimeDatabaseRole();
     });
 
-    // One per pool: both credentials are independently wrong here.
-    expect(emitted).toHaveLength(2);
+    // One per pool: all three credentials are independently wrong here.
+    expect(emitted).toHaveLength(3);
     for (const event of emitted) {
       expect(event.action).toBe(checkModule.RUNTIME_SPLIT_INEFFECTIVE_ACTION);
       expect(event.actor_type).toBe("system");
@@ -164,6 +176,7 @@ describe("verifyRuntimeDatabaseRole", () => {
     }
     expect(emitted.map((e) => e.detail?.pool).sort()).toEqual([
       "audit pool",
+      "gateway-events pool",
       "main pool",
     ]);
   });
@@ -192,32 +205,36 @@ describe("verifyRuntimeDatabaseRole", () => {
     });
 
     const messages = warn.mock.calls.map((call) => String(call[0]));
-    expect(messages.filter((m) => /rolsuper=true/.test(m))).toHaveLength(2);
-    expect(messages.filter((m) => /expected role/.test(m))).toHaveLength(2);
+    expect(messages.filter((m) => /rolsuper=true/.test(m))).toHaveLength(3);
+    expect(messages.filter((m) => /expected role/.test(m))).toHaveLength(3);
 
     const reasons = emitted.map((e) => e.detail?.reason).sort();
     expect(reasons).toEqual([
       "role_mismatch",
       "role_mismatch",
+      "role_mismatch",
+      "superuser",
       "superuser",
       "superuser",
     ]);
   });
 
-  it("still reports the healthy pool when the other pool's query fails", async () => {
-    // `Promise.all` would discard the good answer with the bad one, and the
-    // pool likeliest to fail is the audit pool (max: 2, 1s checkout timeout).
-    // The boot log would then carry one generic error instead of the privilege
-    // facts this check exists to report.
+  it("still reports the healthy pools when one pool's query fails", async () => {
+    // `Promise.all` would discard the good answers with the bad one, and the
+    // pools likeliest to fail are the audit and gateway-events pools (max: 2,
+    // 1s checkout timeout). The boot log would then carry one generic error
+    // instead of the privilege facts this check exists to report.
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const logger = (await import("@/utils/logger")).default;
     const error = vi.spyOn(logger, "error").mockImplementation(() => {});
 
-    (dbModule.pool as unknown as { query: unknown }).query = vi.fn(
-      async () => ({
-        rows: [{ current_user: "metamcp_runtime", is_superuser: false }],
-      }),
-    );
+    const healthy = vi.fn(async () => ({
+      rows: [{ current_user: "metamcp_runtime", is_superuser: false }],
+    }));
+    (dbModule.pool as unknown as { query: unknown }).query = healthy;
+    (
+      gatewayEventsDbModule.gatewayEventsPool as unknown as { query: unknown }
+    ).query = healthy;
     (auditDbModule.auditPool as unknown as { query: unknown }).query = vi.fn(
       async () => {
         throw new Error("timeout exceeded when trying to connect");
@@ -226,11 +243,9 @@ describe("verifyRuntimeDatabaseRole", () => {
 
     await checkModule.verifyRuntimeDatabaseRole();
 
-    expect(
-      log.mock.calls
-        .map((c) => String(c[0]))
-        .filter((l) => /main pool/.test(l)),
-    ).toHaveLength(1);
+    const stdout = log.mock.calls.map((c) => String(c[0]));
+    expect(stdout.filter((l) => /main pool/.test(l))).toHaveLength(1);
+    expect(stdout.filter((l) => /gateway-events pool/.test(l))).toHaveLength(1);
     expect(String(error.mock.calls[0][0])).toMatch(/audit pool/);
   });
 
@@ -262,7 +277,7 @@ describe("verifyRuntimeDatabaseRole", () => {
 
     await checkModule.verifyRuntimeDatabaseRole();
 
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledTimes(3);
     expect(String(warn.mock.calls[0][0])).toMatch(
       /expected role "metamcp_runtime" but authenticated as "someone_else"/,
     );

--- a/apps/backend/src/db/runtime-role-check.ts
+++ b/apps/backend/src/db/runtime-role-check.ts
@@ -4,6 +4,7 @@ import { emit } from "@/lib/audit/audit-emitter";
 import logger from "@/utils/logger";
 
 import { auditPool } from "./audit-db";
+import { gatewayEventsPool } from "./gateway-events-db";
 import { pool } from "./index";
 import type { RuntimeConnection } from "./runtime-connection";
 import { resolveRuntimeConnection } from "./runtime-connection";
@@ -19,10 +20,14 @@ import { resolveRuntimeConnection } from "./runtime-connection";
  * server, over the same pools the request path uses, rather than re-reading
  * the environment and believing it.
  *
- * Both pools are checked. They resolve the connection independently (see
- * ./audit-db), and the audit pool is the one whose privilege the whole feature
- * is about — a check that covered only the main pool would miss exactly the
- * regression that matters.
+ * All three request-path pools are checked: the main pool, the audit pool and
+ * the gateway-events pool. They resolve the connection independently (see
+ * ./audit-db and ./gateway-events-db), so a regression that repointed one and
+ * not the others would otherwise pass here. The audit and gateway-events pools
+ * are the ones whose privilege the whole feature is about: both front an
+ * append-only table whose immutability depends on the credential being
+ * NOSUPERUSER, so a check that covered only the main pool would miss exactly
+ * the regression that matters.
  */
 
 interface RoleFacts {
@@ -143,13 +148,15 @@ export async function verifyRuntimeDatabaseRole(): Promise<void> {
   }
 
   // `allSettled`, not `all`. Under `all` the first rejection discards the
-  // other pool's result, and the pool most likely to fail its query is the
-  // audit pool (`max: 2`, 1s checkout timeout) — so a transient timeout there
-  // would suppress the main pool's answer too and the boot log would carry one
-  // generic error instead of the privilege facts it exists to report.
+  // other pools' results, and the pools most likely to fail their query are
+  // the audit and gateway-events pools (`max: 2`, 1s checkout timeout), so a
+  // transient timeout on one would suppress the others' answers too and the
+  // boot log would carry one generic error instead of the privilege facts it
+  // exists to report.
   const checks: [string, Pool][] = [
     ["main pool", pool],
     ["audit pool", auditPool],
+    ["gateway-events pool", gatewayEventsPool],
   ];
   const results = await Promise.allSettled(
     checks.map(([label, target]) => checkPool(label, target, connection)),

--- a/scripts/ensure-runtime-role.sh
+++ b/scripts/ensure-runtime-role.sh
@@ -278,6 +278,33 @@ BEGIN
         END IF;
     END IF;
 
+    -- gateway_events (migration 0031) carries the same trigger set as
+    -- tool_call_audit, so the runtime role's grant matrix on it must match:
+    -- INSERT + SELECT + DELETE held, UPDATE + TRUNCATE refused. Guarded by
+    -- to_regclass so a database that has not run 0031 yet converges rather than
+    -- erroring. The unconditional REVOKE above already re-runs every boot; this
+    -- block is what makes the SCRIPT fail loudly if that end state is ever not
+    -- reached (a hand-run GRANT on a boot where the REVOKE was edited away, a
+    -- REVOKE that silently no-oped), the way the two blocks above do for the
+    -- other audit tables.
+    IF to_regclass('public.gateway_events') IS NOT NULL THEN
+        IF has_table_privilege(v_role, 'public.gateway_events', 'UPDATE')
+            OR has_table_privilege(v_role, 'public.gateway_events', 'TRUNCATE') THEN
+            RAISE EXCEPTION 'runtime role % can still rewrite gateway_events', v_role;
+        END IF;
+        -- DELETE is held on purpose: the in-app retention sweeper prunes the
+        -- aged tail, and migration 0031's age-gated DELETE trigger is what
+        -- bounds that grant to rows past the 30-day window. SELECT and INSERT
+        -- are the history read and the record() append. Asserted positively so
+        -- a REVOKE that reached too far fails the boot rather than silently
+        -- breaking the write path or the sweeper.
+        IF NOT has_table_privilege(v_role, 'public.gateway_events', 'INSERT')
+            OR NOT has_table_privilege(v_role, 'public.gateway_events', 'SELECT')
+            OR NOT has_table_privilege(v_role, 'public.gateway_events', 'DELETE') THEN
+            RAISE EXCEPTION 'runtime role % cannot append to or prune gateway_events', v_role;
+        END IF;
+    END IF;
+
     RAISE NOTICE 'runtime role % converged: NOSUPERUSER, LOGIN, audit_log append-only', v_role;
 END
 $verify$;


### PR DESCRIPTION
## What and why

The gateway-events write pool built its connection from the raw `DATABASE_URL`, which on the stock image is the cluster bootstrap **superuser**, while the main and audit pools already resolve through the optional NOSUPERUSER runtime split (`resolveRuntimeConnection`). That left one of the three request-path pools holding a credential that can bypass the append-only triggers on `gateway_events` (a superuser bypasses GRANTs and can `SET session_replication_role`), and the boot verifier checked only the main and audit pools, so an operator reading the boot log saw two non-superuser pools and wrongly concluded the process held no superuser.

In normal operation the pool only INSERTs, so immutability was functionally intact, but any code-execution or SQL-injection sink reaching this pool ran as superuser.

## Change

- `gateway-events-db.ts`: build the pool from `resolveRuntimeConnection().connectionString` so all three request-path pools dial the runtime role. Corrects the stale comment that claimed the pool shared the raw `DATABASE_URL` and was connection-isolation only.
- `runtime-role-check.ts`: add the gateway-events pool to the boot verifier's checks array, so it reports non-superuser (or warns loudly) for all three pools.
- `scripts/ensure-runtime-role.sh`: extend the self-check to assert the `gateway_events` grant matrix (INSERT, SELECT and DELETE held; UPDATE and TRUNCATE refused), guarded by `to_regclass` so a database that predates the `gateway_events` migration still converges. The GRANT and REVOKE statements for `gateway_events` were already present, so the repointed pool can write the moment it dials the role; only the self-check assertion was missing.
- `README.md`: the boot-log confirmation step now names all three pools.

No new dependencies. The runtime split stays opt-in and byte-identical when unconfigured.

## Tests

New and extended, each verified red without the fix then green with it:

- `gateway-events-db.test.ts` (new, 6 tests): the pool dials the resolved runtime connection and authenticates as the runtime role, not the raw `DATABASE_URL` / owner; same resolved string as the audit pool; distinct pool object; keeps its `max: 2`, 1s checkout and 5s statement timeouts; survives an idle-client error. (3 of these go red on a revert to `connectionString: DATABASE_URL`.)
- `runtime-role-check.test.ts`: updated to assert all three pools are queried and reported (7 cases go red if the third pool is dropped from the checks array).
- `runtime-connection.test.ts`: asserts the self-check block covers `gateway_events` and is `to_regclass`-guarded (red if the self-check block is absent).
- `ensure-runtime-role.integration.test.ts`: the real-postgres grant matrix now covers `gateway_events` alongside the other two audit tables.

Commands and counts (run inside the worktree):

- `pnpm install --frozen-lockfile`, `pnpm --filter @repo/zod-types build`, `pnpm --filter @repo/trpc build`: green.
- `pnpm -C apps/backend test` (CI-equivalent, integration suites gated on `TEST_DATABASE_URL` and skipped): **2030 passed, 94 skipped** (127 files passed, 6 skipped).
- Changed unit files in isolation: **47 passed** (`runtime-connection`, `runtime-role-check`, `gateway-events-db`, `audit-db`).
- `ensure-runtime-role.integration.test.ts` against a throwaway `postgres:16-alpine` with migrations applied: **15 passed** (including the new `gateway_events` grant-matrix case).
- Directly exercised the self-check DO block against a role hand-granted UPDATE on `gateway_events`: it raised `runtime role ... can still rewrite gateway_events` (exit 1); after REVOKE it passed (exit 0).
- `pnpm -C apps/frontend test`: **28 passed**. `pnpm check-types`: green. `eslint` on all touched files: clean. `sh -n` on the script: valid.

## Deploy note

The container entrypoint order is: `drizzle-kit migrate`, then `scripts/ensure-runtime-role.sh` (which grants and revokes on `gateway_events` and runs the self-check), then the server process starts and the pools dial the runtime role. So the grants land before the pool dials, verified against `docker-entrypoint.sh`. After merge, on a deployment with the split enabled, confirm the boot log now carries a `Runtime DB role check (gateway-events pool): ... rolsuper=false` line alongside the main and audit pool lines. On a database that predates the `gateway_events` migration, the self-check's `to_regclass` guard skips the block rather than failing the boot.

https://claude.ai/code/session_01GLGuUof88SHr6kxCUqzyE7
