### PR TITLE
fix(mcp-proxy): harden pool outbound path and namespace tool routing

### DIFF
--- a/apps/backend/src/lib/m365/injected-fetch.ts
+++ b/apps/backend/src/lib/m365/injected-fetch.ts
@@ -73,11 +73,20 @@ const injectedFetchSingleton: FetchLike = makeM365InjectedFetch();
  * The `client.ts` wiring hook: returns the injected fetch when (and
  * only when) `serverName` is configured for M365 delegated injection.
  * Env is read per call — cheap, and keeps tests deterministic.
+ *
+ * `baseFetch` composes the injection over another fetch (the pool's guarded,
+ * pinned fetch): injection sets the per-user Authorization, then delegates the
+ * actual connection to `baseFetch`. Omitted, the singleton over the global
+ * fetch is returned, preserving the previous behaviour.
  */
 export function getInjectedFetchForServer(
   serverName: string,
+  baseFetch?: FetchLike,
 ): FetchLike | undefined {
-  return getInjectedServerNames().has(serverName)
-    ? injectedFetchSingleton
-    : undefined;
+  if (!getInjectedServerNames().has(serverName)) {
+    return undefined;
+  }
+  return baseFetch
+    ? makeM365InjectedFetch(m365MintService, baseFetch)
+    : injectedFetchSingleton;
 }

