### PR TITLE
fix(namespaces): default private owner on create

### DIFF
--- a/apps/backend/src/trpc/namespaces.create.impl.test.ts
+++ b/apps/backend/src/trpc/namespaces.create.impl.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../db/repositories", () => ({
+  mcpServersRepository: { findByUuid: vi.fn() },
+  namespaceMappingsRepository: {},
+  namespacesRepository: { create: vi.fn() },
+  toolsRepository: {},
+}));
+
+vi.mock("../db/serializers", () => ({
+  NamespacesSerializer: { serializeNamespace: vi.fn() },
+}));
+
+vi.mock("../lib/audit/admin-event", () => ({
+  emitAdminEvent: vi.fn(),
+}));
+
+vi.mock("../lib/metamcp/metamcp-middleware/tool-overrides.functional", () => ({
+  clearOverrideCache: vi.fn(),
+  mapOverrideNameToOriginal: vi.fn(),
+}));
+
+vi.mock("../lib/metamcp/metamcp-server-pool", () => ({
+  metaMcpServerPool: {
+    ensureIdleServerForNewNamespace: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { mcpServersRepository, namespacesRepository } from "../db/repositories";
+import { NamespacesSerializer } from "../db/serializers";
+import { namespacesImplementations } from "./namespaces.impl";
+
+const USER_ID = "user-1";
+const SERVER_UUID = "11111111-1111-4111-8111-111111111111";
+
+describe("namespaces.create implementation — ownership defaults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(namespacesRepository.create).mockResolvedValue({
+      uuid: "namespace-1",
+      name: "private-namespace",
+    } as never);
+    vi.mocked(NamespacesSerializer.serializeNamespace).mockReturnValue({
+      uuid: "namespace-1",
+      name: "private-namespace",
+      description: null,
+      created_at: "2026-09-08T00:00:00.000Z",
+      updated_at: "2026-09-08T00:00:00.000Z",
+      user_id: USER_ID,
+    });
+  });
+
+  it("uses the current user when user_id is omitted", async () => {
+    const result = await namespacesImplementations.create(
+      { name: "private-namespace" },
+      USER_ID,
+    );
+
+    expect(result.success).toBe(true);
+    expect(namespacesRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: USER_ID }),
+    );
+  });
+
+  it("allows an omitted user_id namespace to contain the user's private server", async () => {
+    vi.mocked(mcpServersRepository.findByUuid).mockResolvedValue({
+      uuid: SERVER_UUID,
+      name: "private-server",
+      user_id: USER_ID,
+    } as never);
+
+    const result = await namespacesImplementations.create(
+      { name: "private-namespace", mcpServerUuids: [SERVER_UUID] },
+      USER_ID,
+    );
+
+    expect(result.success).toBe(true);
+    expect(namespacesRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: USER_ID }),
+    );
+  });
+
+  it("keeps an explicit null user_id public", async () => {
+    const result = await namespacesImplementations.create(
+      { name: "public-namespace", user_id: null },
+      USER_ID,
+    );
+
+    expect(result.success).toBe(true);
+    expect(namespacesRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: null }),
+    );
+  });
+});

--- a/apps/backend/src/trpc/namespaces.impl.ts
+++ b/apps/backend/src/trpc/namespaces.impl.ts
@@ -45,7 +45,7 @@ export const namespacesImplementations = {
     try {
       // Determine user ownership based on input.user_id or default to current user
       const effectiveUserId =
-        input.user_id !== undefined ? input.user_id : null;
+        input.user_id !== undefined ? input.user_id : userId;
       const isPublicNamespace = effectiveUserId === null;
 
       // Validate server accessibility and relationship rules


### PR DESCRIPTION
## Summary

- default an omitted user_id to the authenticated user when creating a namespace
- preserve explicit null as the public namespace choice
- add regression coverage for omitted ownership, private MCP membership, and explicit public ownership

## Problem

The frontend represents For myself (Private) by setting user_id to undefined, so JSON serialization omits the field. The create implementation currently converts that omission to null and treats the namespace as public. Selecting a private MCP server then fails with Public namespaces can only contain public MCP servers.

This makes the create semantics match the UI contract: undefined means the current user, while null means Everyone/Public.

## Verification

- backend regression test: 3 passed
- full backend suite: 163 files passed, 2362 tests passed; 6 files and 116 tests skipped
- backend TypeScript check passed
- ESLint and Prettier passed for changed files
- git diff --check passed