### PR TITLE
fix(gateway): harden data-plane rate limiting and response hygiene

### DIFF
--- a/apps/backend/src/lib/client-ip.ts
+++ b/apps/backend/src/lib/client-ip.ts
@@ -37,10 +37,14 @@ export const CLIENT_IP_HEADER = "cf-connecting-ip";
  *
  * WHAT THE CLAMP DOES AND DOES NOT BUY THE LIMITERS THAT KEY ON THIS. It
  * bounds per-key SIZE, not key COUNT. A caller rotating the header still mints
- * one map entry per distinct value — measured at 200k entries for 200k values
- * — and those are reclaimed only by the ten-minute sweep in
- * `lib/auth-rate-limiter`. What bounds the count is the edge overwriting the
- * header, plus that sweep; it is not this line.
+ * one map entry per distinct value -- measured at 200k entries for 200k values.
+ * Each limiter reclaims its own entries on a ten-minute sweep: the auth
+ * limiters through the timer in `lib/auth-rate-limiter` (which iterates
+ * AuthRateLimiter instances ONLY, so it does not touch any other map), and the
+ * data-plane sliding-window map through `SlidingWindowRateLimiting.cleanup`,
+ * wired to its own timer in `middleware/rate-limit.middleware`. What bounds the
+ * count is the edge overwriting the header, plus the relevant sweep; it is not
+ * this line.
  */
 export function resolveClientIp(
   headers: express.Request["headers"],

--- a/apps/backend/src/lib/metamcp/metamcp-server-pool.test.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-server-pool.test.ts
@@ -54,6 +54,9 @@ vi.mock("@/utils/logger", () => ({
   },
 }));
 
+import logger from "@/utils/logger";
+
+import { configService } from "../config.service";
 import { MetaMcpServerPool } from "./metamcp-server-pool";
 
 // The constructor is private (singleton); a fresh instance per test so