--- a/apps/backend/src/lib/metamcp/client.test.ts
+++ b/apps/backend/src/lib/metamcp/client.test.ts
@@ -235,11 +235,13 @@ describe("computeReconnectBackoffMs — exponential backoff schedule", () => {
 });
 
 describe("createMetaMcpClient — STREAMABLE_HTTP transport option wiring", () => {
-  // The M365 injected-fetch wiring restructured this branch; these
-  // cases pin the four header/injection combinations so non-injected
-  // servers provably keep their pre-change transport shape. Reading
-  // SDK privates (_requestInit/_fetch) follows the precedent set by
-  // transport-recovery-hydration.ts.
+  // The pool now routes EVERY remote backend through the guarded, pinned
+  // fetch, so unlike before, a custom `fetch` and a `requestInit` are always
+  // installed regardless of headers or M365 injection. These cases pin that
+  // new shape: the guarded fetch is always present, headers are carried in
+  // requestInit, and an injected server still gets its injecting wrapper (over
+  // the guarded fetch). Reading SDK privates (_requestInit/_fetch) follows the
+  // precedent set by transport-recovery-hydration.ts.
   const baseParams = {
     uuid: "srv-uuid",
     name: "some-server",
@@ -267,14 +269,16 @@ describe("createMetaMcpClient — STREAMABLE_HTTP transport option wiring", () =
     return internals;
   }
 
-  it("no headers, non-injected server: no requestInit, no custom fetch", () => {
+  it("no headers, non-injected server: guarded fetch installed", () => {
     vi.stubEnv("M365_INJECTED_SERVER_NAMES", "m365");
     const internals = transportInternals({ name: "autotask" });
-    expect(internals._requestInit).toBeUndefined();
-    expect(internals._fetch).toBeUndefined();
+    // requestInit is always set now (headers may be empty), and the guarded
+    // fetch is always installed so the pool no longer dials with raw fetch.
+    expect(internals._requestInit).toBeDefined();
+    expect(typeof internals._fetch).toBe("function");
   });
 
-  it("bearer/header server, non-injected: requestInit carries auth, no custom fetch", () => {
+  it("bearer/header server, non-injected: requestInit carries auth, guarded fetch installed", () => {
     vi.stubEnv("M365_INJECTED_SERVER_NAMES", "m365");
     const internals = transportInternals({
       name: "autotask",
@@ -284,13 +288,13 @@ describe("createMetaMcpClient — STREAMABLE_HTTP transport option wiring", () =
     const headers = internals._requestInit?.headers as Record<string, string>;
     expect(headers.Authorization).toBe("Bearer static-token");
     expect(headers["X-Custom"]).toBe("yes");
-    expect(internals._fetch).toBeUndefined();
+    expect(typeof internals._fetch).toBe("function");
   });
 
   it("injected server: custom fetch installed even with no headers", () => {
     vi.stubEnv("M365_INJECTED_SERVER_NAMES", "m365");
     const internals = transportInternals({ name: "m365" });
-    expect(internals._requestInit).toBeUndefined();
+    expect(internals._requestInit).toBeDefined();
     expect(typeof internals._fetch).toBe("function");
   });
 

--- a/apps/backend/src/lib/metamcp/client.ts
+++ b/apps/backend/src/lib/metamcp/client.ts
@@ -2,7 +2,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioServerParameters } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  FetchLike,
+  Transport,
+} from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ServerParameters } from "@repo/zod-types";
 
@@ -19,6 +22,7 @@ import { ProcessManagedStdioTransport } from "../stdio-transport/process-managed
 import { describeConnectError, formatConnectionAge } from "./connect-error";
 import { metamcpLogStore } from "./log-store";
 import { serverErrorTracker } from "./server-error-tracker";
+import { createGuardedFetch } from "./url-guard";
 import { resolveEnvVariables } from "./utils";
 
 const sleep = (time: number) =>
@@ -230,6 +234,32 @@ export const transformDockerUrl = (url: string): string => {
   return url;
 };
 
+/**
+ * The guarded outbound fetch for the pooled data plane (SSE and
+ * Streamable-HTTP remote backends).
+ *
+ * Before this, the pool dialed remote backends with the raw global fetch: no
+ * address-range refusal, no redirect re-validation, no DNS pinning, no
+ * response-size or time cap, while the admin Inspector path already went
+ * through the shared url-guard. This closes that asymmetry for the pool.
+ *
+ * The pool's targets are DB-configured internal services, not caller-supplied
+ * URLs like the Inspector's, so `allowPrivateAddresses` permits the
+ * RFC-1918/loopback ranges where they live (the socket is still pinned to the
+ * resolved address and the cloud metadata address is still refused), and
+ * `refuseCrossOriginRedirect` rejects any redirect to another origin outright:
+ * a trusted backend never redirects the gateway elsewhere, and following one
+ * would carry the row's stored bearer to the redirect target, which is the
+ * SSRF vector this closes. The response byte ceiling and idle timeout come
+ * from the guard defaults (MCP_PROXY_MAX_RESPONSE_BYTES,
+ * MCP_PROXY_REQUEST_TIMEOUT_MS).
+ */
+const createPoolGuardedFetch = (): FetchLike =>
+  createGuardedFetch({
+    allowPrivateAddresses: true,
+    refuseCrossOriginRedirect: true,
+  });
+
 export const createMetaMcpClient = (
   serverParams: ServerParameters,
 ): { client: Client | undefined; transport: Transport | undefined } => {
@@ -288,20 +318,22 @@ export const createMetaMcpClient = (
       headers["Authorization"] = `Bearer ${authToken}`;
     }
 
-    const hasHeaders = Object.keys(headers).length > 0;
-
-    if (!hasHeaders) {
-      transport = new SSEClientTransport(new URL(transformedUrl));
-    } else {
-      transport = new SSEClientTransport(new URL(transformedUrl), {
-        requestInit: {
-          headers,
-        },
-        eventSourceInit: {
-          fetch: (url, init) => fetch(url, { ...init, headers }),
-        },
-      });
-    }
+    // Every request this transport makes goes through the guarded, pinned
+    // fetch, not just the initial GET: the SSE POST back-channel targets the
+    // endpoint the REMOTE server advertises in its `endpoint` event, which is
+    // remote-controlled input the pool never sees otherwise. eventSourceInit
+    // .fetch takes precedence over the `fetch` option inside the SDK, so both
+    // are set for the stream GET and the back-channel POSTs to be covered.
+    const guardedFetch = createPoolGuardedFetch();
+    transport = new SSEClientTransport(new URL(transformedUrl), {
+      eventSourceInit: {
+        fetch: (url, init) => guardedFetch(url, { ...init, headers }),
+      },
+      requestInit: {
+        headers,
+      },
+      fetch: guardedFetch,
+    });
   } else if (serverParams.type === "STREAMABLE_HTTP" && serverParams.url) {
     // Transform the URL if TRANSFORM_LOCALHOST_TO_DOCKER_INTERNAL is set to "true"
     const transformedUrl = transformDockerUrl(serverParams.url);
@@ -318,24 +350,30 @@ export const createMetaMcpClient = (
       headers["Authorization"] = `Bearer ${authToken}`;
     }
 
-    const hasHeaders = Object.keys(headers).length > 0;
+    // Guarded, pinned outbound fetch (see createPoolGuardedFetch), covering
+    // the transport's own reconnects and every redirect hop the one-shot
+    // connect check cannot reach.
+    const guardedFetch = createPoolGuardedFetch();
 
-    // M365 delegated broker: servers configured for per-user Graph
-    // token injection get a custom fetch that stamps a freshly minted
-    // per-user Authorization onto EVERY outgoing request (and strips
-    // any connection-level credential). Request-scoped — survives pool
-    // idle-handoff/cap-reuse without cross-user token leakage. See
+    // M365 delegated broker: servers configured for per-user Graph token
+    // injection get a fetch that stamps a freshly minted per-user
+    // Authorization onto EVERY outgoing request (and strips any
+    // connection-level credential), request-scoped so it survives pool
+    // idle-handoff/cap-reuse without cross-user token leakage. It wraps the
+    // guarded fetch: injection sets the header, then the guarded fetch
+    // validates + pins + caps the actual connection. See
     // `lib/m365/injected-fetch.ts` for the invariant.
-    const injectedFetch = getInjectedFetchForServer(serverParams.name);
+    const injectedFetch = getInjectedFetchForServer(
+      serverParams.name,
+      guardedFetch,
+    );
 
-    if (!hasHeaders && !injectedFetch) {
-      transport = new StreamableHTTPClientTransport(new URL(transformedUrl));
-    } else {
-      transport = new StreamableHTTPClientTransport(new URL(transformedUrl), {
-        ...(hasHeaders ? { requestInit: { headers } } : {}),
-        ...(injectedFetch ? { fetch: injectedFetch } : {}),
-      });
-    }
+    transport = new StreamableHTTPClientTransport(new URL(transformedUrl), {
+      requestInit: {
+        headers,
+      },
+      fetch: injectedFetch ?? guardedFetch,
+    });
   } else {
     metamcpLogStore.addLog(
       serverParams.name,

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/filter-tools.functional.test.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/filter-tools.functional.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Namespace tool-status enforcement fails CLOSED (operator decision
+ * 2026-09-02).
+ *
+ * Tool enable/disable is namespace curation, and it used to fail OPEN: a DB
+ * error or an unresolved server name served (list side) or allowed (call side)
+ * the tool, the opposite of the access-group gate. These tests pin the flipped
+ * direction: on an unresolved server or a DB error the tool is now excluded
+ * from a listing and denied on a call. Each fail-closed case below is written
+ * so it would FAIL against the previous fail-open behavior.
+ *
+ * The db module is mocked with a chain stub routed by call shape: a bare
+ * `.where()` is the getServerUuidByName lookup, an `.innerJoin(...).where()` is
+ * the getToolStatus lookup (same convention as consumer-identity-resolver's
+ * table-routed stub next door).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dbMock, fixtures } = vi.hoisted(() => {
+  const fixtures = {
+    serverRows: [] as Record<string, unknown>[],
+    statusRows: [] as Record<string, unknown>[],
+    serverError: false,
+    statusError: false,
+  };
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: () => ({
+        // getServerUuidByName: from(mcpServers).where()
+        where: () =>
+          fixtures.serverError
+            ? Promise.reject(new Error("db down"))
+            : Promise.resolve(fixtures.serverRows),
+        // getToolStatus: from(namespaceToolMappings).innerJoin(tools).where()
+        innerJoin: () => ({
+          where: () =>
+            fixtures.statusError
+              ? Promise.reject(new Error("db down"))
+              : Promise.resolve(fixtures.statusRows),
+        }),
+      }),
+    })),
+  };
+
+  return { dbMock, fixtures };
+});
+
+vi.mock("../../../db/index", () => ({ db: dbMock }));
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const {
+  createFilterListToolsMiddleware,
+  createFilterCallToolMiddleware,
+  clearFilterCache,
+} = await import("./filter-tools.functional");
+
+const TOOL_NAME = "srv__mytool";
+const context = { namespaceUuid: "ns1", sessionId: "sess1" };
+const listRequest = { method: "tools/list" as const, params: {} };
+const callRequest = {
+  method: "tools/call" as const,
+  params: { name: TOOL_NAME, arguments: {} },
+};
+const tool = {
+  name: TOOL_NAME,
+  description: "",
+  inputSchema: { type: "object" as const },
+};
+
+const listResult = () =>
+  createFilterListToolsMiddleware({ cacheEnabled: false })(async () => ({
+    tools: [tool],
+  }))(listRequest, context);
+
+const callResult = () => {
+  const handler = vi.fn(async () => ({
+    content: [{ type: "text" as const, text: "ok" }],
+  }));
+  const mw = createFilterCallToolMiddleware({ cacheEnabled: false });
+  return { handler, run: () => mw(handler)(callRequest, context) };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fixtures.serverRows = [];
+  fixtures.statusRows = [];
+  fixtures.serverError = false;
+  fixtures.statusError = false;
+  clearFilterCache();
+});
+
+afterEach(() => {
+  clearFilterCache();
+});
+
+describe("filterActiveTools: list side (unchanged happy paths)", () => {
+  it("includes a tool whose mapping is ACTIVE", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusRows = [{ status: "ACTIVE" }];
+    const { tools } = await listResult();
+    expect(tools).toHaveLength(1);
+  });
+
+  it("includes a tool that has no mapping row (active by default)", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusRows = [];
+    const { tools } = await listResult();
+    expect(tools).toHaveLength(1);
+  });
+
+  it("excludes a tool whose mapping is INACTIVE", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusRows = [{ status: "INACTIVE" }];
+    const { tools } = await listResult();
+    expect(tools).toHaveLength(0);
+  });
+});
+
+describe("filterActiveTools: list side fails CLOSED", () => {
+  it("excludes the tool when the server name does not resolve", async () => {
+    fixtures.serverRows = []; // getServerUuidByName -> null
+    const { tools } = await listResult();
+    // Fail-open would have served it; fail-closed drops it.
+    expect(tools).toHaveLength(0);
+  });
+
+  it("excludes the tool when the tool-status query errors", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusError = true; // getToolStatus throws
+    const { tools } = await listResult();
+    expect(tools).toHaveLength(0);
+  });
+});
+
+describe("isToolAllowed: call side fails CLOSED", () => {
+  it("allows the call when the mapping is ACTIVE", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusRows = [{ status: "ACTIVE" }];
+    const { handler, run } = callResult();
+    const result = await run();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it("denies the call when the mapping is INACTIVE", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusRows = [{ status: "INACTIVE" }];
+    const { handler, run } = callResult();
+    const result = await run();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("denies the call when the server name does not resolve", async () => {
+    fixtures.serverRows = []; // getServerUuidByName -> null
+    const { handler, run } = callResult();
+    const result = await run();
+    // Fail-open would have skipped the check and run the handler.
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("denies the call when the tool-status query errors", async () => {
+    fixtures.serverRows = [{ uuid: "srv-uuid" }];
+    fixtures.statusError = true; // getToolStatus throws
+    const { handler, run } = callResult();
+    const result = await run();
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/backend/src/lib/metamcp/metamcp-middleware/filter-tools.functional.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-middleware/filter-tools.functional.ts
@@ -91,7 +91,14 @@ class ToolStatusCache {
 const toolStatusCache = new ToolStatusCache();
 
 /**
- * Get tool status from database with caching
+ * Get tool status from database with caching.
+ *
+ * A `null` return means NO mapping row exists, which the callers read as "tool
+ * active by default". A DB error is deliberately NOT caught here: it must stay
+ * distinguishable from that legitimate `null`, so it propagates and each caller
+ * fails CLOSED (operator decision 2026-09-02). Swallowing it to `null` would
+ * silently re-enable a disabled tool the moment the database blips, the
+ * opposite of how the access-group gate behaves.
  */
 async function getToolStatus(
   namespaceUuid: string,
@@ -107,40 +114,32 @@ async function getToolStatus(
     }
   }
 
-  try {
-    // Query database for tool status
-    const [toolMapping] = await db
-      .select({
-        status: namespaceToolMappingsTable.status,
-      })
-      .from(namespaceToolMappingsTable)
-      .innerJoin(
-        toolsTable,
-        eq(toolsTable.uuid, namespaceToolMappingsTable.tool_uuid),
-      )
-      .where(
-        and(
-          eq(namespaceToolMappingsTable.namespace_uuid, namespaceUuid),
-          eq(toolsTable.name, toolName),
-          eq(namespaceToolMappingsTable.mcp_server_uuid, serverUuid),
-        ),
-      );
-
-    const status = toolMapping?.status || null;
-
-    // Cache the result if found and caching is enabled
-    if (status && useCache) {
-      toolStatusCache.set(namespaceUuid, toolName, serverUuid, status);
-    }
-
-    return status;
-  } catch (error) {
-    logger.error(
-      `Error fetching tool status for ${toolName} in namespace ${namespaceUuid}:`,
-      error,
+  // Query database for tool status
+  const [toolMapping] = await db
+    .select({
+      status: namespaceToolMappingsTable.status,
+    })
+    .from(namespaceToolMappingsTable)
+    .innerJoin(
+      toolsTable,
+      eq(toolsTable.uuid, namespaceToolMappingsTable.tool_uuid),
+    )
+    .where(
+      and(
+        eq(namespaceToolMappingsTable.namespace_uuid, namespaceUuid),
+        eq(toolsTable.name, toolName),
+        eq(namespaceToolMappingsTable.mcp_server_uuid, serverUuid),
+      ),
     );
-    return null;
+
+  const status = toolMapping?.status || null;
+
+  // Cache the result if found and caching is enabled
+  if (status && useCache) {
+    toolStatusCache.set(namespaceUuid, toolName, serverUuid, status);
   }
+
+  return status;
 }
 
 // parseToolName is now imported from shared utility
@@ -181,15 +180,18 @@ async function filterActiveTools(
       try {
         const parsed = parseToolName(tool.name);
         if (!parsed) {
-          // If tool name doesn't follow expected format, include it
+          // Not one of our prefixed tools, so tool-status curation does not
+          // apply: include it unchanged.
           activeTools.push(tool);
           return;
         }
 
         const serverUuid = await getServerUuidByName(parsed.serverName);
         if (!serverUuid) {
-          // If server not found, include the tool (fallback behavior)
-          activeTools.push(tool);
+          // FAIL CLOSED (operator decision 2026-09-02): an unresolved server
+          // means we cannot confirm the tool is enabled, so exclude it rather
+          // than serve a possibly-disabled tool. This matches the access-group
+          // gate's fail-closed direction; the two layers used to disagree.
           return;
         }
 
@@ -207,8 +209,9 @@ async function filterActiveTools(
         // If status is "INACTIVE", tool is filtered out
       } catch (error) {
         logger.error(`Error checking tool status for ${tool.name}:`, error);
-        // On error, include the tool (fail-safe behavior)
-        activeTools.push(tool);
+        // FAIL CLOSED (operator decision 2026-09-02): a DB error must not
+        // silently re-enable a disabled tool, so exclude it rather than
+        // include. Was fail-open (include on error).
       }
     }),
   );
@@ -254,8 +257,13 @@ async function isToolAllowed(
       `Error checking if tool ${toolName} is allowed in namespace ${namespaceUuid}:`,
       error,
     );
-    // On error, allow the tool (fail-safe behavior)
-    return { allowed: true };
+    // FAIL CLOSED (operator decision 2026-09-02): deny on error rather than
+    // allow, so a DB blip cannot let a call through to a tool that may be
+    // disabled. Matches the access-group gate; was fail-open (allow on error).
+    return {
+      allowed: false,
+      reason: "tool status could not be verified",
+    };
   }
 }
 
@@ -313,29 +321,31 @@ export function createFilterCallToolMiddleware(
       const parsed = parseToolName(toolName);
       if (parsed) {
         const serverUuid = await getServerUuidByName(parsed.serverName);
-        if (serverUuid) {
-          const { allowed, reason } = await isToolAllowed(
-            toolName,
-            context.namespaceUuid,
-            serverUuid,
-            useCache,
-          );
+        // FAIL CLOSED (operator decision 2026-09-02): a server-name miss (row
+        // absent, or a DB error surfacing as a null from getServerUuidByName)
+        // used to skip this check entirely and let the call through. Deny
+        // instead, so the call side agrees with the list side and the
+        // access-group gate on failure direction.
+        const { allowed, reason } = serverUuid
+          ? await isToolAllowed(
+              toolName,
+              context.namespaceUuid,
+              serverUuid,
+              useCache,
+            )
+          : { allowed: false, reason: "server could not be resolved" };
 
-          if (!allowed) {
-            // Return error response instead of calling the handler
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: customErrorMessage(
-                    toolName,
-                    reason || "Unknown reason",
-                  ),
-                },
-              ],
-              isError: true,
-            };
-          }
+        if (!allowed) {
+          // Return error response instead of calling the handler
+          return {
+            content: [
+              {
+                type: "text",
+                text: customErrorMessage(toolName, reason || "Unknown reason"),
+              },
+            ],
+            isError: true,
+          };
         }
       }
 

--- a/apps/backend/src/lib/metamcp/metamcp-proxy.ts
+++ b/apps/backend/src/lib/metamcp/metamcp-proxy.ts
@@ -52,7 +52,11 @@ import {
 } from "./metamcp-middleware/tool-overrides.functional";
 import { isRecoverableBackendError } from "./session-error";
 import { acquireSessionWithBoundedWarmup } from "./tool-call-warmup";
-import { parseToolName } from "./tool-name-parser";
+import {
+  parseToolName,
+  registerToolRoute,
+  ToolRouteOwner,
+} from "./tool-name-parser";
 import { toolsSyncCache } from "./tools-sync-cache";
 import { sanitizeName } from "./utils";
 
@@ -113,6 +117,11 @@ export const createServer = async (
 ) => {
   const toolToClient: Record<string, ConnectedClient> = {};
   const toolToServerUuid: Record<string, string> = {};
+  // Which server first claimed each fully-qualified tool name, so a second
+  // server that sanitizes to the same prefix and exposes the same tool name is
+  // detected as a collision rather than silently overwriting the route. See
+  // the collision guard at namespace assembly below.
+  const toolNameOwner = new Map<string, ToolRouteOwner>();
   const promptToClient: Record<string, ConnectedClient> = {};
   const resourceToClient: Record<string, ConnectedClient> = {};
 
@@ -440,17 +449,45 @@ export const createServer = async (
           }
 
           // Use original tools for client response (middleware will be applied later)
-          const toolsWithSource = allServerTools.map((tool) => {
+          //
+          // Cross-server tool-name collision guard: the routing maps are keyed on
+          // `sanitizeName(serverName)__toolName`. sanitizeName strips every
+          // character outside [a-zA-Z0-9_-], so two servers in one namespace
+          // whose names sanitize to the same prefix (or share a name, or fall
+          // back to an unvalidated backend-reported version name) and expose
+          // the same tool name would produce the SAME key. Left unchecked,
+          // last writer wins and a call silently routes to the wrong backend.
+          // We keep the FIRST registration, drop the duplicate, and WARN naming
+          // both servers so the operator can rename one. Disambiguating by a
+          // uuid suffix instead was rejected: the assembly runs concurrently
+          // (Promise.allSettled below), so which server won the base name would
+          // be non-deterministic, and it would rename a tool the caller invokes
+          // by name. This synchronous loop is atomic per server relative to the
+          // others, so the check-then-set sees every already-registered server.
+          const toolsWithSource: Tool[] = [];
+          for (const tool of allServerTools) {
             const toolName = `${sanitizeName(serverName)}__${tool.name}`;
+            const outcome = registerToolRoute(
+              toolName,
+              { uuid: mcpServerUuid, name: serverName },
+              toolNameOwner,
+            );
+            if (!outcome.registered) {
+              const other = outcome.collidedWith;
+              logger.warn(
+                `Tool name collision in namespace ${namespaceUuid}: "${toolName}" is exposed by both server "${other?.name}" (${other?.uuid}) and server "${serverName}" (${mcpServerUuid}); keeping the first and dropping the duplicate. Rename one server so their sanitized name prefixes differ.`,
+              );
+              continue;
+            }
             toolToClient[toolName] = activeSession;
             toolToServerUuid[toolName] = mcpServerUuid;
 
-            return {
+            toolsWithSource.push({
               ...tool,
               name: toolName,
               description: tool.description,
-            };
-          });
+            });
+          }
 
           allTools.push(...toolsWithSource);
         } catch (error) {

--- a/apps/backend/src/lib/metamcp/tool-name-parser.test.ts
+++ b/apps/backend/src/lib/metamcp/tool-name-parser.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tool name parsing and the cross-server routing-collision guard.
+ *
+ * The routing maps in the proxy are keyed on the fully-qualified tool name, and
+ * before the guard a second server producing a name already owned by a
+ * DIFFERENT server would overwrite the route last-writer-wins, silently sending
+ * a call to the wrong backend. `registerToolRoute` is the pure decision behind
+ * the guard; these pin that a same-name-different-server pair is a collision
+ * (the duplicate is dropped, the first owner kept) while a re-list of the same
+ * server is not.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  parseToolName,
+  registerToolRoute,
+  ToolRouteOwner,
+} from "./tool-name-parser";
+
+describe("parseToolName", () => {
+  it("splits on the first double underscore", () => {
+    expect(parseToolName("Server__tool")).toEqual({
+      serverName: "Server",
+      originalToolName: "tool",
+    });
+  });
+
+  it("keeps nested prefixes in the forwarded tool name", () => {
+    expect(parseToolName("Parent__Child__my_tool")).toEqual({
+      serverName: "Parent",
+      originalToolName: "Child__my_tool",
+    });
+  });
+
+  it("returns null when there is no separator", () => {
+    expect(parseToolName("noseparator")).toBeNull();
+  });
+});
+
+describe("registerToolRoute: cross-server collision guard", () => {
+  it("registers a tool name the first time it is seen", () => {
+    const owners = new Map<string, ToolRouteOwner>();
+    const outcome = registerToolRoute(
+      "Srv__tool",
+      { uuid: "uuid-a", name: "Srv" },
+      owners,
+    );
+    expect(outcome.registered).toBe(true);
+    expect(owners.get("Srv__tool")).toEqual({ uuid: "uuid-a", name: "Srv" });
+  });
+
+  it("reports a collision when a DIFFERENT server produces the same name", () => {
+    const owners = new Map<string, ToolRouteOwner>();
+    registerToolRoute("Srv__tool", { uuid: "uuid-a", name: "Srv" }, owners);
+
+    // "Srv " and "Srv" both sanitize to "Srv", so this second server collides.
+    const outcome = registerToolRoute(
+      "Srv__tool",
+      { uuid: "uuid-b", name: "Srv " },
+      owners,
+    );
+
+    expect(outcome.registered).toBe(false);
+    expect(outcome.collidedWith).toEqual({ uuid: "uuid-a", name: "Srv" });
+    // The first owner is kept; the duplicate never overwrites the route.
+    expect(owners.get("Srv__tool")).toEqual({ uuid: "uuid-a", name: "Srv" });
+  });
+
+  it("does not treat a re-list of the SAME server as a collision", () => {
+    const owners = new Map<string, ToolRouteOwner>();
+    registerToolRoute("Srv__tool", { uuid: "uuid-a", name: "Srv" }, owners);
+
+    const outcome = registerToolRoute(
+      "Srv__tool",
+      { uuid: "uuid-a", name: "Srv" },
+      owners,
+    );
+
+    expect(outcome.registered).toBe(true);
+    expect(outcome.collidedWith).toBeUndefined();
+  });
+
+  it("does not collide two different tool names from the same server", () => {
+    const owners = new Map<string, ToolRouteOwner>();
+    const a = registerToolRoute(
+      "Srv__toolA",
+      { uuid: "uuid-a", name: "Srv" },
+      owners,
+    );
+    const b = registerToolRoute(
+      "Srv__toolB",
+      { uuid: "uuid-a", name: "Srv" },
+      owners,
+    );
+    expect(a.registered).toBe(true);
+    expect(b.registered).toBe(true);
+    expect(owners.size).toBe(2);
+  });
+});

--- a/apps/backend/src/lib/metamcp/tool-name-parser.ts
+++ b/apps/backend/src/lib/metamcp/tool-name-parser.ts
@@ -57,3 +57,36 @@ export function parseToolName(toolName: string): ParsedToolName | null {
 export function createToolName(serverName: string, toolName: string): string {
   return `${serverName}__${toolName}`;
 }
+
+/** The server that first claimed a fully-qualified tool name. */
+export interface ToolRouteOwner {
+  uuid: string;
+  name: string;
+}
+
+/**
+ * Register a discovered tool's route, or report a cross-server name collision.
+ *
+ * The proxy's routing maps are keyed on `sanitizeName(serverName)__toolName`.
+ * Two servers in one namespace that produce the same key (their names sanitize
+ * to the same prefix, or they share a name, or one falls back to an
+ * unvalidated backend-reported version name) would otherwise overwrite each
+ * other last-writer-wins, silently routing a call to the wrong backend. This
+ * keeps the FIRST owner and reports the duplicate so the caller drops it and
+ * warns; the operator resolves it by renaming one server. A re-registration by
+ * the SAME server (a re-list of one backend) is not a collision. Kept here,
+ * beside the name parser and free of any db import, so the decision is
+ * unit-testable without standing up the whole proxy.
+ */
+export function registerToolRoute(
+  toolName: string,
+  server: ToolRouteOwner,
+  owners: Map<string, ToolRouteOwner>,
+): { registered: boolean; collidedWith?: ToolRouteOwner } {
+  const owner = owners.get(toolName);
+  if (owner && owner.uuid !== server.uuid) {
+    return { registered: false, collidedWith: owner };
+  }
+  owners.set(toolName, server);
+  return { registered: true };
+}

--- a/apps/backend/src/lib/metamcp/url-guard.test.ts
+++ b/apps/backend/src/lib/metamcp/url-guard.test.ts
@@ -7,7 +7,7 @@
  * on. The hostnames below are all `example.com` subdomains for the same
  * reason — they must never resolve to anything real.
  *
- * `server.remote-url.test.ts` next door proves the route actually calls this;
+ * The `server.remote-url.test.ts` suite proves the route actually calls this;
  * a validator can be perfectly correct and still be wired to nothing.
  */
 
@@ -22,7 +22,9 @@ const {
   createGuardedFetch,
   createPinnedAgent,
   isBlockedSsrfAddress,
+  CROSS_ORIGIN_REDIRECT_REFUSED,
   NOT_A_PERMITTED_TARGET,
+  RESPONSE_TOO_LARGE,
   TOO_MANY_REDIRECTS,
   UNREPLAYABLE_REDIRECT_BODY,
 } = await import("./url-guard");
@@ -709,5 +711,165 @@ describe("createGuardedFetch — every hop is re-validated, not just the first",
     );
     // Two connections happened; the third was refused before it was opened.
     expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * The pooled data plane's posture: internal backends are trusted (their DB
+ * rows are operator-configured), so private ranges are permitted while the
+ * cloud metadata address and the other never-a-backend ranges stay refused.
+ */
+describe("isBlockedSsrfAddress: allowPrivate relaxation", () => {
+  it.each([
+    ["10.1.2.3", "RFC 1918 ten-dot"],
+    ["172.16.0.1", "RFC 1918 one-seven-two"],
+    ["192.168.1.1", "RFC 1918 one-nine-two"],
+    ["127.0.0.1", "loopback"],
+    ["::1", "IPv6 loopback"],
+    ["fd12:3456::1", "IPv6 unique local"],
+    ["::ffff:10.0.0.1", "IPv4-mapped RFC 1918"],
+  ])("permits internal-service %s (%s) under allowPrivate", (address) => {
+    expect(isBlockedSsrfAddress(address, true)).toBeNull();
+  });
+
+  it.each([
+    ["169.254.169.254", "cloud metadata"],
+    ["100.64.0.1", "carrier-grade NAT"],
+    ["224.0.0.1", "multicast"],
+    ["0.0.0.0", "unspecified"],
+    ["::", "IPv6 unspecified"],
+    ["fe80::1", "IPv6 link-local"],
+    ["::ffff:169.254.169.254", "IPv4-mapped metadata"],
+  ])("still blocks %s (%s) under allowPrivate", (address) => {
+    expect(isBlockedSsrfAddress(address, true)).not.toBeNull();
+  });
+});
+
+describe("assertPublicMcpUrl: allowPrivateAddresses (pooled posture)", () => {
+  it("permits an internal RFC-1918 backend and still pins it", async () => {
+    const { url, addresses } = await assertPublicMcpUrl(
+      "http://backend.internal/mcp",
+      { lookup: resolvesTo("10.0.0.5"), allowPrivateAddresses: true },
+    );
+    expect(url.href).toBe("http://backend.internal/mcp");
+    // Non-empty addresses = the socket is pinned to the validated answer.
+    expect(addresses).toEqual(["10.0.0.5"]);
+  });
+
+  it("permits a loopback backend literal under allowPrivate", async () => {
+    const { addresses } = await assertPublicMcpUrl(
+      "http://127.0.0.1:3001/mcp",
+      {
+        allowPrivateAddresses: true,
+      },
+    );
+    expect(addresses).toEqual(["127.0.0.1"]);
+  });
+
+  it("still refuses the cloud metadata address under allowPrivate", async () => {
+    await expect(
+      assertPublicMcpUrl("http://backend.internal/mcp", {
+        lookup: resolvesTo("169.254.169.254"),
+        allowPrivateAddresses: true,
+      }),
+    ).rejects.toThrow(NOT_A_PERMITTED_TARGET);
+  });
+
+  it("still refuses CGNAT under allowPrivate", async () => {
+    await expect(
+      assertPublicMcpUrl("http://backend.internal/mcp", {
+        lookup: resolvesTo("100.64.0.1"),
+        allowPrivateAddresses: true,
+      }),
+    ).rejects.toThrow(NOT_A_PERMITTED_TARGET);
+  });
+});
+
+describe("createGuardedFetch: refuseCrossOriginRedirect (pooled posture)", () => {
+  const ok = () => new Response("ok", { status: 200 });
+  const redirect = (status: number, location: string) =>
+    new Response(null, { status, headers: { location } });
+
+  it("refuses a cross-origin redirect outright rather than following it", async () => {
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValueOnce(redirect(302, "https://elsewhere.example.com/x"))
+      .mockResolvedValueOnce(ok());
+    const guarded = createGuardedFetch({
+      baseFetch,
+      lookup: resolvesTo(PUBLIC_V4),
+      refuseCrossOriginRedirect: true,
+    });
+
+    await expect(guarded("https://mcp.example.com/mcp")).rejects.toThrow(
+      CROSS_ORIGIN_REDIRECT_REFUSED,
+    );
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("still follows a same-origin redirect", async () => {
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValueOnce(redirect(302, "https://mcp.example.com/mcp/"))
+      .mockResolvedValueOnce(ok());
+    const guarded = createGuardedFetch({
+      baseFetch,
+      lookup: resolvesTo(PUBLIC_V4),
+      refuseCrossOriginRedirect: true,
+    });
+
+    const response = await guarded("https://mcp.example.com/mcp");
+    expect(response.status).toBe(200);
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("permits an internal backend but refuses its redirect to the metadata address", async () => {
+    // Together: allowPrivate lets hop 0 (an internal 10.x host) connect, and
+    // the cross-origin refusal stops the compromised-backend 302 to metadata.
+    // Without allowPrivate the first hop is refused and baseFetch is never
+    // called, so the single call also proves allowPrivate did its job.
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        redirect(302, "http://169.254.169.254/latest/meta-data/"),
+      )
+      .mockResolvedValueOnce(ok());
+    const guarded = createGuardedFetch({
+      baseFetch,
+      lookup: resolvesTo("10.0.0.5"),
+      allowPrivateAddresses: true,
+      refuseCrossOriginRedirect: true,
+    });
+
+    await expect(guarded("http://backend.internal/mcp")).rejects.toThrow(
+      CROSS_ORIGIN_REDIRECT_REFUSED,
+    );
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createGuardedFetch: the response body is bounded", () => {
+  it("aborts a response body that exceeds the byte ceiling", async () => {
+    const baseFetch = vi.fn(async () => new Response("abcdefgh")); // 8 bytes
+    const guarded = createGuardedFetch({
+      baseFetch,
+      lookup: resolvesTo(PUBLIC_V4),
+      maxResponseBytes: 4,
+    });
+
+    const response = await guarded("https://mcp.example.com/mcp");
+    await expect(response.text()).rejects.toThrow(RESPONSE_TOO_LARGE);
+  });
+
+  it("passes a response under the byte ceiling untouched", async () => {
+    const baseFetch = vi.fn(async () => new Response("ok"));
+    const guarded = createGuardedFetch({
+      baseFetch,
+      lookup: resolvesTo(PUBLIC_V4),
+      maxResponseBytes: 1024,
+    });
+
+    const response = await guarded("https://mcp.example.com/mcp");
+    expect(await response.text()).toBe("ok");
   });
 });

--- a/apps/backend/src/lib/metamcp/url-guard.ts
+++ b/apps/backend/src/lib/metamcp/url-guard.ts
@@ -62,11 +62,61 @@ export const TOO_MANY_REDIRECTS =
 export const UNREPLAYABLE_REDIRECT_BODY =
   "The MCP server URL redirected a request whose body cannot be resent.";
 
+/** A response body that exceeded the byte ceiling and was aborted. */
+export const RESPONSE_TOO_LARGE =
+  "The MCP server response exceeded the maximum allowed size.";
+
+/**
+ * A redirect to a different origin, refused rather than followed.
+ *
+ * Used only under `refuseCrossOriginRedirect` (the pooled data plane): a
+ * trusted internal backend does not redirect the gateway to another origin,
+ * so one that tries is answering a request with a hostile hop.
+ */
+export const CROSS_ORIGIN_REDIRECT_REFUSED =
+  "The MCP server URL redirected across origins, which is not permitted here.";
+
+/**
+ * Default response-byte ceiling and dispatcher idle timeout, both env-tunable.
+ *
+ * The byte ceiling (100 MiB) is a memory-exhaustion backstop, not an
+ * operational limit; a single JSON-RPC response never approaches it. The
+ * timeout (300000 ms) matches undici's own default, made explicit and tunable;
+ * it is the headers/body IDLE timeout, so it bounds a stalled upstream without
+ * capping a long-lived active stream. Read per call rather than captured at
+ * import so a value can be corrected without a rebuild and varied by a test,
+ * matching `allowedHostsFromEnv`.
+ */
+const DEFAULT_MAX_RESPONSE_BYTES = 100 * 1024 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS = 300000;
+
+const envPositiveInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const maxResponseBytesFromEnv = (): number =>
+  envPositiveInt("MCP_PROXY_MAX_RESPONSE_BYTES", DEFAULT_MAX_RESPONSE_BYTES);
+
+const requestTimeoutMsFromEnv = (): number =>
+  envPositiveInt("MCP_PROXY_REQUEST_TIMEOUT_MS", DEFAULT_REQUEST_TIMEOUT_MS);
+
 interface Ipv4Range {
   readonly base: string;
   readonly prefix: number;
   /** Why this range is not a legitimate destination for a remote MCP server. */
   readonly why: string;
+  /**
+   * True for the private ranges where a trusted, operator-configured backend
+   * legitimately lives (RFC 1918 and loopback). The `allowPrivate` posture
+   * (used by the pooled data plane, whose targets are DB-configured internal
+   * services, not caller-supplied) permits these while still refusing the
+   * ranges that are never a real backend: the cloud metadata address, CGNAT,
+   * multicast and the reserved blocks stay blocked in both postures.
+   */
+  readonly internalService?: boolean;
 }
 
 /**
@@ -82,15 +132,25 @@ interface Ipv4Range {
  */
 const BLOCKED_IPV4_RANGES: readonly Ipv4Range[] = [
   { base: "0.0.0.0", prefix: 8, why: "this-network / unspecified" },
-  { base: "10.0.0.0", prefix: 8, why: "private (RFC 1918)" },
+  {
+    base: "10.0.0.0",
+    prefix: 8,
+    why: "private (RFC 1918)",
+    internalService: true,
+  },
   { base: "100.64.0.0", prefix: 10, why: "carrier-grade NAT (RFC 6598)" },
-  { base: "127.0.0.0", prefix: 8, why: "loopback" },
+  { base: "127.0.0.0", prefix: 8, why: "loopback", internalService: true },
   {
     base: "169.254.0.0",
     prefix: 16,
     why: "link-local, including the cloud instance-metadata address",
   },
-  { base: "172.16.0.0", prefix: 12, why: "private (RFC 1918)" },
+  {
+    base: "172.16.0.0",
+    prefix: 12,
+    why: "private (RFC 1918)",
+    internalService: true,
+  },
   {
     base: "192.0.0.0",
     prefix: 24,
@@ -101,7 +161,12 @@ const BLOCKED_IPV4_RANGES: readonly Ipv4Range[] = [
     prefix: 24,
     why: "6to4 relay anycast (RFC 7526) — reaches a relay, not a server",
   },
-  { base: "192.168.0.0", prefix: 16, why: "private (RFC 1918)" },
+  {
+    base: "192.168.0.0",
+    prefix: 16,
+    why: "private (RFC 1918)",
+    internalService: true,
+  },
   {
     base: "198.18.0.0",
     prefix: 15,
@@ -201,10 +266,13 @@ const ipv6ToBytes = (address: string): Uint8Array | null => {
  * the plain v4 literal would. Judging the text form instead of the address it
  * denotes is how these checks get bypassed.
  */
-const blockedIpv6Reason = (bytes: Uint8Array): string | null => {
+const blockedIpv6Reason = (
+  bytes: Uint8Array,
+  allowPrivate: boolean,
+): string | null => {
   // ::ffff:0:0/96 — IPv4-mapped. `http://[::ffff:127.0.0.1]` is loopback.
   if (allZero(bytes, 0, 10) && bytes[10] === 0xff && bytes[11] === 0xff) {
-    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12));
+    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12), allowPrivate);
     return inner ? `IPv4-mapped ::ffff:0:0/96 -> ${inner}` : null;
   }
 
@@ -217,7 +285,7 @@ const blockedIpv6Reason = (bytes: Uint8Array): string | null => {
     bytes[9] === 0xff &&
     allZero(bytes, 10, 12)
   ) {
-    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12));
+    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12), allowPrivate);
     return inner ? `IPv4-translated ::ffff:0:0:0/96 -> ${inner}` : null;
   }
 
@@ -225,9 +293,13 @@ const blockedIpv6Reason = (bytes: Uint8Array): string | null => {
   // prefix but are the unspecified and loopback addresses, not v4 wrappers.
   if (allZero(bytes, 0, 12)) {
     if (allZero(bytes, 12, 15) && bytes[15] <= 1) {
-      return bytes[15] === 0 ? "::/128 unspecified" : "::1/128 loopback";
+      // `::` (unspecified) is never a real backend and stays blocked in both
+      // postures; `::1` (loopback) is where an internal backend can live, so
+      // the allowPrivate posture permits it.
+      if (bytes[15] === 0) return "::/128 unspecified";
+      return allowPrivate ? null : "::1/128 loopback";
     }
-    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12));
+    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12), allowPrivate);
     return inner ? `IPv4-compatible ::/96 -> ${inner}` : null;
   }
 
@@ -256,13 +328,13 @@ const blockedIpv6Reason = (bytes: Uint8Array): string | null => {
     bytes[3] === 0x9b &&
     allZero(bytes, 4, 12)
   ) {
-    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12));
+    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 12), allowPrivate);
     return inner ? `NAT64 64:ff9b::/96 -> ${inner}` : null;
   }
 
   // 2002::/16 — 6to4 carries the v4 site address in the next four bytes.
   if (bytes[0] === 0x20 && bytes[1] === 0x02) {
-    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 2));
+    const inner = isBlockedSsrfAddress(embeddedIpv4(bytes, 2), allowPrivate);
     return inner ? `6to4 2002::/16 -> ${inner}` : null;
   }
 
