### PR TITLE
feat(security): app-wide security headers and Swagger hardening

### DIFF
--- a/apps/backend/src/app-security-headers.test.ts
+++ b/apps/backend/src/app-security-headers.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Every backend response must carry a security-header baseline, not only the
+ * per-router /trpc and /mcp-proxy legs. index.ts now mounts helmet app-wide
+ * ahead of the routers so /api/auth, /health and /metamcp answer with nosniff,
+ * frame denial and a default CSP too.
+ *
+ * index.ts calls app.listen() at module scope and cannot be imported by a test
+ * (the same constraint that moved the body-parser wiring into a module and is
+ * pinned the same way in x-powered-by.test.ts). So this pins the mechanism the
+ * one line relies on over a real socket: an app with the app-wide helmet
+ * emits the baseline on a plain route, and a default app (the pre-fix control)
+ * does not. Deleting the app-wide mount reintroduces the control behaviour.
+ */
+
+import type { Server } from "node:http";
+
+import express from "express";
+import helmet from "helmet";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+async function startApp(withHelmet: boolean): Promise<{
+  server: Server;
+  baseUrl: string;
+}> {
+  const app = express();
+  if (withHelmet) {
+    // The same app-wide mount index.ts uses, ahead of the route below.
+    app.use(helmet());
+  }
+  app.get("/health", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, "127.0.0.1", () => resolve(s));
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return { server, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+let hardened: { server: Server; baseUrl: string };
+let control: { server: Server; baseUrl: string };
+
+beforeAll(async () => {
+  hardened = await startApp(true);
+  control = await startApp(false);
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => hardened.server.close(resolve));
+  await new Promise((resolve) => control.server.close(resolve));
+});
+
+describe("app-wide security headers", () => {
+  it("adds the baseline to a plain route the way index.ts does", async () => {
+    const response = await fetch(`${hardened.baseUrl}/health`);
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("SAMEORIGIN");
+    expect(response.headers.get("content-security-policy")).toBeTruthy();
+  });
+
+  it("a default app carries none of it, so the test guards a real change", async () => {
+    const response = await fetch(`${control.baseUrl}/health`);
+    expect(response.headers.get("x-content-type-options")).toBeNull();
+    expect(response.headers.get("x-frame-options")).toBeNull();
+    expect(response.headers.get("content-security-policy")).toBeNull();
+  });
+});

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import helmet from "helmet";
 
 import { verifyRuntimeDatabaseRole } from "./db/runtime-role-check";
 import { authApiCorsMiddleware } from "./lib/cors-policy";
@@ -49,6 +50,19 @@ app.use(auditContextMiddleware);
 // real ones were deleted. See that module's header for what each lane does and
 // why the OAuth skip is what makes the 256kb router limit bind at all.
 app.use(globalBodyParser);
+
+// App-wide security response headers, ahead of every router. helmet was only
+// mounted per-router on /trpc and /mcp-proxy, so the /api/auth relay (which
+// answers with the session cookie), /health, /metamcp and the OAuth surface
+// each carried whatever the framework left behind: no nosniff, no frame
+// denial, no default CSP. Mounting it here gives them all the same baseline in
+// one place. It sits BEFORE the routers on purpose: the OAuth router's own
+// securityHeaders and the per-router helmet still run afterwards and override
+// the specific headers they set (X-Frame-Options DENY, the OAuth CSP), so this
+// only fills the gaps and never weakens their tighter values. It does not touch
+// the request body or CORS, so the deliberate /api/auth CORS policy mounted
+// below is unaffected.
+app.use(helmet());
 
 // Mount OAuth metadata endpoints at root level for .well-known discovery
 app.use(oauthRouter);

--- a/apps/backend/src/routers/public-metamcp/openapi/routes.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/routes.ts
@@ -11,6 +11,11 @@ import { metaMcpServerPool } from "../../../lib/metamcp/metamcp-server-pool";
 import { lookupEndpoint } from "../../../middleware/lookup-endpoint-middleware";
 import { createMiddlewareEnabledHandlers } from "./handlers";
 import { generateOpenApiSchema } from "./schema-generator";
+import {
+  renderSwaggerUiHtml,
+  swaggerUiCsp,
+  swaggerUiNonce,
+} from "./swagger-ui";
 import { executeToolWithMiddleware } from "./tool-execution";
 import { ToolExecutionRequest } from "./types";
 
@@ -24,54 +29,16 @@ openApiRouter.get(
   async (req, res) => {
     const { endpointName } = req as ApiKeyAuthenticatedRequest;
 
-    // Return a simple HTML page with Swagger UI
-    const html = `
-<!DOCTYPE html>
-<html>
-<head>
-    <title>${endpointName} API Documentation</title>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@5.10.3/swagger-ui.css" />
-    <style>
-        html {
-            box-sizing: border-box;
-            overflow: -moz-scrollbars-vertical;
-            overflow-y: scroll;
-        }
-        *, *:before, *:after {
-            box-sizing: inherit;
-        }
-        body {
-            margin: 0;
-            background: #fafafa;
-        }
-    </style>
-</head>
-<body>
-    <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5.10.3/swagger-ui-bundle.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist@5.10.3/swagger-ui-standalone-preset.js"></script>
-    <script>
-        window.onload = function() {
-            const ui = SwaggerUIBundle({
-                url: '/metamcp/${endpointName}/api/openapi.json',
-                dom_id: '#swagger-ui',
-                deepLinking: true,
-                presets: [
-                    SwaggerUIBundle.presets.apis,
-                    SwaggerUIStandalonePreset
-                ],
-                plugins: [
-                    SwaggerUIBundle.plugins.DownloadUrl
-                ],
-                layout: "StandaloneLayout"
-            });
-        }
-    </script>
-</body>
-</html>`;
-
+    // Build the Swagger UI page from the escaping/SRI/CSP-aware builder. The
+    // endpoint name comes from the request URL, so it is escaped there; the one
+    // inline script gets a per-response nonce that the CSP below authorises, and
+    // the CDN assets are integrity-pinned. See ./swagger-ui.
+    const nonce = swaggerUiNonce();
     res.setHeader("Content-Type", "text/html");
-    res.send(html);
+    res.setHeader("Content-Security-Policy", swaggerUiCsp(nonce));
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.send(renderSwaggerUiHtml(endpointName, nonce));
   },
 );
 

--- a/apps/backend/src/routers/public-metamcp/openapi/swagger-ui.test.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/swagger-ui.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The Swagger UI page interpolates the endpoint name from the request URL and
+ * loads swagger-ui from a CDN. These pin the three hardenings: the name is
+ * escaped in both the HTML title and the inline script, the CDN assets carry
+ * Subresource Integrity, and the inline bootstrap runs under a nonce the
+ * response CSP authorises with no 'unsafe-inline' for scripts.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  renderSwaggerUiHtml,
+  SWAGGER_UI_CDN_ORIGIN,
+  swaggerUiCsp,
+  swaggerUiNonce,
+} from "./swagger-ui";
+
+describe("renderSwaggerUiHtml escaping", () => {
+  // Endpoint names are charset-restricted upstream; this hostile value proves
+  // the escaping holds if that rule is ever loosened.
+  const hostile = 'a"><script>alert(1)</script>';
+  const html = renderSwaggerUiHtml(hostile, "NONCE123");
+
+  it("does not emit the raw injection payload anywhere", () => {
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("HTML-escapes the name in the title", () => {
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("neutralises a script-closing sequence inside the inline bootstrap", () => {
+    // The openapi.json URL is JSON-encoded with `<` escaped, so a `</script>`
+    // in the name cannot close the element.
+    expect(html).toContain("\\u003c/script>");
+  });
+});
+
+describe("renderSwaggerUiHtml integrity and nonce", () => {
+  const html = renderSwaggerUiHtml("weather", "NONCE123");
+
+  it("pins Subresource Integrity on all three CDN assets", () => {
+    const integrityCount = (html.match(/integrity="sha384-/g) || []).length;
+    expect(integrityCount).toBe(3);
+    expect(html).toContain('crossorigin="anonymous"');
+  });
+
+  it("only loads swagger-ui from the pinned CDN origin", () => {
+    const cdnRefs = html.match(/https:\/\/unpkg\.com/g) || [];
+    expect(cdnRefs.length).toBeGreaterThan(0);
+    expect(html).toContain(`${SWAGGER_UI_CDN_ORIGIN}/swagger-ui-dist@`);
+  });
+
+  it("puts the nonce on the inline script only", () => {
+    expect(html).toContain('<script nonce="NONCE123">');
+  });
+
+  it("mints a fresh, non-empty nonce each call", () => {
+    expect(swaggerUiNonce()).not.toBe(swaggerUiNonce());
+    expect(swaggerUiNonce().length).toBeGreaterThan(0);
+  });
+});
+
+describe("swaggerUiCsp", () => {
+  const csp = swaggerUiCsp("NONCE123");
+
+  it("authorises the inline script by nonce, never by unsafe-inline", () => {
+    const scriptSrc = csp
+      .split(";")
+      .map((d) => d.trim())
+      .find((d) => d.startsWith("script-src"));
+    expect(scriptSrc).toContain("'nonce-NONCE123'");
+    expect(scriptSrc).toContain(SWAGGER_UI_CDN_ORIGIN);
+    expect(scriptSrc).not.toContain("unsafe-inline");
+  });
+
+  it("denies framing", () => {
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+});

--- a/apps/backend/src/routers/public-metamcp/openapi/swagger-ui.ts
+++ b/apps/backend/src/routers/public-metamcp/openapi/swagger-ui.ts
@@ -1,0 +1,140 @@
+import crypto from "node:crypto";
+
+/**
+ * The Swagger UI documentation page, built as a pure function so its escaping,
+ * its Subresource Integrity pins and its Content-Security-Policy are all
+ * testable without a live endpoint, an API key or the MCP pool the route needs.
+ *
+ * The page loads swagger-ui from a CDN. Three things harden that:
+ *
+ *  1. The endpoint name is interpolated from the request URL, so it is HTML
+ *     escaped in the title and JSON-escaped (with `<` neutralised so it cannot
+ *     close the script element) in the inline bootstrap. Endpoint names are
+ *     charset-restricted to `[A-Za-z0-9_-]` and matched exactly upstream, so
+ *     this is defense in depth against a future loosening of that rule, not a
+ *     live hole.
+ *  2. Every CDN asset carries a Subresource Integrity hash, so a swapped or
+ *     compromised CDN artifact is refused by the browser instead of executing
+ *     in an admin's session.
+ *  3. The response carries its own CSP. The single inline script gets a
+ *     per-response nonce; everything else is `'self'` or the pinned CDN.
+ */
+
+// Pinned swagger-ui-dist version. The SRI hashes below are for exactly this
+// version's files; bumping it means recomputing all three with
+// `openssl dgst -sha384 -binary <file> | openssl base64 -A`.
+export const SWAGGER_UI_VERSION = "5.10.3";
+
+export const SWAGGER_UI_CDN_ORIGIN = "https://unpkg.com";
+const CDN_BASE = `${SWAGGER_UI_CDN_ORIGIN}/swagger-ui-dist@${SWAGGER_UI_VERSION}`;
+
+// sha384 SRI for the pinned assets, cross-checked against a second CDN.
+const SRI = {
+  css: "sha384-h0W3Vqg5Snxbn56nHu/JCHYsKdSuoEcQneezEWEYGsAdajQJkgD+v9Qy8cuv/1bA",
+  bundle:
+    "sha384-jVJWQ0wtFEKcwLYTTe3ZTkA8DbVK3s5bLmxjc30v16evmnx8m4NYVsc52bA+qIUl",
+  standalone:
+    "sha384-azzkurII4f+bjmZvm3hWhj7JezshyXtwobwneRyWCCIksK61Xi0Ry3xA2am9/TWp",
+} as const;
+
+/** HTML-escape a value for text and double-quoted attribute contexts. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Encode a value as a JS string literal safe to embed inside `<script>`.
+ * JSON.stringify handles quotes, backslashes and control characters; the extra
+ * `<` escape stops a `</script>` (or `<!--`) in the value from closing the
+ * script element, which JSON alone would not.
+ */
+function jsStringLiteral(value: string): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+/** A per-response nonce for the one inline script. */
+export function swaggerUiNonce(): string {
+  return crypto.randomBytes(16).toString("base64");
+}
+
+/**
+ * The CSP for the Swagger UI response. default-src 'self' is the floor;
+ * script-src adds the nonce and the pinned CDN (no 'unsafe-inline'); style-src
+ * keeps 'unsafe-inline' because swagger-ui injects styles at runtime. The page
+ * is framed by no one and frames no one.
+ */
+export function swaggerUiCsp(nonce: string): string {
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    `script-src 'self' 'nonce-${nonce}' ${SWAGGER_UI_CDN_ORIGIN}`,
+    `style-src 'self' 'unsafe-inline' ${SWAGGER_UI_CDN_ORIGIN}`,
+    `img-src 'self' data: ${SWAGGER_UI_CDN_ORIGIN}`,
+    `font-src 'self' data: ${SWAGGER_UI_CDN_ORIGIN}`,
+    "connect-src 'self'",
+  ].join("; ");
+}
+
+/** Build the Swagger UI HTML page for one endpoint, with the given nonce. */
+export function renderSwaggerUiHtml(
+  endpointName: string,
+  nonce: string,
+): string {
+  const titleName = escapeHtml(endpointName);
+  const openApiUrl = jsStringLiteral(
+    `/metamcp/${endpointName}/api/openapi.json`,
+  );
+
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>${titleName} API Documentation</title>
+    <link rel="stylesheet" type="text/css" href="${CDN_BASE}/swagger-ui.css" integrity="${SRI.css}" crossorigin="anonymous" />
+    <style>
+        html {
+            box-sizing: border-box;
+            overflow: -moz-scrollbars-vertical;
+            overflow-y: scroll;
+        }
+        *, *:before, *:after {
+            box-sizing: inherit;
+        }
+        body {
+            margin: 0;
+            background: #fafafa;
+        }
+    </style>
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="${CDN_BASE}/swagger-ui-bundle.js" integrity="${SRI.bundle}" crossorigin="anonymous"></script>
+    <script src="${CDN_BASE}/swagger-ui-standalone-preset.js" integrity="${SRI.standalone}" crossorigin="anonymous"></script>
+    <script nonce="${nonce}">
+        window.onload = function() {
+            const ui = SwaggerUIBundle({
+                url: ${openApiUrl},
+                dom_id: '#swagger-ui',
+                deepLinking: true,
+                presets: [
+                    SwaggerUIBundle.presets.apis,
+                    SwaggerUIStandalonePreset
+                ],
+                plugins: [
+                    SwaggerUIBundle.plugins.DownloadUrl
+                ],
+                layout: "StandaloneLayout"
+            });
+        }
+    </script>
+</body>
+</html>`;
+}

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -2,12 +2,14 @@ import "./globals.css";
 
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { headers } from "next/headers";
 import { PublicEnvScript } from "next-runtime-env";
 import { Toaster } from "sonner";
 
 import { ThemeProvider } from "../components/providers/theme-provider";
 import { TRPCProvider } from "../components/providers/trpc-provider";
 import { getBranding } from "../lib/branding";
+import { NONCE_HEADER } from "../lib/security-headers";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -42,14 +44,22 @@ interface RootLayoutProps {
   children: React.ReactNode;
 }
 
-export default function RootLayout({ children }: RootLayoutProps) {
+export default async function RootLayout({ children }: RootLayoutProps) {
+  // The CSP nonce minted per request in middleware.ts. Next nonces the scripts
+  // it renders itself once it sees the nonce in the request's CSP header; these
+  // two inline scripts are the ones it does not own: the runtime-env
+  // bootstrap that publishes NEXT_PUBLIC_* to the browser, and the theme
+  // anti-flash script, so the nonce is passed to them by hand. Without it both
+  // are inline scripts with no nonce and `script-src` blocks them. See
+  // ../lib/security-headers.
+  const nonce = (await headers()).get(NONCE_HEADER) ?? undefined;
   return (
     <html suppressHydrationWarning>
       <head>
-        <PublicEnvScript />
+        <PublicEnvScript nonce={nonce} />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <ThemeProvider>
+        <ThemeProvider nonce={nonce}>
           <TRPCProvider>
             {children}
             <Toaster richColors position="top-right" closeButton />

--- a/apps/frontend/lib/security-headers.test.ts
+++ b/apps/frontend/lib/security-headers.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The document CSP holds the script side strict: an inline-script injection is
+ * how the transiently-stored downstream MCP OAuth tokens would be read out of
+ * sessionStorage, so `script-src` must never carry 'unsafe-inline', and it must
+ * not carry 'unsafe-eval' in production, only 'self' plus the per-request
+ * nonce. These pin that shape so a later "just add 'unsafe-inline' to fix a
+ * script" reintroduces the hole loudly. The one env-dependent relaxation
+ * ('unsafe-eval' for `next dev`) is pinned to production-off / development-on.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildContentSecurityPolicy, NONCE_HEADER } from "./security-headers";
+
+function cspForEnv(env: string): string {
+  vi.stubEnv("NODE_ENV", env);
+  try {
+    return buildContentSecurityPolicy("TESTNONCE==");
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+function directive(csp: string, name: string): string | undefined {
+  return csp
+    .split(";")
+    .map((d) => d.trim())
+    .find((d) => d.startsWith(name));
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("buildContentSecurityPolicy (production)", () => {
+  const csp = cspForEnv("production");
+
+  it("carries the nonce in script-src and nothing looser", () => {
+    expect(csp).toContain("script-src 'self' 'nonce-TESTNONCE=='");
+  });
+
+  it("never allows unsafe-inline or unsafe-eval for scripts", () => {
+    const scriptSrc = directive(csp, "script-src");
+    expect(scriptSrc).toBeDefined();
+    expect(scriptSrc).not.toContain("unsafe-inline");
+    expect(scriptSrc).not.toContain("unsafe-eval");
+  });
+
+  it("keeps default-src, object-src and base-uri locked down", () => {
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'self'");
+  });
+
+  it("denies framing in both directions and pins form-action", () => {
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("frame-src 'none'");
+    expect(csp).toContain("form-action 'self'");
+  });
+
+  it("keeps connect-src same-origin", () => {
+    expect(csp).toContain("connect-src 'self'");
+  });
+
+  it("allows unsafe-inline for styles only, not scripts", () => {
+    const styleSrc = directive(csp, "style-src");
+    // Radix/toast/theme set inline style ATTRIBUTES a nonce cannot cover, so
+    // style-src must keep 'unsafe-inline'. It must not also carry a nonce, or
+    // browsers ignore 'unsafe-inline' next to it.
+    expect(styleSrc).toContain("'unsafe-inline'");
+    expect(styleSrc).not.toContain("nonce-");
+  });
+
+  it("exposes the nonce request-header name", () => {
+    expect(NONCE_HEADER).toBe("x-nonce");
+  });
+});
+
+describe("buildContentSecurityPolicy (development)", () => {
+  const csp = cspForEnv("development");
+
+  it("adds 'unsafe-eval' so `next dev` can run, but never 'unsafe-inline'", () => {
+    const scriptSrc = directive(csp, "script-src");
+    expect(scriptSrc).toContain("'unsafe-eval'");
+    expect(scriptSrc).not.toContain("unsafe-inline");
+    expect(scriptSrc).toContain("'nonce-TESTNONCE=='");
+  });
+});

--- a/apps/frontend/lib/security-headers.ts
+++ b/apps/frontend/lib/security-headers.ts
@@ -1,0 +1,74 @@
+/**
+ * The application-wide Content-Security-Policy for the Next.js pages.
+ *
+ * WHY THIS IS A MODULE AND NOT A LINE IN next.config.js. The policy has to be
+ * strict on scripts (no `'unsafe-inline'`, no `'unsafe-eval'`) because the
+ * authenticated UI transiently holds downstream MCP OAuth tokens in
+ * sessionStorage, and an inline-script injection is exactly how those would be
+ * read out. A static `headers()` entry in next.config cannot express that: the
+ * app ships inline bootstrap scripts (Next's own hydration runtime, the
+ * `next-runtime-env` beforeInteractive env script, and `next-themes`'
+ * anti-flash script), so the only way to allow those specific scripts while
+ * still banning arbitrary inline script is a per-request nonce. A nonce is not
+ * a constant, so it cannot live in next.config; it is minted per request in
+ * middleware.ts, the only layer that runs before the document is rendered. The
+ * remaining, value-less headers (frame options, nosniff, referrer policy,
+ * permissions policy) DO live in next.config `headers()` so they also cover
+ * static assets. This module is the single source of truth for the policy
+ * string so middleware and its test agree on exactly one thing.
+ */
+
+/**
+ * The request header middleware stamps the per-request nonce onto. Next reads
+ * the nonce out of the request's CSP header on its own to nonce the framework
+ * scripts; this header is how the server components (the root layout) read the
+ * same value to nonce the third-party inline scripts Next does not own.
+ */
+export const NONCE_HEADER = "x-nonce";
+
+/**
+ * Build the CSP for a document response, given the request's nonce.
+ *
+ * script-src is `'self'` plus the nonce and nothing else: no `'unsafe-inline'`
+ * (that would defeat the whole control) and no `'unsafe-eval'` (production Next
+ * needs neither). Every inline script the page emits carries the nonce, so
+ * this bans injected inline script without breaking the app.
+ *
+ * style-src keeps `'unsafe-inline'` deliberately. The component layer (Radix
+ * primitives, the toast library, the theme switch) sets inline `style="..."`
+ * attributes at runtime, and a nonce cannot cover a style ATTRIBUTE, only a
+ * `<style>` element, so the alternative to `'unsafe-inline'` here is a broken
+ * layout, not a tighter policy. Style injection is not the credential-exfil
+ * vector script injection is, which is why the script side is the one held
+ * strict. A nonce next to `'unsafe-inline'` in style-src makes browsers ignore
+ * `'unsafe-inline'`, so the two must not be combined.
+ *
+ * connect-src is `'self'`: every fetch, tRPC call and MCP inspector transport
+ * goes to this same origin (the MCP proxy is reached at the app's own URL, not
+ * the backend host directly). frame-ancestors and frame-src are `'none'`: the
+ * app frames nothing and must not be framed. form-action and base-uri are
+ * `'self'`, object-src is `'none'`.
+ *
+ * script-src gains `'unsafe-eval'` OUTSIDE production only. `next dev`
+ * (Turbopack, React Fast Refresh) evaluates modules with eval and cannot run
+ * under a policy that forbids it, so a strict-in-every-env policy would break
+ * local development. A production build never evals, so production keeps script
+ * execution to `'self'` plus the per-request nonce with no eval escape. The
+ * gate is read at call time so a test can pin either environment.
+ */
+export function buildContentSecurityPolicy(nonce: string): string {
+  const devEval = process.env.NODE_ENV === "production" ? "" : " 'unsafe-eval'";
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+    "form-action 'self'",
+    `script-src 'self' 'nonce-${nonce}'${devEval}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+  ].join("; ");
+}

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,6 +1,11 @@
 import { betterFetch } from "@better-fetch/fetch";
 import { NextRequest, NextResponse } from "next/server";
 
+import {
+  buildContentSecurityPolicy,
+  NONCE_HEADER,
+} from "./lib/security-headers";
+
 const locales = ["en", "zh", "ko"];
 const defaultLocale = "en";
 
@@ -87,6 +92,31 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Per-request CSP nonce. The policy bans inline script except by nonce, and a
+  // nonce cannot be a static next.config value, so it is minted here, the only
+  // layer that runs before the document is rendered. It is stamped on the
+  // request's CSP header (Next reads it there to nonce the framework hydration
+  // scripts) and on `x-nonce` (the root layout reads it there to nonce the
+  // third-party inline scripts Next does not own: the runtime-env script and
+  // the theme anti-flash script). See ./lib/security-headers.
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = buildContentSecurityPolicy(nonce);
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(NONCE_HEADER, nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  // A document render: carry the nonce forward to the renderer via the request
+  // headers, and the policy back to the browser on the response. Only the
+  // page-rendering branches below use this; the redirect branches return a
+  // bodyless 307 whose destination gets its own pass through this middleware.
+  const renderDocument = () => {
+    const response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+    response.headers.set("Content-Security-Policy", csp);
+    return response;
+  };
+
   // Handle i18n routing first
   const pathnameHasLocale = locales.some(
     (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
@@ -110,7 +140,7 @@ export async function middleware(request: NextRequest) {
   // Now handle authentication for the pathname without locale
   const publicRoutes = ["/login", "/register", "/", "/cors-error"];
   if (publicRoutes.includes(pathnameWithoutLocale)) {
-    return NextResponse.next();
+    return renderDocument();
   }
 
   try {
@@ -142,7 +172,7 @@ export async function middleware(request: NextRequest) {
       );
     }
 
-    return NextResponse.next();
+    return renderDocument();
   } catch (error) {
     console.error("Auth middleware error:", error);
     // On error, redirect to login (with locale)

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -10,21 +10,44 @@ const nextConfig = {
     proxyTimeout: 1000 * 120,
   },
   async headers() {
+    // The value-less security headers, applied to EVERY response, documents
+    // and /_next static assets alike. The Content-Security-Policy is NOT here:
+    // it carries a per-request nonce and is emitted from middleware.ts, because
+    // a static config value cannot hold a nonce and the strict script policy
+    // (no 'unsafe-inline') needs one. See lib/security-headers.ts.
+    //
+    // This replaces the former /consent-only block. Every page, /consent
+    // included, now gets the full nonce'd CSP through middleware plus these
+    // headers. /consent's former Referrer-Policy of no-referrer becomes
+    // strict-origin-when-cross-origin, which still keeps the signed `areq`
+    // query string from leaking cross-origin (only the bare origin is sent),
+    // and the CSP now also bars /consent from loading any cross-origin
+    // subresource that a referrer could leak to.
+    const securityHeaders = [
+      { key: "X-Frame-Options", value: "DENY" },
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=()",
+      },
+    ];
+
+    // HSTS only in production. The edge terminates TLS and owns the HSTS ramp;
+    // this is defense in depth for any direct-to-origin reach. Gated off in
+    // development so `next dev` over http://localhost is not force-upgraded to
+    // https.
+    if (process.env.NODE_ENV === "production") {
+      securityHeaders.push({
+        key: "Strict-Transport-Security",
+        value: "max-age=63072000; includeSubDomains",
+      });
+    }
+
     return [
       {
-        // The OAuth consent screen is the trust anchor of the authorization
-        // flow: it is where a human decides whether a client gets access to
-        // their account. Framing it would allow a clickjacked Approve, and a
-        // referrer leak would hand the signed `areq` token in the query string
-        // to whatever the page links or fetches. The backend's own /oauth/*
-        // routes get these from securityHeaders in the express router; this
-        // page is served by Next.js and had none.
-        source: "/:locale/consent",
-        headers: [
-          { key: "X-Frame-Options", value: "DENY" },
-          { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
-          { key: "Referrer-Policy", value: "no-referrer" },
-        ],
+        source: "/:path*",
+        headers: securityHeaders,
       },
     ];
   },

--- a/apps/frontend/next.config.test.ts
+++ b/apps/frontend/next.config.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The value-less security headers live in next.config's headers() so they cover
+ * static assets too, while the nonce'd CSP is emitted from middleware. These
+ * pin the static set on /:path* and the production-only HSTS gate.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import nextConfig from "./next.config.js";
+
+type HeaderEntry = { key: string; value: string };
+type HeaderRule = { source: string; headers: HeaderEntry[] };
+
+async function rulesForEnv(env: string): Promise<HeaderRule[]> {
+  // headers() reads NODE_ENV at call time; stubEnv sets it without tripping the
+  // read-only NODE_ENV type.
+  vi.stubEnv("NODE_ENV", env);
+  try {
+    return await (
+      nextConfig as { headers: () => Promise<HeaderRule[]> }
+    ).headers();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+describe("next.config headers()", () => {
+  it("applies the static security headers to every path", async () => {
+    const rules = await rulesForEnv("development");
+    const global = rules.find((r) => r.source === "/:path*");
+    expect(global).toBeDefined();
+    const byKey = new Map(global!.headers.map((h) => [h.key, h.value]));
+    expect(byKey.get("X-Frame-Options")).toBe("DENY");
+    expect(byKey.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(byKey.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(byKey.get("Permissions-Policy")).toContain("geolocation=()");
+  });
+
+  it("does not set a static CSP here (the nonce'd CSP is middleware's job)", async () => {
+    const rules = await rulesForEnv("production");
+    const global = rules.find((r) => r.source === "/:path*");
+    const keys = global!.headers.map((h) => h.key);
+    expect(keys).not.toContain("Content-Security-Policy");
+  });
+
+  it("sends HSTS only in production", async () => {
+    const dev = await rulesForEnv("development");
+    const devGlobal = dev.find((r) => r.source === "/:path*")!;
+    expect(
+      devGlobal.headers.some((h) => h.key === "Strict-Transport-Security"),
+    ).toBe(false);
+
+    const prod = await rulesForEnv("production");
+    const prodGlobal = prod.find((r) => r.source === "/:path*")!;
+    const hsts = prodGlobal.headers.find(
+      (h) => h.key === "Strict-Transport-Security",
+    );
+    expect(hsts?.value).toContain("max-age=");
+    expect(hsts?.value).toContain("includeSubDomains");
+  });
+});


### PR DESCRIPTION
## What and why

The Next.js pages carried no security headers except a partial clickjacking
set on /consent, helmet was mounted only on /trpc and /mcp-proxy, and the
Swagger UI page interpolated the endpoint name unescaped into HTML and an
inline script while loading swagger-ui from a CDN with no Subresource
Integrity. This closes all three at the right layer.

## Frontend: app-wide headers plus a real CSP

- next.config.js: the /consent-only block becomes a global set on `/:path*`
  (X-Frame-Options DENY, X-Content-Type-Options nosniff, Referrer-Policy
  strict-origin-when-cross-origin, a minimal Permissions-Policy, and HSTS in
  production only so `next dev` over http is not force-upgraded). /consent now
  gets the full policy like every other page.
- middleware.ts + lib/security-headers.ts: the Content-Security-Policy is
  emitted per request from middleware because it carries a per-request nonce,
  which a static config value cannot hold. `script-src` is `'self'` plus the
  nonce, with no `'unsafe-inline'` and no `'unsafe-eval'` in production. Next
  nonces its own framework scripts from the request CSP header; the two
  third-party inline scripts Next does not own (the runtime-env bootstrap and
  the theme anti-flash script) are handed the same nonce in app/layout.tsx.
  `'unsafe-eval'` is added outside production only, because the dev server
  evaluates modules with eval and would otherwise break.
- `style-src` keeps `'unsafe-inline'`: the component layer sets inline style
  attributes a nonce cannot cover, so the alternative is a broken layout, not
  a tighter policy. The script side, which is the credential-exfil vector, is
  the one held strict. `connect-src` is `'self'`: every client fetch, tRPC
  call and MCP transport is same-origin (verified: the tRPC client uses a
  relative `/trpc` URL and all cross-service paths are same-origin rewrites).

## Backend: helmet app-wide

- index.ts mounts helmet ahead of the routers so the /api/auth relay,
  /health and /metamcp responses carry the same baseline previously only on
  /trpc and /mcp-proxy. It sits before the routers so the OAuth route header
  set and the per-router helmet still override their specific values, and it
  does not touch the request body or the deliberate /api/auth CORS policy.

## Swagger UI

- The page moves into a tested builder (swagger-ui.ts). The endpoint name is
  HTML-escaped in the title and JS-escaped (with `<` neutralised) in the
  inline bootstrap; the response serves its own CSP with a per-response nonce
  for the single inline script; the CDN assets carry Subresource Integrity
  hashes. The three sha384 hashes were computed from the pinned upstream
  files and match exactly. The CDN-plus-SRI route was chosen over self-hosting
  to avoid a new runtime dependency and a static-serve path; SRI refuses a
  tampered artifact and the response CSP pins script execution to the nonce
  and that one origin.

## Tests

- Frontend vitest (6 files, 49 tested) and backend vitest (142 files,
  2131 tested) pass. New coverage: the production and development CSP shape,
  the static header set and production-only HSTS, the app-wide helmet
  baseline against a no-helmet control, and the Swagger escaping, integrity
  and nonce. `check-types` passes.
- Runtime verification: a production build succeeds, and a headless-Chromium
  load of the login page reports zero CSP violations with every one of its
  script tags carrying the nonce the response CSP authorizes. The
  authenticated shell pages share the same layout and providers plus
  same-origin tRPC, which the login-page result and source review cover; they
  were not loaded directly because that needs the full stack and a seeded
  session.

## Notes for review

- Backend style-src: the shared backend security-headers keep `style-src
  'unsafe-inline'` because the M365 enrollment result page renders an inline
  `<style>` block; that is left unchanged. The frontend keeps `'unsafe-inline'`
  for styles for the same class of reason, while holding script-src strict.
- HSTS: the app-wide helmet emits its default HSTS on backend responses, the
  same value the per-router helmet already emitted on /trpc and /mcp-proxy.
  Confirm this does not undercut the edge HSTS ramp before relying on the
  edge value alone.

https://claude.ai/code/session_01GLGuUof88SHr6kxCUqzyE7