@@ -216,5 +219,50 @@ describe("MetaMcpServerPool.cleanupSession — maps drop even when cleanup throw
   it("no-ops on an unknown sessionId", async () => {
     await pool.cleanupSession("missing");
     expect(backendCleanupSessionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("MetaMcpServerPool.cleanupExpiredSessions -- session ids stay out of the info log", () => {
+  let pool: MetaMcpServerPool;
+  let internals: PoolInternals;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backendCleanupSessionMock.mockResolvedValue(undefined);
+    pool = new PoolConstructor();
+    internals = pool as never;
+  });
+
+  it("logs a COUNT at info and the ids only at debug", async () => {
+    // Age-based cleanup used to join every expired session id into the info
+    // line, re-leaking the exact ids the round-1 payload sweep stripped. The
+    // count belongs at info; the ids drop to debug.
+    vi.mocked(configService.getSessionLifetime).mockResolvedValue(1000);
+    internals.sessionTimestamps["sess-secret-aaa"] = Date.now() - 60_000;
+    internals.sessionTimestamps["sess-secret-bbb"] = Date.now() - 60_000;
+
+    await (
+      pool as unknown as { cleanupExpiredSessions: () => Promise<void> }
+    ).cleanupExpiredSessions();
+
+    const infoLines = vi
+      .mocked(logger.info)
+      .mock.calls.map((c) => String(c[0]));
+    const cleanupLine = infoLines.find((l) =>
+      l.includes("expired MetaMCP server pool sessions"),
+    );
+    expect(cleanupLine).toBeDefined();
+    expect(cleanupLine).toContain("2 expired");
+    expect(cleanupLine).not.toContain("sess-secret");
+
+    const debugLines = vi
+      .mocked(logger.debug)
+      .mock.calls.map((c) => String(c[0]));
+    const idLine = debugLines.find((l) =>
+      l.includes("Expired MetaMCP server pool session ids"),
+    );
+    expect(idLine).toBeDefined();
+    expect(idLine).toContain("sess-secret-aaa");
+    expect(idLine).toContain("sess-secret-bbb");
   });
 });

--- a/apps/backend/src/lib/metamcp/metamcp-server-pool.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-server-pool.ts
@@ -689,8 +689,15 @@ export class MetaMcpServerPool {
 
       // Clean up expired sessions
       if (expiredSessionIds.length > 0) {
+        // Count at info, ids at debug only: a live session-id list in a
+        // request-path log undoes the fork's session-id log hygiene. Dormant
+        // in prod (sessionLifetime is null there), but this timer fires the
+        // moment an operator sets a finite lifetime.
         logger.info(
-          `Cleaning up ${expiredSessionIds.length} expired MetaMCP server pool sessions: ${expiredSessionIds.join(", ")}`,
+          `Cleaning up ${expiredSessionIds.length} expired MetaMCP server pool sessions`,
+        );
+        logger.debug(
+          `Expired MetaMCP server pool session ids: ${expiredSessionIds.join(", ")}`,
         );
 
         await Promise.allSettled(

--- a/apps/backend/src/lib/rate-limit.test.ts
+++ b/apps/backend/src/lib/rate-limit.test.ts
@@ -26,8 +26,18 @@ vi.mock("./metamcp/mcp-server-pool", () => ({
   },
 }));
 
+vi.mock("../utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import logger from "../utils/logger";
 import { mcpServerPool } from "./metamcp/mcp-server-pool";
-import { RateLimitError, SlidingWindowRateLimiting } from "./rate-limit";
+import {
+  RateLimitError,
+  RateLimiting,
+  SlidingWindowRateLimiter,
+  SlidingWindowRateLimiting,
+} from "./rate-limit";
 
 const NAMESPACE_UUID = "ns-1111-1111";
 const CLIENT_KEY = "203.0.113.7";
@@ -40,10 +50,12 @@ function makeContext() {
         client_max_rate: 2,
         client_max_rate_seconds: 60,
         client_max_rate_strategy: "ip",
-        client_max_rate_strategy_key: "x-forwarded-for",
+        // Empty override -> the default key, which is now the edge-overwritten
+        // CF-Connecting-IP rather than the forgeable XFF.
+        client_max_rate_strategy_key: "",
       },
       socket: { remoteAddress: "unused" },
-      headers: { "x-forwarded-for": CLIENT_KEY },
+      headers: { "cf-connecting-ip": CLIENT_KEY },
     },
   };
 }
@@ -57,6 +69,9 @@ function mockOpenIdleGate() {
     get: (k: string) => (k === "status" ? "created" : undefined),
     has: () => false,
     set: vi.fn(),
+    // The real inner map is a Map; cleanup() clears the marker in lockstep
+    // with the limiter, so the double must answer delete too.
+    delete: vi.fn(),
   };
   const backgroundIdleSessions = new Map<string, any>([
     [NAMESPACE_UUID, perNamespace],
@@ -66,6 +81,28 @@ function mockOpenIdleGate() {
       typeof vi.fn
     >
   ).mockReturnValue(backgroundIdleSessions);
+}
+
+/**
+ * The STABLE-namespace gate: a real per-namespace Map that actually records
+ * the "initialized" marker (status pre-set to "created"), so `has(clientKey)`
+ * flips true after the first request the way production does when the idle
+ * session is not churning. This is the only setup that exposes the sweep's
+ * marker-consistency requirement -- the always-open gate above masks it by
+ * reopening on every call.
+ */
+function mockStableIdleGate() {
+  const perNamespace = new Map<string, any>();
+  perNamespace.set("status", "created");
+  const backgroundIdleSessions = new Map<string, any>([
+    [NAMESPACE_UUID, perNamespace],
+  ]);
+  (
+    mcpServerPool.getBackgroundIdleSessionsByNamespace as unknown as ReturnType<
+      typeof vi.fn
+    >
+  ).mockReturnValue(backgroundIdleSessions);
+  return { perNamespace, backgroundIdleSessions };
 }
 
 describe("SlidingWindowRateLimiting", () => {
@@ -112,5 +149,226 @@ describe("SlidingWindowRateLimiting", () => {
     ).rejects.toThrow(RateLimitError);
 
     expect(callNext).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The per-client bucket must key on the edge-overwritten
+ * CF-Connecting-IP, never on a caller-settable forwarding header. Keying on a
+ * forgeable header lets a caller rotate it to mint a fresh bucket per request,
+ * so the limit enforces nothing.
+ */
+describe("SlidingWindowRateLimiting -- client key selection", () => {
+  const bothHeaders = () => ({
+    "cf-connecting-ip": "9.9.9.9",
+    "x-forwarded-for": "1.2.3.4",
+  });
+
+  const contextWithKey = (
+    strategyKey: string,
+    headers: Record<string, any>,
+  ) => ({
+    req: {
+      endpoint: {
+        namespace_uuid: NAMESPACE_UUID,
+        client_max_rate: 5,
+        client_max_rate_seconds: 60,
+        client_max_rate_strategy: "ip",
+        client_max_rate_strategy_key: strategyKey,
+      },
+      socket: { remoteAddress: "socket-addr" },
+      headers,
+    },
+  });
+
+  it("keys on cf-connecting-ip by default, ignoring a spoofable x-forwarded-for", async () => {
+    const rl = new SlidingWindowRateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    await rl.onRequest(contextWithKey("", bothHeaders()) as any, callNext);
+
+    expect((rl as any).limiters.has("9.9.9.9")).toBe(true);
+    expect((rl as any).limiters.has("1.2.3.4")).toBe(false);
+  });
+
+  it("refuses a forgeable x-forwarded-for override and falls back to cf-connecting-ip", async () => {
+    const rl = new SlidingWindowRateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    await rl.onRequest(
+      contextWithKey("x-forwarded-for", bothHeaders()) as any,
+      callNext,
+    );
+
+    // Keyed on the edge header, not the header the override named.
+    expect((rl as any).limiters.has("9.9.9.9")).toBe(true);
+    expect((rl as any).limiters.has("1.2.3.4")).toBe(false);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("honors a non-forgeable custom header override", async () => {
+    const rl = new SlidingWindowRateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    await rl.onRequest(
+      contextWithKey("x-consumer-id", {
+        ...bothHeaders(),
+        "x-consumer-id": "consumer-42",
+      }) as any,
+      callNext,
+    );
+
+    expect((rl as any).limiters.has("consumer-42")).toBe(true);
+    expect((rl as any).limiters.has("9.9.9.9")).toBe(false);
+  });
+});
+
+/**
+ * The per-(client, namespace) map is never pruned by the request path,
+ * so it needs its own sweep. `cleanup` drops limiters whose window has fully
+ * drained and leaves live ones in place.
+ */
+describe("SlidingWindowRateLimiting.cleanup -- eviction sweep", () => {
+  it("drops a limiter once its window has fully drained", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const rl = new SlidingWindowRateLimiting();
+      const callNext = vi.fn().mockResolvedValue("ok");
+
+      await rl.onRequest(makeContext() as any, callNext);
+      expect((rl as any).limiters.has(CLIENT_KEY)).toBe(true);
+
+      // +120s, past the 60s window: the only recorded request has aged out.
+      vi.setSystemTime(new Date("2026-01-01T00:02:00Z"));
+      rl.cleanup();
+
+      expect((rl as any).limiters.has(CLIENT_KEY)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a limiter whose newest request is still inside the window", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      const rl = new SlidingWindowRateLimiting();
+      const callNext = vi.fn().mockResolvedValue("ok");
+
+      await rl.onRequest(makeContext() as any, callNext);
+
+      // +30s, still inside the 60s window.
+      vi.setSystemTime(new Date("2026-01-01T00:00:30Z"));
+      rl.cleanup();
+
+      expect((rl as any).limiters.has(CLIENT_KEY)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports an empty limiter as expired", () => {
+    const limiter = new SlidingWindowRateLimiter(2, 60);
+    expect(limiter.isExpired()).toBe(true);
+  });
+
+  it("re-limits a returning client after the sweep evicts its drained limiter", async () => {
+    // The stable-namespace case the always-open gate cannot show: once the pool
+    // marks a (client, namespace) initialized, the marker sticks, so the sweep
+    // MUST clear it alongside the limiter. Otherwise the returning client takes
+    // the skip-creation path with no limiter -- an unlimited pass. Without the
+    // marker delete in cleanup(), the third call below would NOT throw.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      mockStableIdleGate();
+      const rl = new SlidingWindowRateLimiting();
+      const callNext = vi.fn().mockResolvedValue("ok");
+
+      // Budget is 2 per 60s (makeContext): exhaust it.
+      await rl.onRequest(makeContext() as any, callNext);
+      await rl.onRequest(makeContext() as any, callNext);
+      await expect(
+        rl.onRequest(makeContext() as any, callNext),
+      ).rejects.toThrow(RateLimitError);
+
+      // Idle past the window; the sweep evicts the drained limiter and clears
+      // the marker.
+      vi.setSystemTime(new Date("2026-01-01T00:02:00Z"));
+      rl.cleanup();
+      expect((rl as any).limiters.has(CLIENT_KEY)).toBe(false);
+
+      // The returning client is limited again from a fresh budget, not waved
+      // through: two pass, the third is refused.
+      await rl.onRequest(makeContext() as any, callNext);
+      await rl.onRequest(makeContext() as any, callNext);
+      await expect(
+        rl.onRequest(makeContext() as any, callNext),
+      ).rejects.toThrow(RateLimitError);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+/**
+ * The token-bucket path treated an absent limiter as rate-limited and
+ * answered a spurious 503. A namespace with no created limiter must pass
+ * through; a created, over-budget limiter must still refuse.
+ */
+describe("RateLimiting.onRequest -- token bucket", () => {
+  const idleSessions = (status: string, hasUser: boolean) => {
+    const perNamespace = {
+      get: (k: string) => (k === "status" ? status : undefined),
+      has: () => hasUser,
+      set: vi.fn(),
+    };
+    const map = new Map<string, any>([[NAMESPACE_UUID, perNamespace]]);
+    (
+      mcpServerPool.getBackgroundIdleSessionsByNamespace as unknown as ReturnType<
+        typeof vi.fn
+      >
+    ).mockReturnValue(map);
+  };
+
+  const tokenBucketContext = () => ({
+    req: {
+      endpoint: {
+        namespace_uuid: NAMESPACE_UUID,
+        user_id: "user-1",
+        max_rate: 0,
+        max_rate_seconds: 1,
+      },
+    },
+  });
+
+  it("passes through when no limiter was created for the namespace", async () => {
+    // Idle sessions exist (size > 0) but this namespace is not "created", so no
+    // limiter is ever built. Before the fix this threw a spurious RateLimitError.
+    idleSessions("not-created", false);
+
+    const rl = new RateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    await expect(
+      rl.onRequest(tokenBucketContext() as any, callNext),
+    ).resolves.toBe("ok");
+    expect(callNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refuses when a created limiter is over budget", async () => {
+    // status "created" + user not yet initialized -> a limiter is created; a
+    // zero-capacity bucket refuses the first consume, proving enforcement is
+    // intact after the missing-limiter guard.
+    idleSessions("created", false);
+
+    const rl = new RateLimiting();
+    const callNext = vi.fn().mockResolvedValue("ok");
+
+    await expect(
+      rl.onRequest(tokenBucketContext() as any, callNext),
+    ).rejects.toThrow(RateLimitError);
+    expect(callNext).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/lib/rate-limit.ts
+++ b/apps/backend/src/lib/rate-limit.ts
@@ -2,10 +2,33 @@
 // Rate limiting for protecting MCP servers from abuse
 
 import logger from "../utils/logger";
+import { CLIENT_IP_HEADER, resolveClientIp } from "./client-ip";
 import { mcpServerPool } from "./metamcp/mcp-server-pool";
 
 type Context = Record<string, any>;
 type CallNext = (context: Context) => Promise<any>;
+
+/**
+ * Forwarding / hop headers a client sets on its own request.
+ *
+ * A per-client limiter keyed on any of these enforces nothing: the caller
+ * rotates (or omits) the value to mint a fresh bucket per request. The auth
+ * plane keys on the edge-overwritten CF-Connecting-IP for exactly this reason
+ * (see lib/client-ip). The data plane now defaults to that same header and
+ * refuses a configured strategy-key override that names one of these,
+ * degrading to the safe default instead of a limiter that can be walked past.
+ */
+const FORGEABLE_RATE_KEY_HEADERS = new Set([
+  "x-forwarded-for",
+  "x-forwarded",
+  "forwarded",
+  "forwarded-for",
+  "x-real-ip",
+  "x-client-ip",
+  "x-cluster-client-ip",
+  "true-client-ip",
+  "via",
+]);
 
 export class RateLimitError extends Error {
   public code: number;
@@ -76,6 +99,17 @@ export class SlidingWindowRateLimiter {
     }
     return false;
   }
+
+  /**
+   * True when this limiter holds nothing the current window would keep, so the
+   * eviction sweep can drop it without changing any decision. Exposed here
+   * rather than reaching into `requests` from the sweep, which is private.
+   */
+  isExpired(now: number = Date.now() / 1000): boolean {
+    if (this.requests.length === 0) return true;
+    const newest = this.requests[this.requests.length - 1];
+    return newest < now - this.clientMaxRateSeconds;
+  }
 }
 
 /**
@@ -120,8 +154,13 @@ export class RateLimiting {
         }
       }
 
-      const allowed = await limiter?.consume();
-      if (!allowed) {
+      // A missing limiter is a PASS, not a refusal. A limiter is created only
+      // in the narrow branch above (namespace status "created", first call for
+      // this user), so a namespace that never entered it has none -- and
+      // `await undefined?.consume()` is `undefined`, which the old `!allowed`
+      // read as rate-limited and answered with a spurious 503. Guard on the
+      // limiter existing so only a real over-budget consume refuses.
+      if (limiter && !(await limiter.consume())) {
         throw new RateLimitError(`Rate limit exceeded`);
       }
     }
@@ -142,7 +181,9 @@ export class SlidingWindowRateLimiting {
     this.clientMaxRate = 0;
     this.clientMaxRateSeconds = 0;
     this.clientMaxRateStrategy = "ip";
-    this.clientMaxRateStrategyKey = "x-forwarded-for";
+    // Default to the edge-overwritten client IP, never the forgeable XFF: see
+    // FORGEABLE_RATE_KEY_HEADERS and the per-request validation below.
+    this.clientMaxRateStrategyKey = CLIENT_IP_HEADER;
     this.limiters = new Map();
   }
 
@@ -155,14 +196,45 @@ export class SlidingWindowRateLimiting {
       endpoint.client_max_rate_strategy === ""
         ? this.clientMaxRateStrategy
         : endpoint.client_max_rate_strategy;
-    this.clientMaxRateStrategyKey =
-      endpoint.client_max_rate_strategy_key === ""
-        ? this.clientMaxRateStrategyKey
-        : endpoint.client_max_rate_strategy_key;
+
+    // Resolve which header the per-client bucket is keyed on. An empty
+    // override takes the safe default; an override naming a caller-settable
+    // forwarding header is refused (it would let the caller mint a fresh
+    // bucket per request) and degrades to the default.
+    const requestedKey = String(endpoint.client_max_rate_strategy_key ?? "")
+      .trim()
+      .toLowerCase();
+    if (requestedKey === "" || FORGEABLE_RATE_KEY_HEADERS.has(requestedKey)) {
+      if (requestedKey !== "") {
+        logger.warn(
+          `Ignoring client_max_rate_strategy_key ${JSON.stringify(
+            requestedKey,
+          )}: a caller-settable forwarding header cannot key a rate limiter; using ${CLIENT_IP_HEADER}.`,
+        );
+      }
+      this.clientMaxRateStrategyKey = CLIENT_IP_HEADER;
+    } else {
+      this.clientMaxRateStrategyKey = requestedKey;
+    }
 
     const backgroundIdleSessions =
       mcpServerPool.getBackgroundIdleSessionsByNamespace();
-    const key = headers[this.clientMaxRateStrategyKey] || socket.remoteAddress;
+
+    // The default path routes through resolveClientIp so a duplicated
+    // CF-Connecting-IP is collapsed the same way the auth plane collapses it;
+    // a validated custom header is read directly with the same first-value
+    // handling, falling back to the socket address when absent.
+    let key;
+    if (this.clientMaxRateStrategyKey === CLIENT_IP_HEADER) {
+      key = resolveClientIp(headers) || socket.remoteAddress;
+    } else {
+      const raw = headers[this.clientMaxRateStrategyKey];
+      const value = Array.isArray(raw) ? raw[0] : raw;
+      key =
+        typeof value === "string" && value.trim() !== ""
+          ? value.trim()
+          : socket.remoteAddress;
+    }
 
     let limiter = this.limiters.get(key);
 
@@ -220,5 +292,44 @@ export class SlidingWindowRateLimiting {
 
   async onResponse(context: Context, callNext: CallNext): Promise<any> {
     return callNext(context);
+  }
+
+  /**
+   * Drop limiters whose window has fully drained.
+   *
+   * WHY THIS EXISTS. The per-(client, namespace) map is populated on every
+   * new key and never pruned by the request path. With a distinct key per
+   * request -- which a rotated header would give even after the edge-IP default, and which
+   * distinct real callers give normally -- the map grows for the life of the
+   * process, a slow leak. `lib/client-ip` used to claim the auth limiter's
+   * sweep bounded this map; it does not (that sweep iterates AuthRateLimiter
+   * instances only), so this map carries its own. Wired to an unref'd
+   * ten-minute timer at the singleton site in
+   * `middleware/rate-limit.middleware`, mirroring `lib/auth-rate-limiter`.
+   */
+  cleanup(): void {
+    const now = Date.now() / 1000;
+    const backgroundIdleSessions =
+      mcpServerPool.getBackgroundIdleSessionsByNamespace();
+    for (const [clientKey, perNamespace] of this.limiters.entries()) {
+      for (const [ns, limiter] of perNamespace.entries()) {
+        if (limiter.isExpired(now)) {
+          perNamespace.delete(ns);
+          // Drop the pool's matching "initialized" marker in lockstep. onRequest
+          // only builds a limiter for a (clientKey, namespace) whose marker is
+          // unset; when the namespace's idle session is stable the marker
+          // sticks, so evicting the limiter while leaving the marker would send
+          // the next request from a returning client down the skip-creation
+          // path with no limiter -- an unlimited pass, the limit silently gone.
+          // Deleting the marker forces a rebuild, re-limiting the client with a
+          // fresh budget. (When the idle session churns the marker is already
+          // reopened every call, so this is a no-op there.)
+          backgroundIdleSessions.get(ns)?.delete(clientKey);
+        }
+      }
+      if (perNamespace.size === 0) {
+        this.limiters.delete(clientKey);
+      }
+    }
   }
 }

--- a/apps/backend/src/lib/session-lifetime-manager.cleanup-log.test.ts
+++ b/apps/backend/src/lib/session-lifetime-manager.cleanup-log.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Log hygiene: the age-based session cleanup used to join every expired
+ * session id into a single info line, re-leaking the ids the round-1 payload
+ * sweep stripped from the HTTP responses. The count belongs at info; the ids
+ * drop to debug. Dormant in production (session lifetime is null there), but the
+ * timer fires the moment an operator sets a finite lifetime.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getSessionLifetimeMock } = vi.hoisted(() => ({
+  getSessionLifetimeMock: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// config.service reaches @/db transitively; the manager's TTL path is the one
+// under test, so drive getSessionLifetime directly.
+vi.mock("@/db", () => ({ db: {}, pool: { on: vi.fn() } }));
+vi.mock("./config.service", () => ({
+  configService: { getSessionLifetime: getSessionLifetimeMock },
+}));
+
+import logger from "@/utils/logger";
+
+import { SessionLifetimeManagerImpl } from "./session-lifetime-manager";
+
+const BINDING = {
+  namespaceUuid: "ns-A",
+  endpointName: "ep-A",
+  identity: { method: "api_key", credentialId: "key-A" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SessionLifetimeManagerImpl.cleanupExpiredSessions -- session ids stay out of the info log", () => {
+  it("logs a COUNT at info and the ids only at debug", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      getSessionLifetimeMock.mockResolvedValue(1000);
+
+      const mgr = new SessionLifetimeManagerImpl<{ id: string }>("Streamable");
+      mgr.addSession("sess-secret-aaa", { id: "a" }, BINDING as never);
+      mgr.addSession("sess-secret-bbb", { id: "b" }, BINDING as never);
+
+      // Advance past the 1s lifetime so both sessions are expired.
+      vi.setSystemTime(new Date("2026-01-01T00:00:02Z"));
+      const cleaned: string[] = [];
+      await mgr.cleanupExpiredSessions(async (id) => {
+        cleaned.push(id);
+      });
+
+      expect(cleaned.sort()).toEqual(["sess-secret-aaa", "sess-secret-bbb"]);
+
+      const infoLines = vi
+        .mocked(logger.info)
+        .mock.calls.map((c) => String(c[0]));
+      const cleanupLine = infoLines.find((l) =>
+        l.includes("expired Streamable sessions"),
+      );
+      expect(cleanupLine).toBeDefined();
+      expect(cleanupLine).toContain("2 expired");
+      expect(cleanupLine).not.toContain("sess-secret");
+
+      const debugLines = vi
+        .mocked(logger.debug)
+        .mock.calls.map((c) => String(c[0]));
+      const idLine = debugLines.find((l) =>
+        l.includes("Expired Streamable session ids"),
+      );
+      expect(idLine).toBeDefined();
+      expect(idLine).toContain("sess-secret-aaa");
+      expect(idLine).toContain("sess-secret-bbb");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/backend/src/lib/session-lifetime-manager.ts
+++ b/apps/backend/src/lib/session-lifetime-manager.ts
@@ -221,8 +221,15 @@ export class SessionLifetimeManagerImpl<T>
 
       // Clean up expired sessions
       if (expiredSessions.length > 0) {
+        // Count at info, ids at debug only: a live session-id list in a
+        // request-path log undoes the fork's session-id log hygiene. Dormant
+        // in prod (sessionLifetime is null there), but this timer fires the
+        // moment an operator sets a finite lifetime.
         logger.info(
-          `Cleaning up ${expiredSessions.length} expired ${this.name} sessions: ${expiredSessions.map((s) => s.sessionId).join(", ")}`,
+          `Cleaning up ${expiredSessions.length} expired ${this.name} sessions`,
+        );
+        logger.debug(
+          `Expired ${this.name} session ids: ${expiredSessions.map((s) => s.sessionId).join(", ")}`,
         );
 
         await Promise.allSettled(

--- a/apps/backend/src/middleware/rate-limit.middleware.ts
+++ b/apps/backend/src/middleware/rate-limit.middleware.ts
@@ -11,6 +11,18 @@ import {
 const slidingWindowRateLimit = new SlidingWindowRateLimiting();
 const tokenBucketRateLimit = new RateLimiting();
 
+// Sweep the per-client sliding-window map every 10 minutes so it cannot grow
+// unbounded for the life of the process. `unref` for the same reason as the
+// auth limiter's sweep: this is housekeeping and must never keep the event
+// loop (or a test that merely imports this module) alive. Mirrors
+// lib/auth-rate-limiter's timer.
+setInterval(
+  () => {
+    slidingWindowRateLimit.cleanup();
+  },
+  10 * 60 * 1000,
+).unref();
+
 interface RateLimitOptions extends express.Request {
   endpoint: DatabaseEndpoint;
 }

--- a/apps/backend/src/routers/mcp-proxy/server.spawn-call-site.test.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.spawn-call-site.test.ts
@@ -305,4 +305,32 @@ describe("GET /mcp-proxy/server/stdio — what reaches the transport", () => {
 
     expect(spawnCalls).toEqual([]);
   });
+
+  it("does NOT leak the gateway's own process.env secrets into the child env", async () => {
+    // The Inspector used to spread the whole gateway process.env into the
+    // spawned child, so an npx MCP an admin registers inherited DATABASE_URL,
+    // BETTER_AUTH_SECRET and every vendor secret. The child env is now the
+    // curated getDefaultEnvironment (which allowlists operational vars, NOT
+    // arbitrary secrets) plus the row's own env. A gateway secret no server env
+    // references must not reach the child; the row's FILESYSTEM_TOKEN still
+    // must, proving the curated path is not simply empty. Real declared gateway
+    // vars are used (saved/restored) so this asserts against the actual secrets.
+    const priorAuth = process.env.BETTER_AUTH_SECRET;
+    const priorDb = process.env.DATABASE_URL;
+    process.env.BETTER_AUTH_SECRET = "auth-secret-must-not-leak";
+    process.env.DATABASE_URL = "postgres://must-not-leak";
+    try {
+      await getStdio({ transportType: "STDIO", mcpServerUuid: SERVER_UUID });
+    } finally {
+      if (priorAuth === undefined) delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = priorAuth;
+      if (priorDb === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = priorDb;
+    }
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].env.BETTER_AUTH_SECRET).toBeUndefined();
+    expect(spawnCalls[0].env.DATABASE_URL).toBeUndefined();
+    expect(spawnCalls[0].env.FILESYSTEM_TOKEN).toBe("s3cret");
+  });
 });

--- a/apps/backend/src/routers/mcp-proxy/server.spawn-source.test.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.spawn-source.test.ts
@@ -390,17 +390,33 @@ describe("resolveStdioSpawnParams — the Inspector still connects", () => {
     expect(params.errorStatus).toBe("ERROR");
   });
 
-  it("passes the backend environment through, so a server keeps its own", async () => {
-    // Read generically rather than by name: the spawned process inherits the
-    // whole backend environment, and naming one variable here would both pin
-    // an assumption about the host and add it to turbo's declared env set.
-    findAccessibleMock.mockResolvedValue([registeredServer()]);
+  it("gives the child the curated default env plus the row's own env, not the whole gateway environment", async () => {
+    // The Inspector used to spread the entire backend
+    // process.env into the child, so an admin-registered npx MCP inherited
+    // DATABASE_URL, BETTER_AUTH_SECRET and every vendor secret. The child env
+    // is now the curated getDefaultEnvironment allowlist (operational vars only)
+    // plus the row's resolved env, matching the pool path. A real declared
+    // gateway secret is used (saved/restored) for the negative assertion.
+    const prior = process.env.BETTER_AUTH_SECRET;
+    process.env.BETTER_AUTH_SECRET = "must-not-leak";
+    try {
+      findAccessibleMock.mockResolvedValue([registeredServer()]);
 
-    const params = await resolveStdioSpawnParams(
-      makeReq({ transportType: "STDIO", mcpServerUuid: SERVER_UUID }),
-    );
+      const params = await resolveStdioSpawnParams(
+        makeReq({ transportType: "STDIO", mcpServerUuid: SERVER_UUID }),
+      );
 
-    const [inheritedKey, inheritedValue] = Object.entries(process.env)[0];
-    expect(params.env[inheritedKey]).toBe(inheritedValue);
+      // The row's own env still reaches the child.
+      expect(params.env.FILESYSTEM_TOKEN).toBe("s3cret");
+      // The curated allowlist contributed operational vars beyond the single
+      // row key, so the fix did not over-restrict into an empty env (an
+      // Inspector-spawned server can still find its interpreter).
+      expect(Object.keys(params.env).length).toBeGreaterThan(1);
+      // A gateway secret no server env references does NOT reach the child.
+      expect(params.env.BETTER_AUTH_SECRET).toBeUndefined();
+    } finally {
+      if (prior === undefined) delete process.env.BETTER_AUTH_SECRET;
+      else process.env.BETTER_AUTH_SECRET = prior;
+    }
   });
 });

--- a/apps/backend/src/routers/mcp-proxy/server.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.ts
@@ -4,7 +4,6 @@ import {
   SSEClientTransport,
   SseError,
 } from "@modelcontextprotocol/sdk/client/sse.js";
-import { getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -24,7 +23,10 @@ import { mcpServersRepository } from "../../db/repositories";
 import mcpProxy from "../../lib/mcp-proxy";
 import { transformDockerUrl } from "../../lib/metamcp/client";
 import { mcpServerPool } from "../../lib/metamcp/mcp-server-pool";
-import { resolveEnvVariables } from "../../lib/metamcp/utils";
+import {
+  getDefaultEnvironment,
+  resolveEnvVariables,
+} from "../../lib/metamcp/utils";
 import { ProcessManagedStdioTransport } from "../../lib/stdio-transport/process-managed-transport";
 import { assertPublicMcpUrl, createGuardedFetch } from "./url-guard";
 
@@ -233,10 +235,20 @@ const findRegisteredStdioServer = async (
  * `args` comes from the stored array rather than from a shell-parse of the
  * request's flattened string, so an argument that legitimately contains a
  * space survives instead of being split into two.
+ *
+ * The child env is the SAME curated allowlist the pool path uses
+ * (`lib/metamcp/utils` getDefaultEnvironment, applied to the server env in
+ * `convertDbServerToParams` and spawned via `lib/metamcp/client.ts`) plus this
+ * server's own resolved env, and NOT a spread of the whole gateway
+ * `process.env`. Matching that curated function rather than the SDK's shorter
+ * default keeps an Inspector-spawned server's inherited env (PATH, proxy and
+ * CA-cert variables) identical to a pool-spawned one, and stops an npx MCP an
+ * admin registers from inheriting DATABASE_URL, BETTER_AUTH_SECRET and every
+ * vendor secret. A server that genuinely needs a gateway variable still names
+ * it explicitly with a `${VAR}` placeholder, which `resolveEnvVariables` fills.
  */
 const buildStdioSpawnParams = (server: DatabaseMcpServer): StdioSpawnParams => {
   const env = {
-    ...process.env,
     ...defaultEnvironment,
     ...resolveEnvVariables(server.env || {}),
   } as Record<string, string>;

--- a/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/handlers.ts
@@ -174,12 +174,16 @@ export const createOriginalCallToolHandler = (): CallToolHandler => {
   const toolToServerUuid: Record<string, string> = {};
 
   return async (request, context) => {
+    // `name` is the caller-controlled tool name (a URL-decoded path segment on
+    // the OpenAPI path). Every log line and thrown message below runs it
+    // through JSON.stringify so an embedded CR/LF cannot forge log lines, the
+    // same discipline as the mcp-proxy connection log.
     const { name, arguments: args } = request.params;
 
     // Extract the original tool name by removing the server prefix
     const firstDoubleUnderscoreIndex = name.indexOf("__");
     if (firstDoubleUnderscoreIndex === -1) {
-      throw new Error(`Invalid tool name format: ${name}`);
+      throw new Error(`Invalid tool name format: ${JSON.stringify(name)}`);
     }
 
     const serverPrefix = name.substring(0, firstDoubleUnderscoreIndex);
@@ -269,7 +273,7 @@ export const createOriginalCallToolHandler = (): CallToolHandler => {
     }
 
     if (!targetSession) {
-      throw new Error(`Unknown tool: ${name}`);
+      throw new Error(`Unknown tool: ${JSON.stringify(name)}`);
     }
 
     const targetServerUuid = toolToServerUuid[name];
@@ -320,7 +324,7 @@ export const createOriginalCallToolHandler = (): CallToolHandler => {
       // Streamable-HTTP one when investigating.
       if (!isRecoverableBackendError(error)) {
         logger.error(
-          `Error calling tool "${name}" through ${
+          `Error calling tool ${JSON.stringify(name)} through ${
             targetSession.client.getServerVersion()?.name || "unknown"
           }:`,
           error,
@@ -329,7 +333,7 @@ export const createOriginalCallToolHandler = (): CallToolHandler => {
       }
 
       logger.warn(
-        `OpenAPI bridge: backend connection lost for server ${targetServerUuid} on tool "${name}"; invalidating pool and retrying once. (envelope: ${
+        `OpenAPI bridge: backend connection lost for server ${targetServerUuid} on tool ${JSON.stringify(name)}; invalidating pool and retrying once. (envelope: ${
           error instanceof Error ? error.message : String(error)
         })`,
       );
@@ -368,7 +372,7 @@ export const createOriginalCallToolHandler = (): CallToolHandler => {
         return (await callOnce(freshSession)) as CallToolResult;
       } catch (retryError) {
         logger.error(
-          `OpenAPI bridge: error calling tool "${name}" through ${
+          `OpenAPI bridge: error calling tool ${JSON.stringify(name)} through ${
             freshSession.client.getServerVersion()?.name || "unknown"
           } after session re-initialize:`,
           retryError,

--- a/apps/backend/src/routers/public-metamcp/openapi/tool-execution.log-hygiene.test.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/tool-execution.log-hygiene.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Log hygiene: the OpenAPI bridge logs the caller-controlled tool name
+ * (a URL-decoded path segment) when a tool execution fails. Interpolating it
+ * raw lets an embedded CR/LF forge whole log lines; the fix runs it through
+ * JSON.stringify first, matching the mcp-proxy connection-log treatment.
+ *
+ * The module graph is fully mocked at tool-execution's own import boundary so
+ * the test needs no postgres and no live backend.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getOpenApiServerMock, loggerErrorMock } = vi.hoisted(() => ({
+  getOpenApiServerMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  default: {
+    error: loggerErrorMock,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../../../lib/metamcp/metamcp-server-pool", () => ({
+  metaMcpServerPool: { getOpenApiServer: getOpenApiServerMock },
+}));
+
+vi.mock("../../../lib/metamcp/caller-context", () => ({
+  resolveCallerContext: vi.fn(),
+}));
+
+vi.mock("../../../lib/metamcp/consumer-identity-resolver", () => ({
+  resolveClientIdentity: vi.fn().mockResolvedValue({ name: "test-consumer" }),
+}));
+
+vi.mock("./handlers", () => ({
+  createMiddlewareEnabledHandlers: vi.fn(),
+}));
+
+import { executeToolWithMiddleware } from "./tool-execution";
+
+/** A tool name carrying a real newline, the log-forging payload. */
+const HOSTILE_TOOL_NAME = "server__evilTool\ninjected fake log line";
+
+function makeRes() {
+  const res = {
+    statusCode: 200,
+    status: vi.fn(function status(this: unknown, code: number) {
+      (res as { statusCode: number }).statusCode = code;
+      return res;
+    }),
+    json: vi.fn(function json(this: unknown) {
+      return res;
+    }),
+  };
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Fail pool acquisition so the catch runs and the tool name reaches the log.
+  getOpenApiServerMock.mockResolvedValue(undefined);
+});
+
+describe("executeToolWithMiddleware -- tool name is escaped before it enters a log line", () => {
+  it("JSON.stringifies a tool name containing a newline (no raw CR/LF in the log)", async () => {
+    const req = {
+      namespaceUuid: "ns-1",
+      params: { tool_name: HOSTILE_TOOL_NAME },
+    } as unknown as Parameters<typeof executeToolWithMiddleware>[0];
+
+    await executeToolWithMiddleware(req, makeRes() as never, {});
+
+    expect(loggerErrorMock).toHaveBeenCalled();
+    const logged = String(loggerErrorMock.mock.calls[0][0]);
+
+    // The line still names the failing tool for the operator.
+    expect(logged).toContain("Error executing tool");
+    // A real newline in the name can no longer split the log line: it is
+    // escaped to the two-character sequence backslash-n.
+    expect(logged).not.toContain("\n");
+    expect(logged).toContain("server__evilTool\\ninjected fake log line");
+  });
+});

--- a/apps/backend/src/routers/public-metamcp/openapi/tool-execution.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/tool-execution.ts
@@ -81,7 +81,11 @@ export const executeToolWithMiddleware = async (
     // Return the result directly (simplified format)
     res.json(result);
   } catch (error) {
-    logger.error(`Error executing tool ${toolName}:`, error);
+    // JSON.stringify the caller-controlled tool name before it enters a log
+    // line: `tool_name` is a URL-decoded path segment, so an embedded CR/LF
+    // would forge whole log lines. Same discipline as the mcp-proxy
+    // connection log.
+    logger.error(`Error executing tool ${JSON.stringify(toolName)}:`, error);
 
     // Handle different types of errors
     if (error instanceof Error) {

--- a/apps/backend/src/routers/public-metamcp/sse.ts
+++ b/apps/backend/src/routers/public-metamcp/sse.ts
@@ -190,7 +190,7 @@ sseRouter.get(
   lookupEndpoint,
   authenticateApiKey,
   rateLimitMiddleware,
-  async (req, res) => {
+  async (req, res, next) => {
     const authReq = req as ApiKeyAuthenticatedRequest;
     const { namespaceUuid, endpointName } = authReq;
 
@@ -253,7 +253,10 @@ sseRouter.get(
       await mcpServerInstance.server.connect(webAppTransport);
     } catch (error) {
       logger.error("Error in public endpoint /sse route:", error);
-      res.status(500).json(error);
+      // Constant body via the terminal error handler (middleware/error-handler)
+      // instead of serializing the raw error object to the client; it also
+      // destroys an already streaming SSE socket correctly.
+      return next(error);
     }
   },
 );
@@ -263,7 +266,7 @@ sseRouter.post(
   lookupEndpoint,
   authenticateApiKey,
   rateLimitMiddleware,
-  async (req, res) => {
+  async (req, res, next) => {
     const authReq = req as ApiKeyAuthenticatedRequest;
 
     try {
@@ -300,7 +303,9 @@ sseRouter.post(
       );
     } catch (error) {
       logger.error("Error in public endpoint /message route:", error);
-      res.status(500).json(error);
+      // Constant body via the terminal error handler instead of serializing
+      // the raw error object to the client.
+      return next(error);
     }
   },
 );

--- a/apps/backend/src/routers/public-metamcp/streamable-http.test.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.test.ts
@@ -131,6 +131,12 @@ vi.mock("../../lib/metamcp/transport-recovery-hydration", () => ({
 import { mcpSessionsRepository } from "@/db/repositories/mcp-sessions.repo";
 import type { ApiKeyAuthenticatedRequest } from "@/middleware/api-key-oauth.middleware";
 import { authenticateApiKey } from "@/middleware/api-key-oauth.middleware";
+// The REAL terminal handler, mounted after the router below exactly as index.ts
+// wires it, so the route's `next(error)` is answered the way production answers.
+import {
+  errorHandler,
+  INTERNAL_ERROR_BODY,
+} from "@/middleware/error-handler.middleware";
 import { lookupEndpoint } from "@/middleware/lookup-endpoint-middleware";
 import { rateLimitMiddleware } from "@/middleware/rate-limit.middleware";
 
@@ -1922,5 +1928,99 @@ describe("POST/GET /:endpoint/mcp — a refused session reuse answers 404, not 4
     expect(mcpSessionsRepository.findById).not.toHaveBeenCalled();
 
     await cleanupSession(sessionId);
+  });
+});
+
+/**
+ * Response hygiene: a route-level 500 must answer the constant body the
+ * terminal error handler produces, never a serialized raw error (message, and
+ * on the POST branches the session id and endpoint name). The POST route now
+ * defers to `next(error)`; this drives the real router + terminal handler and
+ * forces a throw before any header is written.
+ */
+describe("POST /:endpoint/mcp -- a forced 500 answers the constant body, not the raw error", () => {
+  let server: Server;
+  let baseUrl = "";
+
+  beforeAll(async () => {
+    vi.mocked(lookupEndpoint).mockImplementation(((
+      req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => {
+      Object.assign(req, {
+        namespaceUuid: "ns-500",
+        endpointName: "ep-500-secret-name",
+        endpoint: { uuid: "ep-500-uuid", name: "ep-500-secret-name" },
+        authMethod: "api_key",
+        apiKeyUuid: "key-500",
+      });
+      next();
+    }) as never);
+    vi.mocked(authenticateApiKey).mockImplementation(((
+      _req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => next()) as never);
+    vi.mocked(rateLimitMiddleware).mockImplementation(((
+      _req: express.Request,
+      _res: express.Response,
+      next: () => void,
+    ) => next()) as never);
+
+    const app = express();
+    app.use("/metamcp", streamableHttpRouter);
+    app.use(errorHandler);
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (typeof address === "object" && address) {
+      baseUrl = `http://127.0.0.1:${address.port}`;
+    }
+  });
+
+  afterAll(async () => {
+    vi.mocked(lookupEndpoint).mockImplementation((() => undefined) as never);
+    vi.mocked(authenticateApiKey).mockImplementation(
+      (() => undefined) as never,
+    );
+    vi.mocked(rateLimitMiddleware).mockImplementation(
+      (() => undefined) as never,
+    );
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("returns the constant internal-error body with no error text, session id or endpoint name", async () => {
+    // New-session POST (no Mcp-Session-Id): pool acquisition returns nothing,
+    // so the route throws before writing a header and the terminal handler
+    // answers the constant body.
+    (
+      metaMcpServerPool.getServer as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const response = await fetch(`${baseUrl}/metamcp/ep-500-secret-name/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      }),
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(JSON.parse(body)).toEqual(INTERNAL_ERROR_BODY);
+    // None of the detail the old branches serialized to the caller leaks.
+    expect(body).not.toContain("ep-500-secret-name");
+    expect(body).not.toContain("Failed to get MetaMCP server instance");
+    // The old envelope's literal keys are gone too.
+    expect(body).not.toContain("Internal server error");
+    expect(body).not.toContain("timestamp");
   });
 });

--- a/apps/backend/src/routers/public-metamcp/streamable-http.ts
+++ b/apps/backend/src/routers/public-metamcp/streamable-http.ts
@@ -906,7 +906,7 @@ streamableHttpRouter.get(
   lookupEndpoint,
   authenticateApiKey,
   rateLimitMiddleware,
-  async (req, res) => {
+  async (req, res, next) => {
     // const authReq = req as ApiKeyAuthenticatedRequest;
     // const { namespaceUuid, endpointName } = authReq;
     const sessionId = req.headers["mcp-session-id"] as string;
@@ -968,7 +968,12 @@ streamableHttpRouter.get(
       await dispatchTracked(authReq, transport, req, res, sessionId);
     } catch (error) {
       logger.error("Error in public endpoint /mcp route:", error);
-      res.status(500).json(error);
+      // Defer to the terminal error handler (middleware/error-handler): it
+      // returns the constant INTERNAL_ERROR_BODY and destroys an already
+      // streaming socket. Client-facing bodies here previously serialized the
+      // raw error object (message, and on the branches below the session id
+      // and endpoint name); detail stays in the server log above.
+      return next(error);
     }
   },
 );
@@ -978,7 +983,7 @@ streamableHttpRouter.post(
   lookupEndpoint,
   authenticateApiKey,
   rateLimitMiddleware,
-  async (req, res) => {
+  async (req, res, next) => {
     const authReq = req as ApiKeyAuthenticatedRequest;
     const { namespaceUuid, endpointName } = authReq;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
@@ -1143,16 +1148,9 @@ streamableHttpRouter.post(
         );
       } catch (error) {
         logger.error("Error in public endpoint /mcp POST route:", error);
-
-        // Provide more detailed error information
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        res.status(500).json({
-          error: "Internal server error",
-          message: errorMessage,
-          endpoint: endpointName,
-          timestamp: new Date().toISOString(),
-        });
+        // Constant body via the terminal error handler; no error message or
+        // endpoint name in the client-facing response (detail is logged above).
+        return next(error);
       }
     } else {
       // logger.info(
@@ -1272,16 +1270,9 @@ streamableHttpRouter.post(
         );
       } catch (error) {
         logger.error("Error in public endpoint /mcp route:", error);
-
-        const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
-        res.status(500).json({
-          error: "Internal server error",
-          message: errorMessage,
-          session_id: sessionId,
-          endpoint: endpointName,
-          timestamp: new Date().toISOString(),
-        });
+        // Constant body via the terminal error handler; no error message,
+        // session id or endpoint name in the client-facing response.
+        return next(error);
       }
     }
   },
@@ -1292,7 +1283,7 @@ streamableHttpRouter.delete(
   lookupEndpoint,
   authenticateApiKey,
   rateLimitMiddleware,
-  async (req, res) => {
+  async (req, res, next) => {
     const authReq = req as ApiKeyAuthenticatedRequest;
     const { namespaceUuid, endpointName } = authReq;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
@@ -1333,11 +1324,9 @@ streamableHttpRouter.delete(
         });
       } catch (error) {
         logger.error("Error in public endpoint /mcp DELETE route:", error);
-        res.status(500).json({
-          error: "Cleanup failed",
-          message: error instanceof Error ? error.message : "Unknown error",
-          sessionId: sessionId,
-        });
+        // Constant body via the terminal error handler; no error message or
+        // session id in the client-facing response.
+        return next(error);
       }
     } else {
       res.status(400).json({


### PR DESCRIPTION
## What

Wave-0 hardening on the data plane and the machine-plane response surface, in three areas.

### Data-plane rate limiter (lib/rate-limit.ts, middleware/rate-limit.middleware.ts, lib/client-ip.ts)
- The per-client sliding-window limiter defaulted its key to the caller-forgeable X-Forwarded-For, so a caller could rotate or omit the header to mint a fresh bucket per request. It now defaults to the edge-overwritten CF-Connecting-IP (routed through resolveClientIp), and a configured strategy-key override is validated: any forwarding or hop header is refused and degrades to the safe default.
- The per-(client, namespace) limiter map had no eviction and grew for the life of the process. Added an unref'd ten-minute sweep mirroring the credential sign-in limiter's timer. The sweep also clears the pool's matching init marker in lockstep, so a returning idle client whose limiter was evicted is re-limited from a fresh budget instead of being passed through unlimited.
- The token-bucket path answered a spurious 503 when no limiter existed for a namespace; a missing limiter is now a pass-through.
- Corrected the client-ip comment that claimed the sign-in limiter's sweep bounded this map (it does not).

### Inspector STDIO spawn (routers/mcp-proxy/server.ts)
- The Inspector spawn spread the full gateway process.env into the child, unlike the pooled path. The child env is now the curated getDefaultEnvironment plus the server's own resolved env, matching the pooled path, so a registered STDIO server cannot inherit unrelated gateway secrets.

### Response and log hygiene (routers/public-metamcp/streamable-http.ts, sse.ts, openapi/*, lib/session-lifetime-manager.ts, lib/metamcp/metamcp-server-pool.ts)
- The streamable-HTTP and SSE route-level 500 handlers serialized the raw error (message, and on some branches the session id and endpoint name) to the client. They now defer to the terminal error handler's constant body and log detail server-side.
- The OpenAPI bridge interpolated the caller-controlled tool name into log lines raw; it is now run through JSON.stringify first, matching the mcp-proxy connection-log treatment.
- The age-based cleanup timers joined full session-id lists into info log lines; counts now go at info and the id lists at debug only.

## Tests
- Backend vitest: 2037 passed, 93 skipped (pre-existing integration tests that need a database), 0 failed.
- Frontend vitest: 28 passed.
- check-types: pass. eslint on touched files: 0 errors.
- New or updated tests cover limiter keying plus override validation, the eviction sweep including the returning-client re-limit, the token-bucket pass-through, the curated spawn env, the constant 500 body, the tool-name log escaping, and the count-only cleanup logs. Each was confirmed to fail without its fix.

## Notes for review
- One existing spawn-source test pinned the old full-environment passthrough and was rewritten to assert the curated env.
- The OpenAPI tool-execution 500 response still echoes error.message to the client (same class as the streamable and SSE fix) but was outside this change's scope; flagged for a follow-up.

https://claude.ai/code/session_01GLGuUof88SHr6kxCUqzyE7
