### PR TITLE
feat(m365): request Presence.ReadWrite in delegated broker scopes

### DIFF
--- a/apps/backend/src/lib/m365/config.ts
+++ b/apps/backend/src/lib/m365/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_M365_SCOPES = [
   "Chat.ReadWrite",
   "Notes.ReadWrite.All",
   "People.Read",
+  "Presence.ReadWrite",
 ].join(" ");
 
 export interface M365BrokerConfig {


### PR DESCRIPTION
## What

Adds `Presence.ReadWrite` to `DEFAULT_M365_SCOPES` (`apps/backend/src/lib/m365/config.ts`) so the delegated-token broker requests it at enrollment and on every refresh. Required for the `m365` MCP's new `presence_manage` tool (set your own Teams presence/status) to receive a token whose `scp` carries the scope.

## Pairs with (Umbrella-MCP-Server)

- `scripts/create-entra-m365-app.ps1` now lists `Presence.ReadWrite` on the `Umbrella-M365-User` app; re-run it (or grant delegated `Presence.ReadWrite` + admin consent by hand) so the scope is admin-consented before tokens request it.
- Shipped in Umbrella-MCP-Server PR #735 / `docs/TASKLIST.md` → `M365-PRESENCE-ROLLOUT`.

## Deploy path (gated, not automatic on merge)

The gateway runs a digest-pinned image (off Watchtower). After merge, the fork image must rebuild and the pin in Umbrella-MCP-Server `metamcp/compose.fragment.yml` must bump (the reviewed `bump/metamcp-image` PR flow) before this reaches production.

## Risk

One-line additive scope change. No behavior change until the Entra consent and the image bump both land; the broker still boots cleanly with or without the consent.