@@ -273,7 +345,11 @@ const blockedIpv6Reason = (bytes: Uint8Array): string | null => {
   if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0xc0) {
     return "fec0::/10 site-local (deprecated)";
   }
-  if ((bytes[0] & 0xfe) === 0xfc) return "fc00::/7 unique local";
+  // fc00::/7 unique local is the IPv6 analogue of RFC 1918: an internal
+  // backend can live here, so the allowPrivate posture permits it.
+  if ((bytes[0] & 0xfe) === 0xfc) {
+    return allowPrivate ? null : "fc00::/7 unique local";
+  }
 
   return null;
 };
@@ -286,8 +362,17 @@ const blockedIpv6Reason = (bytes: Uint8Array): string | null => {
  * accepted or a string a resolver returned, so an unrecognisable value means
  * an assumption broke — and the safe reading of a broken assumption on this
  * path is "block".
+ *
+ * `allowPrivate` (default false) permits the private ranges where a trusted,
+ * operator-configured backend legitimately lives (RFC 1918, loopback, and
+ * their IPv6 unique-local/loopback/mapped forms). It NEVER relaxes the ranges
+ * that are never a real backend: the cloud metadata address, CGNAT, multicast,
+ * the unspecified address and the reserved blocks stay blocked either way.
  */
-export const isBlockedSsrfAddress = (address: string): string | null => {
+export const isBlockedSsrfAddress = (
+  address: string,
+  allowPrivate: boolean = false,
+): string | null => {
   const family = isIP(address);
 
   if (family === 4) {
@@ -297,6 +382,7 @@ export const isBlockedSsrfAddress = (address: string): string | null => {
     for (const range of BLOCKED_IPV4_RANGES) {
       const base = ipv4ToInt(range.base);
       if (base !== null && inIpv4Range(value, base, range.prefix)) {
+        if (allowPrivate && range.internalService) return null;
         return `${range.base}/${range.prefix} ${range.why}`;
       }
     }
@@ -306,7 +392,7 @@ export const isBlockedSsrfAddress = (address: string): string | null => {
   if (family === 6) {
     const bytes = ipv6ToBytes(address);
     if (!bytes) return "unparsable IPv6 address";
-    return blockedIpv6Reason(bytes);
+    return blockedIpv6Reason(bytes, allowPrivate);
   }
 
   return "not a recognisable IP address";
@@ -382,6 +468,45 @@ export interface McpUrlGuardOptions {
    * unblocks the attacker's redirect into it instead.
    */
   allowlistOrigin?: string;
+  /**
+   * Permit the private ranges where a trusted, operator-configured backend
+   * legitimately lives (RFC 1918, loopback, IPv6 unique-local) while still
+   * pinning the socket and still refusing the never-a-backend ranges (cloud
+   * metadata, CGNAT, multicast, reserved). The pooled data plane sets this:
+   * its targets are DB-configured internal services, not caller-supplied URLs
+   * like the Inspector's, so blocking every internal address (the default
+   * posture) would refuse every legitimate backend. Off by default so the
+   * Inspector path keeps its strict block-internal / allow-public posture.
+   */
+  allowPrivateAddresses?: boolean;
+  /**
+   * Refuse a redirect to a different origin outright instead of following it
+   * with credentials stripped. The pooled data plane sets this: a
+   * compromised backend answering `302` toward the metadata address or any
+   * other host is the exact vector this closes, and legitimate internal
+   * backends do not cross-origin-redirect. Same-origin redirects are still
+   * followed and re-validated. Off by default so the Inspector keeps
+   * following cross-origin redirects (for example an http->https upgrade
+   * mid-session) with credentials dropped.
+   */
+  refuseCrossOriginRedirect?: boolean;
+  /**
+   * Hard ceiling on the bytes read from a single response body before the
+   * request is aborted, guarding the gateway against a hostile or misbehaving
+   * upstream that streams an unbounded response. Defaults to
+   * `MCP_PROXY_MAX_RESPONSE_BYTES` (100 MiB). For a long-lived SSE stream the
+   * count is cumulative over the connection, so the default is a generous
+   * memory-exhaustion backstop, not an operational limit.
+   */
+  maxResponseBytes?: number;
+  /**
+   * Undici headers-and-body idle timeout (ms) applied to the pinned
+   * dispatcher, defaulting to `MCP_PROXY_REQUEST_TIMEOUT_MS` (300000). It is
+   * an idle timeout, reset on every received chunk, NOT a total-duration cap:
+   * a total cap would kill a legitimately long-lived SSE stream, whereas this
+   * bounds a hung or stalled upstream without that regression.
+   */
+  requestTimeoutMs?: number;
 }
 
 /**
@@ -469,11 +594,13 @@ export const assertPublicMcpUrl = async (
     throw refuse(`${JSON.stringify(hostname)} resolved to nothing`);
   }
 
-  // EVERY answer has to be public. A host that returns one public and one
-  // internal address is a rebinding attempt that got greedy, and connecting is
-  // a coin flip over which record the client picks.
+  // EVERY answer has to be public (or, under allowPrivate, an internal-service
+  // range). A host that returns one allowed and one refused address is a
+  // rebinding attempt that got greedy, and connecting is a coin flip over
+  // which record the client picks.
+  const allowPrivate = options.allowPrivateAddresses ?? false;
   for (const address of addresses) {
-    const blockedBy = isBlockedSsrfAddress(address);
+    const blockedBy = isBlockedSsrfAddress(address, allowPrivate);
     if (blockedBy) {
       throw refuse(`${JSON.stringify(hostname)} resolves into ${blockedBy}`);
     }
@@ -512,14 +639,37 @@ const pinnedLookup =
     callback(null, entries[0].address, entries[0].family);
   };
 
+/** Undici dispatcher timeouts, applied to the pinned Agent. */
+interface DispatcherTimeouts {
+  /** Max ms to receive the response headers. */
+  readonly headersTimeout?: number;
+  /** Max ms of inactivity between body chunks (idle, reset per chunk). */
+  readonly bodyTimeout?: number;
+}
+
 /**
  * An undici dispatcher whose connections can only land on `addresses`.
  *
  * Exported for the test that proves the pin at socket level: given a hostname
  * that cannot resolve at all, a request through this agent still connects.
+ *
+ * `timeouts` bounds a hung or stalled upstream. `bodyTimeout` is undici's idle
+ * timeout (reset on every received chunk), not a total-duration cap, so it
+ * does not sever a legitimately long-lived-but-active SSE stream.
  */
-export const createPinnedAgent = (addresses: string[]): Agent =>
-  new Agent({ connect: { lookup: pinnedLookup(addresses) } });
+export const createPinnedAgent = (
+  addresses: string[],
+  timeouts: DispatcherTimeouts = {},
+): Agent =>
+  new Agent({
+    connect: { lookup: pinnedLookup(addresses) },
+    ...(timeouts.headersTimeout !== undefined
+      ? { headersTimeout: timeouts.headersTimeout }
+      : {}),
+    ...(timeouts.bodyTimeout !== undefined
+      ? { bodyTimeout: timeouts.bodyTimeout }
+      : {}),
+  });
 
 /**
  * What `createGuardedFetch` calls, and the reason it is undici's `fetch` rather
@@ -634,18 +784,99 @@ const FORWARDABLE_ON_ORIGIN_CHANGE = new Set([
  * back-channel endpoint the remote server chooses — is judged with an empty
  * allowlist. Otherwise the entry that unblocks the operator's own internal
  * host also unblocks an attacker's `302` into it.
+ *
+ * THE POOLED DATA PLANE uses a different posture, set through options: its
+ * targets are DB-configured internal services, so `allowPrivateAddresses`
+ * permits the RFC-1918/loopback ranges where they live (the socket is still
+ * pinned and the metadata address is still refused), and
+ * `refuseCrossOriginRedirect` rejects any redirect to another origin outright
+ * rather than following it, because a trusted backend never redirects the
+ * gateway elsewhere and one that tries is answering with a hostile hop.
+ *
+ * EVERY RESPONSE IS BOUNDED. The final body is capped at `maxResponseBytes`
+ * (aborting the request when exceeded) so a hostile or misbehaving upstream
+ * cannot exhaust gateway memory, and the pinned dispatcher carries a
+ * headers/body idle timeout (`requestTimeoutMs`) so a hung upstream cannot
+ * stall a pool slot forever.
  */
+/**
+ * Wrap a response so reading its body aborts the request once `maxBytes` is
+ * exceeded.
+ *
+ * The count is cumulative over the stream, so on a long-lived SSE connection
+ * this is a memory-exhaustion backstop rather than a per-message limit.
+ * `onExceed` tears down the underlying connection (via the request's
+ * AbortController) so undici stops pulling bytes, then the stream errors so the
+ * consumer sees the refusal rather than a silently-truncated body. A body-less
+ * response (204/304 and friends) is returned untouched.
+ */
+const capResponseBody = (
+  response: Response,
+  maxBytes: number,
+  onExceed: () => void,
+): Response => {
+  if (!response.body) return response;
+  const source = response.body.getReader();
+  let seen = 0;
+  const capped = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await source.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        seen += value.byteLength;
+        if (seen > maxBytes) {
+          onExceed();
+          await source.cancel().catch(() => {});
+          logger.warn(
+            "MCP proxy remote URL refused: response exceeded the byte ceiling",
+          );
+          controller.error(new Error(RESPONSE_TOO_LARGE));
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      void source.cancel(reason).catch(() => {});
+    },
+  });
+  const wrapped = new Response(capped, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+  // A constructed Response reports an empty url and redirected=false; restore
+  // both because `eventsource` resolves a relative SSE endpoint against `url`.
+  Object.defineProperty(wrapped, "url", { value: response.url });
+  Object.defineProperty(wrapped, "redirected", {
+    value: response.redirected,
+  });
+  return wrapped;
+};
+
 export const createGuardedFetch = (
   options: McpUrlGuardOptions = {},
 ): FetchLike => {
   const baseFetch = options.baseFetch ?? pinnedFetch;
+  const maxBytes = options.maxResponseBytes ?? maxResponseBytesFromEnv();
+  const timeoutMs = options.requestTimeoutMs ?? requestTimeoutMsFromEnv();
+  const timeouts: DispatcherTimeouts = {
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+  };
 
   /**
    * One dispatcher per validated address set, for the life of this transport.
    * Rebuilding an Agent per request would throw away connection reuse, which
    * on the streamable-HTTP transport is a TLS handshake for every JSON-RPC
    * message. Keyed by the addresses, so a host that legitimately moves gets a
-   * new pool rather than a stale one.
+   * new pool rather than a stale one. An allowlisted host (no addresses) is
+   * trusted by name and not pinned, so it rides the runtime default dispatcher.
    */
   const agents = new Map<string, Agent>();
   const agentFor = (addresses: string[]): Agent | undefined => {
@@ -653,13 +884,22 @@ export const createGuardedFetch = (
     const key = [...addresses].sort().join(",");
     let agent = agents.get(key);
     if (!agent) {
-      agent = createPinnedAgent(addresses);
+      agent = createPinnedAgent(addresses, timeouts);
       agents.set(key, agent);
     }
     return agent;
   };
 
   return async (input, init) => {
+    // Byte-ceiling teardown: an oversized final body aborts THIS request so
+    // undici stops pulling bytes. Chained with any caller-supplied signal so
+    // request cancellation still propagates through the guard.
+    const controller = new AbortController();
+    const signal =
+      init?.signal != null
+        ? AbortSignal.any([init.signal, controller.signal])
+        : controller.signal;
+
     // Hop 0 is the only destination an allowlist entry can speak for, and only
     // when it is the origin the route already validated.
     const firstHopOptions =
@@ -686,6 +926,7 @@ export const createGuardedFetch = (
           body,
           headers,
           redirect: "manual",
+          signal,
         },
         agentFor(target.addresses),
       );
@@ -693,7 +934,11 @@ export const createGuardedFetch = (
       const location = REDIRECT_STATUSES.has(response.status)
         ? response.headers.get("location")
         : null;
-      if (!location) return response;
+      // Only the final (non-redirect) body is capped; redirect bodies are
+      // drained below.
+      if (!location) {
+        return capResponseBody(response, maxBytes, () => controller.abort());
+      }
 
       // Drain the redirect body so the connection is released rather than held
       // open for the life of the chain.
@@ -710,6 +955,21 @@ export const createGuardedFetch = (
       } catch {
         throw refuse("redirect target is not a parsable URL");
       }
+
+      // Pooled posture: a redirect to another origin is refused outright, not
+      // followed with credentials stripped. A trusted internal backend never
+      // redirects the gateway elsewhere, so one that tries is the SSRF hop this
+      // closes; same-origin redirects still fall through and are re-validated.
+      if (
+        options.refuseCrossOriginRedirect &&
+        nextUrl.origin !== target.url.origin
+      ) {
+        logger.warn(
+          "MCP proxy remote URL refused: cross-origin redirect on the pooled path",
+        );
+        throw new Error(CROSS_ORIGIN_REDIRECT_REFUSED);
+      }
+
       const next = await assertPublicMcpUrl(nextUrl, laterHopOptions);
 
       if (

--- a/apps/backend/src/routers/mcp-proxy/server.remote-url.test.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.remote-url.test.ts
@@ -1,8 +1,8 @@
 /**
  * What the REMOTE-URL branches of the mcp-proxy actually connect to.
  *
- * `url-guard.test.ts` next door pins the validator — given a URL, is it a
- * public destination. That is necessary and NOT sufficient, and the gap is why
+ * The `url-guard.test.ts` suite pins the validator (given a URL, is it a
+ * public destination). That is necessary and NOT sufficient, and the gap is why
  * this file exists: a validator can be flawless while the route never calls
  * it, or calls it and connects anyway. Every assertion in that suite keeps
  * passing if the guard is deleted from `createTransport`.
@@ -146,7 +146,7 @@ vi.mock("../../db/index", () => ({ db: {}, pool: {} }));
 vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
 
 const { default: serverRouter } = await import("./server");
-const { NOT_A_PERMITTED_TARGET } = await import("./url-guard");
+const { NOT_A_PERMITTED_TARGET } = await import("@/lib/metamcp/url-guard");
 
 const PUBLIC_V4 = "93.184.216.34";
 

--- a/apps/backend/src/routers/mcp-proxy/server.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.ts
@@ -17,6 +17,10 @@ import express from "express";
 import { findActualExecutable } from "spawn-rx";
 import { z } from "zod";
 
+import {
+  assertPublicMcpUrl,
+  createGuardedFetch,
+} from "@/lib/metamcp/url-guard";
 import logger from "@/utils/logger";
 
 import { mcpServersRepository } from "../../db/repositories";
@@ -28,7 +32,6 @@ import {
   resolveEnvVariables,
 } from "../../lib/metamcp/utils";
 import { ProcessManagedStdioTransport } from "../../lib/stdio-transport/process-managed-transport";
-import { assertPublicMcpUrl, createGuardedFetch } from "./url-guard";
 
 // `x-mcp-actor` is best-effort, client-asserted attribution: it names who an
 // action is on behalf of so backend MCPs (shell-broker, ninja, inventory) can
@@ -508,7 +511,7 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
     const url = transformDockerUrl(query.url as string);
 
     // The destination is caller-supplied, so it is checked BEFORE anything is
-    // opened and before the database is asked about it — see ./url-guard. The
+    // opened and before the database is asked about it (see the url-guard module). The
     // check is by address range rather than by "is this row registered",
     // because pointing the Inspector at a not-yet-saved public server is a
     // flow that has to keep working.
@@ -590,7 +593,7 @@ const createTransport = async (req: express.Request): Promise<Transport> => {
   } else if (transportType === McpServerTypeEnum.enum.STREAMABLE_HTTP) {
     const url = transformDockerUrl(query.url as string);
 
-    // Same destination check as the SSE branch above — see ./url-guard.
+    // Same destination check as the SSE branch above (see the url-guard module).
     const target = await assertPublicMcpUrl(url);
 
     // Same caller-scoped row lookup and same in-memory error-state read as the

--- a/example.env
+++ b/example.env
@@ -379,7 +379,33 @@ MAX_TOTAL_CONNECTIONS=400 # Global backend-connection cap (soft LRU bound). Code
 # that host at the connect URL only. An allowlisted host is trusted by NAME, so
 # it is also the one case where the connection is not pinned to a
 # pre-validated address.
+#
+# THIS ALLOWLIST APPLIES TO THE INSPECTOR PATH ONLY. The pooled data plane
+# (the namespace backends served to connectors) dials DB-configured internal
+# services, so it uses a different posture, not this allowlist: it permits the
+# RFC 1918 / loopback ranges where those backends live (the socket is still
+# pinned to the resolved address and the cloud metadata address is still
+# refused) and it refuses any redirect to another origin outright. No allowlist
+# entry is needed to keep an internal backend connecting.
 # MCP_PROXY_URL_ALLOWED_HOSTS=host.docker.internal
+
+# --- mcp-proxy response size and time caps (optional) ---
+# Both the Inspector's guarded fetch and the pooled data plane bound every
+# upstream response, so a hostile or misbehaving MCP backend cannot exhaust
+# gateway memory or stall a pool slot forever.
+#
+# MCP_PROXY_MAX_RESPONSE_BYTES caps the bytes read from a single response body
+# before the request is aborted (default 104857600, i.e. 100 MiB). It is a
+# memory-exhaustion backstop, not an operational limit; a JSON-RPC response
+# never approaches it. On a long-lived SSE stream the count is cumulative over
+# the connection, so keep the default generous.
+#
+# MCP_PROXY_REQUEST_TIMEOUT_MS is the pinned dispatcher's headers-and-body IDLE
+# timeout in ms (default 300000). It is reset on every received chunk, NOT a
+# total-duration cap, so it bounds a hung or stalled upstream without severing
+# a legitimately long-lived, active SSE stream.
+# MCP_PROXY_MAX_RESPONSE_BYTES=104857600
+# MCP_PROXY_REQUEST_TIMEOUT_MS=300000
 
 # --- NOSUPERUSER runtime database role (optional, off by default) ---
 # WHAT IT FIXES. On the shipped compose stack the gateway connects with


### PR DESCRIPTION
## What and why

The pooled data plane (the namespace backends served to connectors) dialed
remote SSE and Streamable-HTTP backends with the raw global fetch: no
address-range refusal, no redirect re-validation, no DNS pinning, and no
response caps, while the admin Inspector path already went through the shared
url-guard. This closes that asymmetry and fixes two related namespace-assembly
gaps.

## Changes

**Pooled outbound is now guarded and pinned.** The url-guard moves into
`lib/metamcp` so the Inspector and the pool share one validator, and the pool's
outbound fetch routes through it. The pool's targets are operator-configured
internal services, so it runs a different posture from the Inspector:

- `allowPrivateAddresses` permits the RFC 1918 / loopback ranges where internal
  backends live, while the socket is still pinned to the resolved address and
  the cloud metadata address, CGNAT, multicast and reserved blocks stay refused.
- `refuseCrossOriginRedirect` rejects any redirect to another origin outright.
  A trusted backend never redirects the gateway elsewhere, and following one
  would carry the row's stored bearer to the redirect target.

The M365 injected fetch now composes over the guarded fetch: injection sets the
per-user Authorization, then the guarded fetch validates, pins and caps the
actual connection.

**Response byte ceiling and idle timeout.** Both the guarded fetch and the pool
fetch bound every upstream response so a hostile or misbehaving backend cannot
exhaust gateway memory or stall a pool slot forever. Both are env-configurable
with documented defaults (`MCP_PROXY_MAX_RESPONSE_BYTES` default 100 MiB,
`MCP_PROXY_REQUEST_TIMEOUT_MS` default 300000). The byte count is cumulative
over a connection, so on a long-lived SSE stream it is a memory-exhaustion
backstop rather than a per-message limit; the timeout is undici's idle timeout
(reset per received chunk), not a total-duration cap, so it does not sever a
legitimately long-lived active stream.

**Cross-server tool-name collision guard.** The routing maps are keyed on
`sanitizeName(serverName)__toolName`. Two servers in one namespace whose names
sanitize to the same prefix and expose the same tool name overwrote each other
last-writer-wins, silently routing a call to the wrong backend. Assembly now
keeps the first registration, drops the duplicate, and logs a warning naming
both servers so the operator can rename one.

**Namespace tool-status fails closed.** Tool enable/disable enforcement now
fails closed on a DB error and on an unresolved server name, on both the list
and call sides, matching the access-group gate's direction; the two layers
previously disagreed (this side failed open).

## Deviation from the proposed fix

The proposed fix offered either an explicit host allowlist of the known-internal
backends or an outright cross-origin-redirect refusal. This does both, and uses
a range-based `allowPrivateAddresses` posture rather than an enumerated host
allowlist: the pool's backends are DB-configured by the operator and change over
time, so an enumerated allowlist would be brittle and would need editing on
every new backend, whereas the range posture permits the operator's private
fabric while still pinning the socket, still refusing the metadata address, and
now also refusing cross-origin redirects. The existing
`MCP_PROXY_URL_ALLOWED_HOSTS` env allowlist remains for explicit name-trust
exemptions on the Inspector path.

## Tests

- `url-guard.test.ts`: the private/public range matrix, the allowPrivate
  relaxation (permits RFC 1918 / loopback, still blocks metadata / CGNAT /
  multicast / unspecified / link-local), the cross-origin-redirect refusal,
  the response-byte ceiling, and socket-level DNS pinning.
- `tool-name-parser.test.ts`: the collision decision (same-name different-server
  is a collision, re-list of the same server is not).
- `filter-tools.functional.test.ts`: fail-closed on unresolved server and DB
  error, list and call sides, with the happy paths held.
- Existing `client.test.ts` and `server.remote-url.test.ts` updated for the new
  transport wiring and the moved module.

Each behavior test was confirmed to fail against the prior behavior before the
fix was in place.

Full backend suite: 2159 passed, 101 skipped, 0 failed. Frontend: 38 passed.
`check-types` and eslint (`--max-warnings 0`) clean.

## Deploy notes

- The guarded fetch introduces the first use of `AbortSignal.any` in the
  backend, which needs Node >= 20.3. The Docker base installs Node 20.x, so the
  production runtime is fine; the root `engines` still reads `>=18`.
- Fail-closed tool-status means that during a primary-DB outage, curated tools
  are excluded from listings and denied on call rather than served. This is the
  operator decision; a primary-DB outage already degrades the gateway broadly.
- The pool response byte ceiling is cumulative per connection; a very high
  volume SSE backend may see periodic reconnects at the default 100 MiB.
  Operators can raise `MCP_PROXY_MAX_RESPONSE_BYTES`.

https://claude.ai/code/session_01GLGuUof88SHr6kxCUqzyE7
