### PR TITLE
chore(ci): pin actions by SHA and base image by digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,18 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+
+  # Watches the root Dockerfile's digest-pinned base image. Dependabot's
+  # docker ecosystem bumps the FROM @sha256 digest via a reviewable PR when
+  # the pinned tag moves upstream; the github-actions entry above does the
+  # same for the SHA-pinned `uses:` in .github/workflows. (Neither tracks
+  # apt package versions inside RUN layers, e.g. the pinned nodejs.)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0  # Fetch all history for all branches and tags
 
@@ -86,11 +86,11 @@ jobs:
 
     - name: Set up Docker Buildx
       if: steps.check-branch.outputs.on-main == 'true' || steps.check-branch.outputs.on-test == 'true' || steps.check-branch.outputs.on-docker-per-mcp == 'true'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
     - name: Log in to Container Registry
       if: steps.check-branch.outputs.on-main == 'true' || steps.check-branch.outputs.on-test == 'true' || steps.check-branch.outputs.on-docker-per-mcp == 'true'
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -99,7 +99,7 @@ jobs:
     - name: Extract metadata for main branch
       if: steps.check-branch.outputs.on-main == 'true'
       id: meta-main
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -111,7 +111,7 @@ jobs:
     - name: Extract metadata for test branch
       if: steps.check-branch.outputs.on-test == 'true'
       id: meta-test
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -121,7 +121,7 @@ jobs:
     - name: Extract metadata for docker-per-mcp branch
       if: steps.check-branch.outputs.on-docker-per-mcp == 'true'
       id: meta-docker-per-mcp
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-docker-per-mcp
         tags: |
@@ -131,7 +131,7 @@ jobs:
     - name: Build and push Docker image for main branch
       if: steps.check-branch.outputs.on-main == 'true'
       id: push-main
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -144,7 +144,7 @@ jobs:
     - name: Build and push Docker image for test branch
       if: steps.check-branch.outputs.on-test == 'true'
       id: push-test
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -157,7 +157,7 @@ jobs:
     - name: Build and push Docker image for docker-per-mcp branch
       if: steps.check-branch.outputs.on-docker-per-mcp == 'true'
       id: push-docker-per-mcp
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
       with:
         context: .
         platforms: linux/amd64,linux/arm64
@@ -169,7 +169,7 @@ jobs:
 
     - name: Generate artifact attestation for main branch
       if: steps.check-branch.outputs.on-main == 'true'
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
         subject-digest: ${{ steps.push-main.outputs.digest }}
@@ -177,7 +177,7 @@ jobs:
 
     - name: Generate artifact attestation for test branch
       if: steps.check-branch.outputs.on-test == 'true'
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
         subject-digest: ${{ steps.push-test.outputs.digest }}
