### PR TITLE
fix(frontend): clear rate limit fields when disabled

### DIFF
--- a/apps/frontend/app/[locale]/(sidebar)/endpoints/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/endpoints/page.tsx
@@ -397,9 +397,14 @@ export default function EndpointsPage() {
                     </div>
                     <Switch
                       checked={form.watch("enableMaxRate")}
-                      onCheckedChange={(checked) =>
-                        form.setValue("enableMaxRate", checked)
-                      }
+                      onCheckedChange={(checked) => {
+                        form.setValue("enableMaxRate", checked);
+                        if (!checked) {
+                          form.setValue("maxRate", undefined);
+                          form.setValue("maxRateSeconds", undefined);
+                          form.clearErrors(["maxRate", "maxRateSeconds"]);
+                        }
+                      }}
                       disabled={isSubmitting}
                     />
                   </div>
@@ -464,9 +469,17 @@ export default function EndpointsPage() {
                     </div>
                     <Switch
                       checked={form.watch("enableClientMaxRate")}
-                      onCheckedChange={(checked) =>
-                        form.setValue("enableClientMaxRate", checked)
-                      }
+                      onCheckedChange={(checked) => {
+                        form.setValue("enableClientMaxRate", checked);
+                        if (!checked) {
+                          form.setValue("clientMaxRate", undefined);
+                          form.setValue("clientMaxRateSeconds", undefined);
+                          form.clearErrors([
+                            "clientMaxRate",
+                            "clientMaxRateSeconds",
+                          ]);
+                        }
+                      }}
                       disabled={isSubmitting}
                     />
                   </div>

--- a/apps/frontend/components/edit-endpoint.tsx
+++ b/apps/frontend/components/edit-endpoint.tsx
@@ -344,9 +344,14 @@ export function EditEndpoint({
                 </div>
                 <Switch
                   checked={editForm.watch("enableMaxRate")}
-                  onCheckedChange={(checked) =>
-                    editForm.setValue("enableMaxRate", checked)
-                  }
+                  onCheckedChange={(checked) => {
+                    editForm.setValue("enableMaxRate", checked);
+                    if (!checked) {
+                      editForm.setValue("maxRate", undefined);
+                      editForm.setValue("maxRateSeconds", undefined);
+                      editForm.clearErrors(["maxRate", "maxRateSeconds"]);
+                    }
+                  }}
                   disabled={isUpdating}
                 />
               </div>
@@ -408,9 +413,17 @@ export function EditEndpoint({
                 </div>
                 <Switch
                   checked={editForm.watch("enableClientMaxRate")}
-                  onCheckedChange={(checked) =>
-                    editForm.setValue("enableClientMaxRate", checked)
-                  }
+                  onCheckedChange={(checked) => {
+                    editForm.setValue("enableClientMaxRate", checked);
+                    if (!checked) {
+                      editForm.setValue("clientMaxRate", undefined);
+                      editForm.setValue("clientMaxRateSeconds", undefined);
+                      editForm.clearErrors([
+                        "clientMaxRate",
+                        "clientMaxRateSeconds",
+                      ]);
+                    }
+                  }}
                   disabled={isUpdating}
                 />
               </div>


### PR DESCRIPTION
## Summary

- clear rate-limit values when endpoint rate limiting is disabled
- clear hidden validation errors for both global and per-client limits
- apply the fix to create and edit endpoint forms

## Why

React Hook Form stores empty number inputs as NaN. After rate limiting is turned off, those inputs are hidden but their NaN values remain in form state, so the Zod resolver rejects the form before the tRPC mutation runs.

## Validation

- Prettier check passed
- frontend TypeScript check passed
- targeted ESLint for both changed files passed
- full frontend lint still reports pre-existing warnings in unrelated files