@@ -185,7 +185,7 @@ jobs:
 
     - name: Generate artifact attestation for docker-per-mcp branch
       if: steps.check-branch.outputs.on-docker-per-mcp == 'true'
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
       with:
         subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}-docker-per-mcp
         subject-digest: ${{ steps.push-docker-per-mcp.outputs.digest }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: dataaxiom/ghcr-cleanup-action@v1
+      - uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           owner: Umbrella-IT-Group
           packages: metamcp

--- a/.github/workflows/umbrella-build.yml
+++ b/.github/workflows/umbrella-build.yml
@@ -108,14 +108,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       # Login, tag metadata, and attestation only make sense on the push
       # path — a PR build never touches the registry, so there's nothing
       # to authenticate, tag, or attest.
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         if: github.event_name == 'push'
         with:
           registry: ${{ env.REGISTRY }}
@@ -124,7 +124,7 @@ jobs:
 
       - id: meta
         if: github.event_name == 'push'
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -132,7 +132,7 @@ jobs:
             type=sha,prefix=,format=long
 
       - id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           # The deploy host is amd64-only; arm64 cross-build doubles CI time
@@ -149,7 +149,7 @@ jobs:
           cache-from: type=gha,scope=metamcp-umbrella
           cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=metamcp-umbrella' || '' }}
 
-      - uses: actions/attest-build-provenance@v1
+      - uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
         if: github.event_name == 'push'
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/umbrella-ci.yml
+++ b/.github/workflows/umbrella-ci.yml
@@ -37,7 +37,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # No `version:` input on purpose. pnpm/action-setup reads the root
       # package.json `packageManager` field when the input is omitted, and
@@ -46,9 +46,9 @@ jobs:
       # future bump to `packageManager` doesn't silently skip CI. (The
       # Dockerfile installs its own, newer pnpm; that's the image's
       # business, not this job's.)
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # Matches the Node the Dockerfile installs (nodesource setup_20.x),
           # so a type or runtime error CI catches is one the image would hit.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
-# Use the official uv image as base
-FROM ghcr.io/astral-sh/uv:debian AS base
+# Base image: the official uv image, digest-pinned so the build is
+# reproducible and the base layer cannot shift under us between builds. The
+# :debian tag is kept for human context; the @sha256 index digest is what
+# Docker resolves. Bumped by Dependabot's docker ecosystem (see
+# .github/dependabot.yml), which opens a reviewable PR when the tag moves.
+FROM ghcr.io/astral-sh/uv:debian@sha256:b2b767dc8bbe5b9f813ca4958a43cc8421ca8eab6c954c74e5b1e641fea7a6ad AS base
 
-# Install Node.js and pnpm directly
+# Install Node.js and pnpm directly. nodejs is pinned to an exact nodesource
+# version so the image ships a known Node build instead of "whatever 20.x is
+# current at build time"; bump it by hand when moving Node (Dependabot's
+# docker ecosystem tracks the base image digest, not apt package versions
+# inside RUN layers). pnpm is already version-pinned.
 RUN apt-get update && apt-get install -y \
     curl \
     gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get install -y nodejs=20.20.2-1nodesource1 \
     && npm install -g pnpm@10.12.0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/apps/backend/src/supply-chain-pinning.test.ts
+++ b/apps/backend/src/supply-chain-pinning.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Supply-chain pinning guard for the fork's build and deploy path.
+ *
+ * A mutable action tag or a floating base-image tag lets whoever controls (or
+ * compromises) an upstream tag move new code into a build that runs with
+ * packages:write and id-token:write, or shift the deployed image out from
+ * under a digest nobody reviewed. So every `uses:` in .github/workflows is
+ * pinned to a full 40-char commit SHA, the root Dockerfile base image is
+ * pinned to a sha256 digest, and its Node install names an exact version.
+ * This reads those files from source and fails the moment any of them drifts
+ * back to a moving reference, including in a workflow added later. Same
+ * source-reading technique as the cors() call-site guard in
+ * routers/cors-policy.test.ts.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// apps/backend/src -> repo root.
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const WORKFLOWS_DIR = path.join(REPO_ROOT, ".github", "workflows");
+const DOCKERFILE = path.join(REPO_ROOT, "Dockerfile");
+const DEPENDABOT = path.join(REPO_ROOT, ".github", "dependabot.yml");
+
+function workflowFiles(): string[] {
+  return readdirSync(WORKFLOWS_DIR).filter(
+    (f) => f.endsWith(".yml") || f.endsWith(".yaml"),
+  );
+}
+
+/** Every `uses:` reference across the workflow files, with its raw line. */
+const USES: { file: string; line: string; ref: string }[] = [];
+for (const file of workflowFiles()) {
+  const source = readFileSync(path.join(WORKFLOWS_DIR, file), "utf8");
+  for (const line of source.split("\n")) {
+    const m = line.match(/^\s*(?:-\s*)?uses:\s*(\S+)/);
+    if (m) USES.push({ file, line, ref: m[1] });
+  }
+}
+
+describe("supply-chain pinning", () => {
+  it("finds the workflow uses: references it is meant to be guarding", () => {
+    // A regex that silently matched nothing would make the pin assertions
+    // below pass without checking anything.
+    expect(USES.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("pins every external action to a full commit SHA", () => {
+    for (const { file, ref } of USES) {
+      // Local composite actions (./path) carry no version to pin.
+      if (ref.startsWith("./")) continue;
+      const version = ref.split("@")[1];
+      expect(version, `${file}: ${ref} is not @<40-hex-sha>`).toMatch(
+        /^[0-9a-f]{40}$/,
+      );
+    }
+  });
+
+  it("gives every SHA-pinned action a trailing version comment", () => {
+    for (const { file, line, ref } of USES) {
+      if (ref.startsWith("./")) continue;
+      expect(
+        line,
+        `${file}: ${ref} pinned SHA has no # version comment`,
+      ).toMatch(/@[0-9a-f]{40}\s+#\s*v?\d/);
+    }
+  });
+
+  it("digest-pins every external Dockerfile base image", () => {
+    const dockerfile = readFileSync(DOCKERFILE, "utf8");
+    // `FROM base AS ...` re-references an internal stage, not a registry
+    // image; only external images need a digest.
+    const stages = new Set(
+      [...dockerfile.matchAll(/^FROM\s+\S+\s+AS\s+(\S+)/gim)].map((m) =>
+        m[1].toLowerCase(),
+      ),
+    );
+    const external = [...dockerfile.matchAll(/^FROM\s+(\S+)/gim)]
+      .map((m) => m[1])
+      .filter((img) => !stages.has(img.toLowerCase()));
+
+    expect(external.length).toBeGreaterThanOrEqual(1);
+    for (const img of external) {
+      expect(img, `Dockerfile FROM ${img} is not digest-pinned`).toMatch(
+        /@sha256:[0-9a-f]{64}$/,
+      );
+    }
+  });
+
+  it("pins the Dockerfile Node install to an exact version", () => {
+    const dockerfile = readFileSync(DOCKERFILE, "utf8");
+    // Bare `apt-get install -y nodejs` takes whatever 20.x is current at
+    // build time; the pinned form names the nodesource version explicitly.
+    expect(dockerfile, "Dockerfile installs a floating nodejs").toMatch(
+      /apt-get install -y nodejs=\d+\.\d+\.\d+/,
+    );
+  });
+
+  it("watches the docker ecosystem in dependabot so digests get bump PRs", () => {
+    const dependabot = readFileSync(DEPENDABOT, "utf8");
+    expect(dependabot).toMatch(/package-ecosystem:\s*"docker"/);
+  });
+});


### PR DESCRIPTION
## What

- Pin every GitHub Actions `uses:` to a full 40-char commit SHA with a trailing version comment, across all four workflows. The third-party, registry-writing cleanup action (it runs with `packages: write`) is pinned along with the first-party ones.
- Digest-pin the Dockerfile base image (`ghcr.io/astral-sh/uv:debian` gains an `@sha256:...`) and pin the Node install to an exact nodesource version instead of "whatever 20.x is current at build time".
- Add a `docker` ecosystem entry to `.github/dependabot.yml` so the base image digest gets reviewable bump PRs. The existing `github-actions` entry already bumps the pinned action SHAs.

## Why

A mutable action tag or a floating base-image tag lets whoever controls or compromises an upstream tag move new code into a build that runs with `packages: write` and `id-token: write`, or shift the deployed image out from under a digest nobody reviewed.

## Same versions, unchanged build

Each pinned SHA is the commit its moving tag currently resolves to, and the base-image digest is the one `:debian` currently resolves to; the pinned Node version is the one the unpinned install would fetch today. The build behaves identically.

| action | pinned version |
| --- | --- |
| dataaxiom/ghcr-cleanup-action | v1.2.2 |
| actions/checkout | v4.4.0 |
| actions/setup-node | v4.4.0 |
| pnpm/action-setup | v4.3.0 |
| docker/setup-buildx-action | v3.12.0 |
| docker/login-action | v3.7.0 |
| docker/metadata-action | v5.10.0 |
| docker/build-push-action | v5.4.0 |
| actions/attest-build-provenance | v1.4.4 |

Base image: `ghcr.io/astral-sh/uv:debian@sha256:b2b767dc8bbe5b9f813ca4958a43cc8421ca8eab6c954c74e5b1e641fea7a6ad`
Node: `nodejs=20.20.2-1nodesource1`

## Test

Adds `apps/backend/src/supply-chain-pinning.test.ts`, a guard that reads the workflow files, the Dockerfile and `dependabot.yml` and fails if any action drifts back to a moving tag, the base image loses its digest, the Node install unpins, or the docker ecosystem entry is dropped. It fails without this change (5 of 6 assertions red) and passes with it.

Cosign signing plus verification is a later step and is not part of this change.

https://claude.ai/code/session_01GLGuUof88SHr6kxCUqzyE7
